### PR TITLE
Un uncrustify

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [cppcheck, cpplint, uncrustify]
+          linter: [cppcheck, cpplint]
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@0.0.13

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -39,6 +39,7 @@ install(TARGETS controller_interface
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
 
   ament_index_get_prefix_path(ament_index_build_path SKIP_AMENT_PREFIX_PATH)

--- a/controller_parameter_server/CMakeLists.txt
+++ b/controller_parameter_server/CMakeLists.txt
@@ -51,6 +51,7 @@ install(DIRECTORY include/
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
 
   set(test_config_file ${CMAKE_CURRENT_SOURCE_DIR}/test/config/test_controller_config.yaml)

--- a/controller_parameter_server/src/parameter_server.cpp
+++ b/controller_parameter_server/src/parameter_server.cpp
@@ -21,12 +21,12 @@
 namespace controller_parameter_server
 {
 
-ParameterServer::ParameterServer(const rclcpp::NodeOptions & options)
+ParameterServer::ParameterServer(const rclcpp::NodeOptions& options)
 : rclcpp::Node("controller_parameter_server", options)
 {}
 
 void
-ParameterServer::load_parameters(const std::string & yaml_config_file)
+ParameterServer::load_parameters(const std::string& yaml_config_file)
 {
   if (yaml_config_file.empty()) {
     throw std::runtime_error("yaml config file path is empty");
@@ -42,7 +42,7 @@ ParameterServer::load_parameters(const std::string & yaml_config_file)
 }
 
 void
-ParameterServer::load_parameters(const std::string & key, const std::string & value)
+ParameterServer::load_parameters(const std::string& key, const std::string& value)
 {
   this->set_parameters({rclcpp::Parameter(key, value)});
 }

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -50,6 +50,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_macros test/test_macros.cpp)

--- a/test_robot_hardware/CMakeLists.txt
+++ b/test_robot_hardware/CMakeLists.txt
@@ -37,6 +37,7 @@ install(TARGETS test_robot_hardware
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_robot_hardware_interface test/test_robot_hardware_interface.cpp)


### PR DESCRIPTION
In the last few weeks uncrustify has proven to be more of an annoyance than help. 

I propose to make the uncrustify gh action step optional (if this is possible @piraka9011 ?) but otherwise remove uncrustify from the ament-generated tests. This should show up as a warning but not a blocker for a PR, especially not in the same list where *actual tests* are.

In the mean time, I propose to simply remove uncrustify checks from our CI tooling and periodically, manually run it. Call me immature but I would much more prefer to see commits adding good contributions with time spent on testing rather than PR-s dangling for days, sometimes weeks on trying to satisfy a tool. I volunteer to submit periodic `ament_uncrustify` fix PRs to both `ros2_control` and `ros2_controllers`, let's remove this barrier to entry from contributors.

PS: I can remove the second commit, it's there for testing :) 