### PR TITLE
Use yaml_cpp_vendor package

### DIFF
--- a/controller_parameter_server/CMakeLists.txt
+++ b/controller_parameter_server/CMakeLists.txt
@@ -13,18 +13,15 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(yaml-cpp REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 
-message("yaml-cpp dir ${YAML_CPP_INCLUDE_DIR}")
 add_library(yaml_parser SHARED src/yaml_parser.cpp)
-target_include_directories(
-  yaml_parser PUBLIC include
-  yaml_parser PUBLIC ${YAML_CPP_INCLUDE_DIR})
-target_link_libraries(yaml_parser ${YAML_CPP_LIBRARIES})
+target_include_directories(yaml_parser PUBLIC include)
 target_compile_definitions(yaml_parser PRIVATE "CONTROLLER_PARAMETER_SERVER_BUILDING_DLL")
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_libraries(yaml_parser "stdc++fs")
 endif()
+ament_target_dependencies(yaml_parser yaml_cpp_vendor)
 
 add_library(parameter_server SHARED src/parameter_server.cpp)
 target_include_directories(parameter_server PUBLIC include)
@@ -32,8 +29,7 @@ target_link_libraries(parameter_server yaml_parser)
 target_compile_definitions(parameter_server PRIVATE "CONTROLLER_PARAMETER_SERVER_BUILDING_DLL")
 ament_target_dependencies(
   parameter_server
-  rclcpp
-)
+  rclcpp)
 
 add_executable(controller_parameter_server src/controller_parameter_server.cpp)
 target_include_directories(controller_parameter_server PRIVATE include)


### PR DESCRIPTION
Update the `yaml-cpp` package to the `yaml_cpp_vendor` package that is vended with the ROS2 sources.

This fixes the macOS builds in #35.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>