### PR TITLE
rclcpp 0.4.0 changes

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -61,10 +61,10 @@ public:
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node_;
-  std::shared_ptr<rclcpp::parameter_client::AsyncParametersClient> parameters_client_;
+  std::shared_ptr<rclcpp::AsyncParametersClient> parameters_client_;
 
 private:
-  std::shared_ptr<rclcpp::node::Node> parameter_client_node_;
+  std::shared_ptr<rclcpp::Node> parameter_client_node_;
 };
 
 }  // namespace controller_interface

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -47,7 +47,7 @@ ControllerInterface::init(
     std::bind(&ControllerInterface::on_error, this, std::placeholders::_1));
 
   std::string remote_controller_parameter_server = "controller_parameter_server";
-  parameters_client_ = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(
+  parameters_client_ = std::make_shared<rclcpp::AsyncParametersClient>(
     lifecycle_node_->get_node_base_interface(),
     lifecycle_node_->get_node_topics_interface(),
     lifecycle_node_->get_node_graph_interface(),

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -37,7 +37,7 @@ class ClassLoader;
 namespace controller_manager
 {
 
-class ControllerManager : public rclcpp::node::Node
+class ControllerManager : public rclcpp::Node
 {
 public:
   CONTROLLER_MANAGER_PUBLIC

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -130,7 +130,7 @@ ControllerManager::ControllerManager(
   std::shared_ptr<hardware_interface::RobotHardware> hw,
   std::shared_ptr<rclcpp::executor::Executor> executor,
   const std::string & manager_node_name)
-: rclcpp::node::Node(manager_node_name),
+: rclcpp::Node(manager_node_name),
   hw_(hw),
   executor_(executor)
 {}

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -21,7 +21,7 @@
 #include "ament_index_cpp/get_resource.hpp"
 #include "ament_index_cpp/get_resources.hpp"
 
-#include "class_loader/class_loader.h"
+#include "class_loader/class_loader.hpp"
 
 #include "controller_interface/controller_interface.hpp"
 

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -42,7 +42,7 @@ TestController::on_configure(const rclcpp_lifecycle::State & previous_state)
 
 }  // namespace test_controller
 
-#include "class_loader/class_loader_register_macro.h"
+#include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
   test_controller::TestController, controller_interface::ControllerInterface)

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -31,7 +31,7 @@ class TestControllerManager : public ::testing::Test
 public:
   static void SetUpTestCase()
   {
-    rclcpp::utilities::init(0, nullptr);
+    rclcpp::init(0, nullptr);
   }
 
   void SetUp()

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -31,7 +31,7 @@ class TestControllerManager : public ::testing::Test
 public:
   static void SetUpTestCase()
   {
-    rclcpp::utilities::init(0, nullptr);
+    rclcpp::init(0, nullptr);
   }
 
   void SetUp()

--- a/controller_parameter_server/include/controller_parameter_server/parameter_server.hpp
+++ b/controller_parameter_server/include/controller_parameter_server/parameter_server.hpp
@@ -25,7 +25,7 @@
 namespace controller_parameter_server
 {
 
-class ParameterServer : public rclcpp::node::Node
+class ParameterServer : public rclcpp::Node
 {
 public:
   CONTROLLER_PARAMETER_SERVER_PUBLIC
@@ -48,7 +48,7 @@ public:
   load_parameters(const std::string & key, const std::string & value);
 
 private:
-  std::shared_ptr<rclcpp::parameter_service::ParameterService> parameter_service_;
+  std::shared_ptr<rclcpp::ParameterService> parameter_service_;
 };
 
 }  // namespace controller_parameter_server

--- a/controller_parameter_server/include/controller_parameter_server/parameter_server.hpp
+++ b/controller_parameter_server/include/controller_parameter_server/parameter_server.hpp
@@ -37,18 +37,11 @@ public:
 
   CONTROLLER_PARAMETER_SERVER_PUBLIC
   void
-  init();
-
-  CONTROLLER_PARAMETER_SERVER_PUBLIC
-  void
   load_parameters(const std::string & yaml_config_file);
 
   CONTROLLER_PARAMETER_SERVER_PUBLIC
   void
   load_parameters(const std::string & key, const std::string & value);
-
-private:
-  std::shared_ptr<rclcpp::ParameterService> parameter_service_;
 };
 
 }  // namespace controller_parameter_server

