### PR TITLE
Remove test_depend from metapackage

### DIFF
--- a/ros2_control/package.xml
+++ b/ros2_control/package.xml
@@ -17,8 +17,6 @@
   <exec_depend>controller_parameter_server</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
 
-  <test_depend>test_robot_hardware</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Addresses #72.

Test packages shouldn't be listed in the metapackage.

Disclaimer: As mentioned in #72, I'm still green with ROS2, but AFAIK the dependency management is largely the same as ROS1. This PR is in part to see if CI still passes ;)