### PR TITLE
Add code coverage to workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,14 @@ jobs:
           package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml
+          fail_ci_if_error: true
       - uses: actions/upload-artifact@master
         with:
           name: colcon-logs-${{ matrix.os }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "ros_ws/src/ros2_control/::"


### PR DESCRIPTION
Uses the [codecov GitHub action](https://github.com/codecov/codecov-action).
Assumes that the `CODECOV_TOKEN` secret has been added to the repo.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>