--- a/controller_parameter_server/src/controller_parameter_server.cpp
+++ b/controller_parameter_server/src/controller_parameter_server.cpp
@@ -34,7 +34,6 @@ int main(int argc, char ** argv)
   }
 
   auto ps = std::make_shared<controller_parameter_server::ParameterServer>();
-  ps->init();
   ps->load_parameters(argv[1]);
 
   rclcpp::spin(ps);

--- a/controller_parameter_server/src/parameter_server.cpp
+++ b/controller_parameter_server/src/parameter_server.cpp
@@ -26,19 +26,8 @@ ParameterServer::ParameterServer()
 {}
 
 void
-ParameterServer::init()
-{
-  parameter_service_ =
-    std::make_shared<rclcpp::ParameterService>(shared_from_this());
-}
-
-void
 ParameterServer::load_parameters(const std::string & yaml_config_file)
 {
-  if (!parameter_service_) {
-    throw std::runtime_error("parameter server is not initialized");
-  }
-
   if (yaml_config_file.empty()) {
     throw std::runtime_error("yaml config file path is empty");
   }
@@ -48,18 +37,14 @@ ParameterServer::load_parameters(const std::string & yaml_config_file)
 
   auto key_values = parser.get_key_value_pairs();
   for (auto pair : key_values) {
-    this->set_parameters({rclcpp::parameter::ParameterVariant(pair.first, pair.second)});
+    this->set_parameters({rclcpp::Parameter(pair.first, pair.second)});
   }
 }
 
 void
 ParameterServer::load_parameters(const std::string & key, const std::string & value)
 {
-  if (!parameter_service_) {
-    throw std::runtime_error("parameter server is not initialized");
-  }
-
-  this->set_parameters({rclcpp::parameter::ParameterVariant(key, value)});
+  this->set_parameters({rclcpp::Parameter(key, value)});
 }
 
 }  // namespace controller_parameter_server

--- a/controller_parameter_server/src/parameter_server.cpp
+++ b/controller_parameter_server/src/parameter_server.cpp
@@ -22,14 +22,14 @@ namespace controller_parameter_server
 {
 
 ParameterServer::ParameterServer()
-: rclcpp::node::Node("controller_parameter_server")
+: rclcpp::Node("controller_parameter_server")
 {}
 
 void
 ParameterServer::init()
 {
   parameter_service_ =
-    std::make_shared<rclcpp::parameter_service::ParameterService>(shared_from_this());
+    std::make_shared<rclcpp::ParameterService>(shared_from_this());
 }
 
 void

--- a/controller_parameter_server/test/test_parameter_server.cpp
+++ b/controller_parameter_server/test/test_parameter_server.cpp
@@ -84,9 +84,9 @@ TEST_F(TestControllerParameterServer, load_config_file) {
   ps->init();
   ps->load_parameters(file_path);
 
-  auto client_node = std::make_shared<rclcpp::node::Node>("test_parameter_client_node");
+  auto client_node = std::make_shared<rclcpp::Node>("test_parameter_client_node");
   auto parameters_client =
-    std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(client_node, ps->get_name());
+    std::make_shared<rclcpp::AsyncParametersClient>(client_node, ps->get_name());
 
   rclcpp::executors::MultiThreadedExecutor executor;
   executor.add_node(ps);

--- a/controller_parameter_server/test/test_parameter_server.cpp
+++ b/controller_parameter_server/test/test_parameter_server.cpp
@@ -38,24 +38,15 @@ protected:
   }
 };
 
