### PR TITLE
Controller interface now accepts yaml as node parameters

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -19,8 +19,7 @@ add_library(controller_interface SHARED src/controller_interface.cpp)
 target_include_directories(
   controller_interface
   PRIVATE
-  include
-  "yaml_cpp_vendor")
+  include)
 ament_target_dependencies(
   controller_interface
   "hardware_interface"

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -13,16 +13,19 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 
 add_library(controller_interface SHARED src/controller_interface.cpp)
 target_include_directories(
   controller_interface
   PRIVATE
-  include)
+  include
+  "yaml_cpp_vendor")
 ament_target_dependencies(
   controller_interface
   "hardware_interface"
   "rclcpp_lifecycle"
+  "yaml_cpp_vendor"
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -64,6 +64,7 @@ public:
   get_lifecycle_node();
 
   void load_params_from_yaml(const std::string & yaml_config_file);
+  
   void load_params_from_yaml_node(YAML::Node & yaml_node);
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -66,6 +66,7 @@ public:
   void load_params_from_yaml(const std::string & yaml_config_file);
 
   void load_params_from_yaml_node(YAML::Node & yaml_node);
+
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node_;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -64,7 +64,7 @@ public:
   get_lifecycle_node();
 
   void load_params_from_yaml(const std::string & yaml_config_file);
-  
+
   void load_params_from_yaml_node(YAML::Node & yaml_node);
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -25,9 +25,9 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
-namespace YAML 
+namespace YAML
 {
-  class Node;
+class Node;
 }
 
 namespace controller_interface

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -37,7 +37,6 @@ using controller_interface_ret_t = std::uint8_t;
 static constexpr controller_interface_ret_t CONTROLLER_INTERFACE_RET_SUCCESS = 1;
 static constexpr controller_interface_ret_t CONTROLLER_INTERFACE_RET_ERROR = 0;
 
-
 class ControllerInterface : public rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 {
 public:

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -25,12 +25,18 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
+namespace YAML 
+{
+  class Node;
+}
+
 namespace controller_interface
 {
 
 using controller_interface_ret_t = std::uint8_t;
 static constexpr controller_interface_ret_t CONTROLLER_INTERFACE_RET_SUCCESS = 1;
 static constexpr controller_interface_ret_t CONTROLLER_INTERFACE_RET_ERROR = 0;
+
 
 class ControllerInterface : public rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 {
@@ -58,6 +64,8 @@ public:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode>
   get_lifecycle_node();
 
+  void load_params_from_yaml(const std::string & yaml_config_file);
+  void load_params_from_yaml_node(YAML::Node& yaml_node);
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node_;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -64,7 +64,7 @@ public:
   get_lifecycle_node();
 
   void load_params_from_yaml(const std::string & yaml_config_file);
-  void load_params_from_yaml_node(YAML::Node& yaml_node);
+  void load_params_from_yaml_node(YAML::Node & yaml_node);
 protected:
   std::weak_ptr<hardware_interface::RobotHardware> robot_hardware_;
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node_;

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -11,6 +11,7 @@
 
   <build_depend>hardware_interface</build_depend>
   <build_depend>rclcpp_lifecycle</build_depend>
+  <build_depend>yaml_cpp_vendor</build_depend>
 
   <exec_depend>hardware_interface</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include "yaml-cpp/yaml.h"
+
 namespace controller_interface
 {
 
@@ -53,6 +55,55 @@ std::shared_ptr<rclcpp_lifecycle::LifecycleNode>
 ControllerInterface::get_lifecycle_node()
 {
   return lifecycle_node_;
+}
+
+void ControllerInterface::load_params_from_yaml(const std::string & yaml_config_file)
+{
+  if (yaml_config_file.empty()) {
+    throw std::runtime_error("yaml config file path is empty");
+  }
+
+  YAML::Node root_node = YAML::LoadFile(yaml_config_file);
+  load_params_from_yaml_node(root_node);
+}
+
+void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
+{
+  std::function<void(YAML::Node, const std::string&, std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)> 
+    feed_yaml_to_node_rec = 
+    [&](YAML::Node yaml_node, const std::string& key, 
+    std::shared_ptr<rclcpp_lifecycle::LifecycleNode>& node)
+  {
+    static constexpr char separator = '.';
+    if (yaml_node.Type() == YAML::NodeType::Scalar) 
+    {
+      std::string val_str = yaml_node.as<std::string>();
+      RCLCPP_INFO(rclcpp::get_logger("l"), "%s: %s", key.c_str(), val_str.c_str());
+
+      //@todo: Do stricter typing for set_parameter value types. 
+      //(ie. Numbers should be converted to int/double/etc instead of strings)
+      node->declare_parameter(key);
+      node->set_parameter({rclcpp::Parameter(key, val_str)});
+      return;
+    }
+    else if (yaml_node.Type() == YAML::NodeType::Map) 
+    {
+      for (auto yaml_node_it = yaml_node.begin(); yaml_node_it != yaml_node.end(); ++yaml_node_it) 
+      {
+        feed_yaml_to_node_rec(
+          yaml_node_it->second, key + separator + yaml_node_it->first.as<std::string>(), node);
+      }
+    }
+    else if (yaml_node.Type() == YAML::NodeType::Sequence) 
+    {
+      size_t index = 0;
+      for (auto yaml_node_it = yaml_node.begin(); yaml_node_it != yaml_node.end(); ++yaml_node_it) 
+      {
+        feed_yaml_to_node_rec(*yaml_node_it, key + separator + std::to_string((index++)), node);
+      }
+    }
+  };
+  feed_yaml_to_node_rec(yaml_node, "", lifecycle_node_);
 }
 
 }  // namespace controller_interface

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -67,7 +67,7 @@ void ControllerInterface::load_params_from_yaml(const std::string & yaml_config_
   load_params_from_yaml_node(root_node);
 }
 
-void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
+void ControllerInterface::load_params_from_yaml_node(YAML::Node & yaml_node)
 {
   std::function<void(YAML::Node, const std::string&,
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)>

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -69,9 +69,9 @@ void ControllerInterface::load_params_from_yaml(const std::string & yaml_config_
 
 void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
 {
-  std::function<void(YAML::Node, const std::string&, 
+  std::function<void(YAML::Node, const std::string&,
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)>
-    feed_yaml_to_node_rec = 
+    feed_yaml_to_node_rec =
     [&](YAML::Node yaml_node, const std::string& key,
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode>& node)
   {
@@ -84,8 +84,7 @@ void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
       node->declare_parameter(key);
       node->set_parameter({rclcpp::Parameter(key, val_str)});
       return;
-    }
-    else if (yaml_node.Type() == YAML::NodeType::Map) {
+    } else if (yaml_node.Type() == YAML::NodeType::Map) {
       for (auto yaml_node_it : yaml_node) {
         feed_yaml_to_node_rec(
           yaml_node_it.second, key + separator + yaml_node_it.first.as<std::string>(), node);

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -69,36 +69,31 @@ void ControllerInterface::load_params_from_yaml(const std::string & yaml_config_
 
 void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
 {
-  std::function<void(YAML::Node, const std::string&, std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)> 
+  std::function<void(YAML::Node, const std::string&, 
+    std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)>
     feed_yaml_to_node_rec = 
-    [&](YAML::Node yaml_node, const std::string& key, 
+    [&](YAML::Node yaml_node, const std::string& key,
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode>& node)
   {
     static constexpr char separator = '.';
-    if (yaml_node.Type() == YAML::NodeType::Scalar) 
-    {
+    if (yaml_node.Type() == YAML::NodeType::Scalar) {
       std::string val_str = yaml_node.as<std::string>();
 
-      //@todo: Do stricter typing for set_parameter value types. 
-      //(ie. Numbers should be converted to int/double/etc instead of strings)
+      // @todo: Do stricter typing for set_parameter value types. 
+      // (ie. Numbers should be converted to int/double/etc instead of strings)
       node->declare_parameter(key);
       node->set_parameter({rclcpp::Parameter(key, val_str)});
       return;
     }
-    else if (yaml_node.Type() == YAML::NodeType::Map) 
-    {
-      for (auto yaml_node_it = yaml_node.begin(); yaml_node_it != yaml_node.end(); ++yaml_node_it) 
-      {
+    else if (yaml_node.Type() == YAML::NodeType::Map) {
+      for (auto yaml_node_it : yaml_node) {
         feed_yaml_to_node_rec(
-          yaml_node_it->second, key + separator + yaml_node_it->first.as<std::string>(), node);
+          yaml_node_it.second, key + separator + yaml_node_it.first.as<std::string>(), node);
       }
-    }
-    else if (yaml_node.Type() == YAML::NodeType::Sequence) 
-    {
+    } else if (yaml_node.Type() == YAML::NodeType::Sequence) {
       size_t index = 0;
-      for (auto yaml_node_it = yaml_node.begin(); yaml_node_it != yaml_node.end(); ++yaml_node_it) 
-      {
-        feed_yaml_to_node_rec(*yaml_node_it, key + separator + std::to_string((index++)), node);
+      for (auto yaml_node_it : yaml_node) {
+        feed_yaml_to_node_rec(yaml_node_it, key + separator + std::to_string((index++)), node);
       }
     }
   };

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -79,7 +79,7 @@ void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
     if (yaml_node.Type() == YAML::NodeType::Scalar) {
       std::string val_str = yaml_node.as<std::string>();
 
-      // @todo: Do stricter typing for set_parameter value types. 
+      // TODO: Do stricter typing for set_parameter value types.
       // (ie. Numbers should be converted to int/double/etc instead of strings)
       node->declare_parameter(key);
       node->set_parameter({rclcpp::Parameter(key, val_str)});

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -69,33 +69,33 @@ void ControllerInterface::load_params_from_yaml(const std::string & yaml_config_
 
 void ControllerInterface::load_params_from_yaml_node(YAML::Node & yaml_node)
 {
-  std::function<void(YAML::Node, const std::string&,
-    std::shared_ptr<rclcpp_lifecycle::LifecycleNode>&)>
-    feed_yaml_to_node_rec =
-    [&](YAML::Node yaml_node, const std::string& key,
-    std::shared_ptr<rclcpp_lifecycle::LifecycleNode>& node)
-  {
-    static constexpr char separator = '.';
-    if (yaml_node.Type() == YAML::NodeType::Scalar) {
-      std::string val_str = yaml_node.as<std::string>();
+  std::function<void(YAML::Node, const std::string &,
+    std::shared_ptr<rclcpp_lifecycle::LifecycleNode> &)>
+  feed_yaml_to_node_rec =
+    [&](YAML::Node yaml_node, const std::string & key,
+      std::shared_ptr<rclcpp_lifecycle::LifecycleNode> & node)
+    {
+      static constexpr char separator = '.';
+      if (yaml_node.Type() == YAML::NodeType::Scalar) {
+        std::string val_str = yaml_node.as<std::string>();
 
-      // TODO(ddengster): Do stricter typing for set_parameter value types.
-      // (ie. Numbers should be converted to int/double/etc instead of strings)
-      node->declare_parameter(key);
-      node->set_parameter({rclcpp::Parameter(key, val_str)});
-      return;
-    } else if (yaml_node.Type() == YAML::NodeType::Map) {
-      for (auto yaml_node_it : yaml_node) {
-        feed_yaml_to_node_rec(
-          yaml_node_it.second, key + separator + yaml_node_it.first.as<std::string>(), node);
+        // TODO(ddengster): Do stricter typing for set_parameter value types.
+        // (ie. Numbers should be converted to int/double/etc instead of strings)
+        node->declare_parameter(key);
+        node->set_parameter({rclcpp::Parameter(key, val_str)});
+        return;
+      } else if (yaml_node.Type() == YAML::NodeType::Map) {
+        for (auto yaml_node_it : yaml_node) {
+          feed_yaml_to_node_rec(
+            yaml_node_it.second, key + separator + yaml_node_it.first.as<std::string>(), node);
+        }
+      } else if (yaml_node.Type() == YAML::NodeType::Sequence) {
+        size_t index = 0;
+        for (auto yaml_node_it : yaml_node) {
+          feed_yaml_to_node_rec(yaml_node_it, key + separator + std::to_string((index++)), node);
+        }
       }
-    } else if (yaml_node.Type() == YAML::NodeType::Sequence) {
-      size_t index = 0;
-      for (auto yaml_node_it : yaml_node) {
-        feed_yaml_to_node_rec(yaml_node_it, key + separator + std::to_string((index++)), node);
-      }
-    }
-  };
+    };
   feed_yaml_to_node_rec(yaml_node, "", lifecycle_node_);
 }
 

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -78,7 +78,6 @@ void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
     if (yaml_node.Type() == YAML::NodeType::Scalar) 
     {
       std::string val_str = yaml_node.as<std::string>();
-      RCLCPP_INFO(rclcpp::get_logger("l"), "%s: %s", key.c_str(), val_str.c_str());
 
       //@todo: Do stricter typing for set_parameter value types. 
       //(ie. Numbers should be converted to int/double/etc instead of strings)

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -79,7 +79,7 @@ void ControllerInterface::load_params_from_yaml_node(YAML::Node& yaml_node)
     if (yaml_node.Type() == YAML::NodeType::Scalar) {
       std::string val_str = yaml_node.as<std::string>();
 
-      // TODO: Do stricter typing for set_parameter value types.
+      // TODO(ddengster): Do stricter typing for set_parameter value types.
       // (ie. Numbers should be converted to int/double/etc instead of strings)
       node->declare_parameter(key);
       node->set_parameter({rclcpp::Parameter(key, val_str)});


### PR DESCRIPTION
2 new(rather, moved) functions that allow yaml to be parsed and fed into the lifecycle node of the controller; allowing our controllers to use them. One just takes in a filename, the other takes in an already custom-parsed yaml node.

If this goes in there shouldn't be any more reason to have controller_parameter_server as a seperate node, nor library nor class. We could use the testing code around though. Let me know if it goes against any of your philosophies.

Thanks Karsten for the initial yaml parsing code.