### PR TITLE
Remove quotes around dependencies in ament_target_dependencies

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -21,8 +21,8 @@ target_include_directories(
   include)
 ament_target_dependencies(
   controller_interface
-  "hardware_interface"
-  "rclcpp_lifecycle"
+  hardware_interface
+  rclcpp_lifecycle
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -21,11 +21,11 @@ find_package(rclcpp REQUIRED)
 add_library(controller_manager SHARED src/controller_manager.cpp src/controller_loader_pluginlib.cpp)
 target_include_directories(controller_manager PRIVATE include)
 ament_target_dependencies(controller_manager
-  "ament_index_cpp"
-  "controller_interface"
-  "hardware_interface"
-  "pluginlib"
-  "rclcpp"
+  ament_index_cpp
+  controller_interface
+  hardware_interface
+  pluginlib
+  rclcpp
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -28,8 +28,8 @@ target_include_directories(
   include)
 ament_target_dependencies(
   hardware_interface
-  "rclcpp"
-  "rcpputils"
+  rclcpp
+  rcpputils
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -54,7 +54,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
-  ament_target_dependencies(test_macros "rcpputils")
+  ament_target_dependencies(test_macros rcpputils)
 endif()
 
 ament_export_include_directories(


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/issues/70