### PR TITLE
don't include pluginlib header in controller manager header

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -27,8 +27,6 @@
 
 #include "hardware_interface/robot_hardware.hpp"
 
-#include "pluginlib/class_loader.hpp"
-
 #include "rclcpp/executor.hpp"
 #include "rclcpp/node.hpp"
 


### PR DESCRIPTION
This will unblock https://github.com/ros-controls/ros2_controllers/pull/24 in such that each controller doesn't include the `pluginlib/class_loader.hpp` and thus had to explicitly disable boost.
 
Signed-off-by: Karsten Knese <karsten@openrobotics.org>