### PR TITLE
Use rclcpp::Executor instead of rclcpp::executor::Executor(deprecated)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
+language: generic
 services:
   - docker
 
-install:
-  - git clone --quiet --depth 1 https://github.com/mikaelarguedas/ros2ci.git .ros2ci
+env:
+  matrix:
+    - ROS_DISTRO="foxy" ROS_REPO=testing
+    - ROS_DISTRO="foxy" ROS_REPO=main
 
-matrix:
-  include:
-    # - env: JOB_TYPE=crystal
-    #   script: .ros2ci/travis.bash $JOB_TYPE
-    # Uncomment the following to test against ROS 2 Dashing
-    # - env: JOB_TYPE=dashing
-    #   script: .ros2ci/travis.bash $JOB_TYPE
-    # - env: JOB_TYPE=eloquent
-    #   script: .ros2ci/travis.bash $JOB_TYPE
-    # Uncomment the following to test against ROS 2 nightly build
-    - env: JOB_TYPE=nightly
-      script: .ros2ci/travis.bash $JOB_TYPE
+install:
+  -  git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
+script:
+  - .industrial_ci/travis.sh

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -39,7 +39,7 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   ControllerManager(
     std::shared_ptr<hardware_interface::RobotHardware> hw,
-    std::shared_ptr<rclcpp::executor::Executor> executor,
+    std::shared_ptr<rclcpp::Executor> executor,
     const std::string & name = "controller_manager");
 
   CONTROLLER_MANAGER_PUBLIC
@@ -98,7 +98,7 @@ protected:
 
 private:
   std::shared_ptr<hardware_interface::RobotHardware> hw_;
-  std::shared_ptr<rclcpp::executor::Executor> executor_;
+  std::shared_ptr<rclcpp::Executor> executor_;
   std::vector<ControllerLoaderInterfaceSharedPtr> loaders_;
   std::vector<std::shared_ptr<controller_interface::ControllerInterface>> loaded_controllers_;
 };

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -31,7 +31,7 @@ namespace controller_manager
 
 ControllerManager::ControllerManager(
   std::shared_ptr<hardware_interface::RobotHardware> hw,
-  std::shared_ptr<rclcpp::executor::Executor> executor,
+  std::shared_ptr<rclcpp::Executor> executor,
   const std::string & manager_node_name)
 : rclcpp::Node(manager_node_name),
   hw_(hw),

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -43,7 +43,7 @@ public:
   }
 
   std::shared_ptr<test_robot_hardware::TestRobotHardware> robot;
-  std::shared_ptr<rclcpp::executor::Executor> executor;
+  std::shared_ptr<rclcpp::Executor> executor;
 };
 
 TEST_F(TestControllerManager, controller_lifecycle) {

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -50,7 +50,7 @@ public:
   }
 
   std::shared_ptr<test_robot_hardware::TestRobotHardware> robot;
-  std::shared_ptr<rclcpp::executor::Executor> executor;
+  std::shared_ptr<rclcpp::Executor> executor;
 };
 
 class ControllerMock : public controller_interface::ControllerInterface

--- a/controller_parameter_server/test/test_parameter_server.cpp
+++ b/controller_parameter_server/test/test_parameter_server.cpp
@@ -57,7 +57,7 @@ TEST_F(TestControllerParameterServer, init_key_value) {
 }
 
 void
-spin(rclcpp::executor::Executor * exe)
+spin(rclcpp::Executor * exe)
 {
   exe->spin();
 }


### PR DESCRIPTION
In response to `warning: ‘using Executor = class rclcpp::Executor’ is deprecated: use rclcpp::Executor instead [-Wdeprecated-declarations]`