### PR TITLE
Remove macOS from the build workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,9 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-18.04, macos-latest]
     steps:
       - uses: ros-tooling/setup-ros@0.0.13
       - uses: ros-tooling/action-ros-ci@0.0.13


### PR DESCRIPTION
Removing the macOS build workflow until a solution in `action-ros-ci` is found and  released.

An issue has been opened in `action-ros-ci` to track this [here](https://github.com/ros-tooling/action-ros-ci/issues/81).

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>