-TEST_F(TestControllerParameterServer, init) {
-  auto ps = std::make_shared<controller_parameter_server::ParameterServer>();
-  EXPECT_THROW(ps->load_parameters("key", "value"), std::runtime_error);
-
-  ps->init();
-  EXPECT_NO_THROW(ps->load_parameters("key", "value"));
-}
-
 TEST_F(TestControllerParameterServer, init_key_value) {
   auto ps = std::make_shared<controller_parameter_server::ParameterServer>();
-  ps->init();
 
   std::map<std::string, std::string> parameters =
   {{
-     {"test_controller.joints.joint1", "joint1"},
-     {"test_controller.joints.joint2", "joint2"},
-     {"test_controller.joints.joint3", "joint3"}
-   }};
+      {"test_controller.joints.joint1", "joint1"},
+      {"test_controller.joints.joint2", "joint2"},
+      {"test_controller.joints.joint3", "joint3"}
+    }};
 
   for (auto param : parameters) {
     ps->load_parameters(param.first, param.second);
@@ -81,7 +72,6 @@ TEST_F(TestControllerParameterServer, load_config_file) {
   std::string file_path = std::string(yaml_file);
 
   auto ps = std::make_shared<controller_parameter_server::ParameterServer>();
-  ps->init();
   ps->load_parameters(file_path);
 
   auto client_node = std::make_shared<rclcpp::Node>("test_parameter_client_node");
@@ -105,25 +95,25 @@ TEST_F(TestControllerParameterServer, load_config_file) {
 
   std::vector<std::string> expected_keys =
   {{
-     ".controller_name",
-     ".controller_list.0",
-     ".controller_list.1",
-     ".test_joint_controller.joints",
-     ".test_trajectory_controller.joints.0.joint1.name",
-     ".test_trajectory_controller.joints.1",
-     ".test_trajectory_controller.joints.2"
-   }};
+      ".controller_name",
+      ".controller_list.0",
+      ".controller_list.1",
+      ".test_joint_controller.joints",
+      ".test_trajectory_controller.joints.0.joint1.name",
+      ".test_trajectory_controller.joints.1",
+      ".test_trajectory_controller.joints.2"
+    }};
 
   std::vector<std::string> expected_values =
   {{
-     "my_controller",
-     "my_controller1",
-     "my_controller2",
-     "my_joint1",
-     "my_joint1",
-     "my_joint2",
-     "my_joint3"
-   }};
+      "my_controller",
+      "my_controller1",
+      "my_controller2",
+      "my_joint1",
+      "my_joint1",
+      "my_joint2",
+      "my_joint3"
+    }};
 
   auto parameter_future = parameters_client->get_parameters(expected_keys);
 

