### PR TITLE
Add Github Actions workflow for testing and linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint ros2_control
+on:
+  pull_request:
+
+jobs:
+  ament_copyright:
+    name: ament_copyright
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros@0.0.13
+    - uses: ros-tooling/action-ros-lint@0.0.5
+      with:
+        linter: copyright
+        package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
+
+  ament_xmllint:
+    name: ament_xmllint
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros@0.0.13
+    - uses: ros-tooling/action-ros-lint@0.0.5
+      with:
+        linter: xmllint
+        package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
+
+  ament_lint_cpp:
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [cppcheck, cpplint, uncrustify]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros@0.0.13
+    - uses: ros-tooling/action-ros-lint@0.0.5
+      with:
+        linter: ${{ matrix.linter }}
+        package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test ros2_control
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '17 8 * * *'
+
+jobs:
+  build_and_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+    steps:
+      - uses: ros-tooling/setup-ros@0.0.13
+      - uses: ros-tooling/action-ros-ci@0.0.13
+        with:
+          package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
+          colcon-mixin-name: coverage-gcc
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: actions/upload-artifact@master
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros_ws/log


### PR DESCRIPTION
This PR addresses #21 by adding the following Github workflows:

## Testing

* Runs on Ubuntu 18.04 and macOS 10.15
* Creates a coverage report.
* Runs on pull requests, pushes to master, and everyday at 8AM UTC

## Linting

* Runs on every PR
* Tests C++ packages, XML, copyright

A codecov workflow could be added once the repo has a `CODECOV_TOKEN` secret.

This PR depends on:

* [x] #19 
* [ ] #39 
Signed-off-by: Anas Abou Allaban <allabana@amazon.com>