### PR TITLE
Fixed typo on nullptr check

### DIFF
--- a/hardware_interface/src/joint_command_handle.cpp
+++ b/hardware_interface/src/joint_command_handle.cpp
@@ -50,7 +50,7 @@ JointCommandHandle::get_cmd() const
 void
 JointCommandHandle::set_cmd(double cmd)
 {
-  THROW_ON_NULLPTR(cmd)
+  THROW_ON_NULLPTR(cmd_)
 
   * cmd_ = cmd;
 }


### PR DESCRIPTION
Typo on nullptr check causing exceptions to be thrown whenever input command is set to 0