--- a/controller_parameter_server/test/test_yaml_parser.cpp
+++ b/controller_parameter_server/test/test_yaml_parser.cpp
@@ -47,25 +47,25 @@ TEST_F(TestYamlParser, init) {
 
   std::vector<std::string> expected_keys =
   {{
-     ".controller_name",
-     ".controller_list.0",
-     ".controller_list.1",
-     ".test_joint_controller.joints",
-     ".test_trajectory_controller.joints.0.joint1.name",
-     ".test_trajectory_controller.joints.1",
-     ".test_trajectory_controller.joints.2"
-   }};
+      ".controller_name",
+      ".controller_list.0",
+      ".controller_list.1",
+      ".test_joint_controller.joints",
+      ".test_trajectory_controller.joints.0.joint1.name",
+      ".test_trajectory_controller.joints.1",
+      ".test_trajectory_controller.joints.2"
+    }};
 
   std::vector<std::string> expected_values =
   {{
-     "my_controller",
-     "my_controller1",
-     "my_controller2",
-     "my_joint1",
-     "my_joint1",
-     "my_joint2",
-     "my_joint3"
-   }};
+      "my_controller",
+      "my_controller1",
+      "my_controller2",
+      "my_joint1",
+      "my_joint1",
+      "my_joint2",
+      "my_joint3"
+    }};
 
   if (expected_keys.size() != expected_values.size()) {
     FAIL();


### PR DESCRIPTION
Changed object references to reflect `rclcpp` changes in v0.4.0, i.e. branch <b>ardent</b>.
Build fails with
<details><pre><code>
[ 83%] Linking CXX executable test_controller_manager
/usr/bin/ld: warning: libconsole_bridge.so.0.2, needed by libcontroller_manager.so, may conflict with libconsole_bridge.so.0.4
CMakeFiles/test_load_controller.dir/test/test_load_controller.cpp.o: In function `TestControllerManager_load_known_controller_Test::TestBody()':
test_load_controller.cpp:(.text+0xc96): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0xcad): undefined reference to `rclcpp_lifecycle::LifecycleNode::configure()'
test_load_controller.cpp:(.text+0xcd1): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0xce8): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_load_controller.cpp:(.text+0xcf0): undefined reference to `rclcpp_lifecycle::State::id() const'
CMakeFiles/test_load_controller.dir/test/test_load_controller.cpp.o: In function `TestControllerManager_load2_known_controller_Test::TestBody()':
test_load_controller.cpp:(.text+0x1434): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x144b): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_name() const'
test_load_controller.cpp:(.text+0x154a): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x1561): undefined reference to `rclcpp_lifecycle::LifecycleNode::configure()'
test_load_controller.cpp:(.text+0x1594): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x15ab): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_load_controller.cpp:(.text+0x15b3): undefined reference to `rclcpp_lifecycle::State::id() const'
test_load_controller.cpp:(.text+0x1918): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x192f): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_name() const'
test_load_controller.cpp:(.text+0x1a2e): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x1a45): undefined reference to `rclcpp_lifecycle::LifecycleNode::configure()'
test_load_controller.cpp:(.text+0x1a78): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x1a8f): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_load_controller.cpp:(.text+0x1a97): undefined reference to `rclcpp_lifecycle::State::id() const'
CMakeFiles/test_load_controller.dir/test/test_load_controller.cpp.o: In function `TestControllerManager_update_Test::TestBody()':
test_load_controller.cpp:(.text+0x22e4): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x22fb): undefined reference to `rclcpp_lifecycle::LifecycleNode::configure()'
test_load_controller.cpp:(.text+0x231f): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_load_controller.cpp:(.text+0x2336): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_load_controller.cpp:(.text+0x233e): undefined reference to `rclcpp_lifecycle::State::id() const'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::deactivate()'
libcontroller_manager.so: undefined reference to `typeinfo for controller_interface::ControllerInterface'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::State::~State()'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::State::State(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::get_node_base_interface()'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::cleanup()'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::activate()'
collect2: error: ld returned 1 exit status
CMakeFiles/test_load_controller.dir/build.make:194: recipe for target 'test_load_controller' failed
make[2]: *** [test_load_controller] Error 1
CMakeFiles/Makefile2:677: recipe for target 'CMakeFiles/test_load_controller.dir/all' failed
make[1]: *** [CMakeFiles/test_load_controller.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: warning: libconsole_bridge.so.0.2, needed by libtest_controller.so, may conflict with libconsole_bridge.so.0.4
CMakeFiles/test_controller_manager.dir/test/test_controller_manager.cpp.o: In function `TestControllerManager_controller_lifecycle_Test::TestBody()':
test_controller_manager.cpp:(.text+0x6ff): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_controller_manager.cpp:(.text+0x716): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_controller_manager.cpp:(.text+0x71e): undefined reference to `rclcpp_lifecycle::State::id() const'
test_controller_manager.cpp:(.text+0x901): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_controller_manager.cpp:(.text+0x918): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_controller_manager.cpp:(.text+0x920): undefined reference to `rclcpp_lifecycle::State::id() const'
test_controller_manager.cpp:(.text+0xb03): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_controller_manager.cpp:(.text+0xb1a): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_controller_manager.cpp:(.text+0xb22): undefined reference to `rclcpp_lifecycle::State::id() const'
test_controller_manager.cpp:(.text+0xd05): undefined reference to `controller_interface::ControllerInterface::get_lifecycle_node()'
test_controller_manager.cpp:(.text+0xd1c): undefined reference to `rclcpp_lifecycle::LifecycleNode::get_current_state()'
test_controller_manager.cpp:(.text+0xd24): undefined reference to `rclcpp_lifecycle::State::id() const'
libtest_controller.so: undefined reference to `rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::on_error(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::deactivate()'
libtest_controller.so: undefined reference to `typeinfo for controller_interface::ControllerInterface'
libtest_controller.so: undefined reference to `vtable for rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface'
libtest_controller.so: undefined reference to `vtable for controller_interface::ControllerInterface'
libtest_controller.so: undefined reference to `rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::on_activate(rclcpp_lifecycle::State const&)'
libtest_controller.so: undefined reference to `rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::on_deactivate(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::State::~State()'
libtest_controller.so: undefined reference to `rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::on_shutdown(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::State::State(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::get_node_base_interface()'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::configure()'
libtest_controller.so: undefined reference to `rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::on_cleanup(rclcpp_lifecycle::State const&)'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::cleanup()'
libcontroller_manager.so: undefined reference to `rclcpp_lifecycle::LifecycleNode::activate()'
libtest_controller.so: undefined reference to `controller_interface::ControllerInterface::init(std::weak_ptr<hardware_interface::RobotHardware>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
CMakeFiles/test_controller_manager.dir/build.make:195: recipe for target 'test_controller_manager' failed
make[2]: *** [test_controller_manager] Error 1
CMakeFiles/Makefile2:1399: recipe for target 'CMakeFiles/test_controller_manager.dir/all' failed
make[1]: *** [CMakeFiles/test_controller_manager.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2

</code></pre></details>