### PR TITLE
export controller_interface

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -101,6 +101,7 @@ ament_export_include_directories(
   include
 )
 ament_export_dependencies(
+  controller_interface
   pluginlib
 )
 ament_package()


### PR DESCRIPTION
The controller manager header relies on the controller interface, which it's currently no exporting.

Signed-off-by: Karsten Knese <karsten@openrobotics.org>