### PR TITLE
Rename get_controller to get_controllers

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -56,6 +56,11 @@ public:
   std::vector<std::shared_ptr<controller_interface::ControllerInterface>>
   get_loaded_controllers() const;
 
+  [[deprecated("get_loaded_controller is deprecated, it has been renamed to get_loaded_controllers")]]
+  CONTROLLER_MANAGER_PUBLIC
+  std::vector<std::shared_ptr<controller_interface::ControllerInterface>>
+  get_loaded_controller() const;
+
   CONTROLLER_MANAGER_PUBLIC
   void register_controller_loader(ControllerLoaderInterfaceSharedPtr loader);
 

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -54,7 +54,7 @@ public:
 
   CONTROLLER_MANAGER_PUBLIC
   std::vector<std::shared_ptr<controller_interface::ControllerInterface>>
-  get_loaded_controller() const;
+  get_loaded_controllers() const;
 
   CONTROLLER_MANAGER_PUBLIC
   void register_controller_loader(ControllerLoaderInterfaceSharedPtr loader);

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -66,7 +66,7 @@ ControllerManager::load_controller(
 }
 
 std::vector<std::shared_ptr<controller_interface::ControllerInterface>>
-ControllerManager::get_loaded_controller() const
+ControllerManager::get_loaded_controllers() const
 {
   return loaded_controllers_;
 }

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -51,7 +51,7 @@ TEST_F(TestControllerManager, controller_lifecycle) {
 
   auto test_controller = std::make_shared<test_controller::TestController>();
   auto abstract_test_controller = cm.add_controller(test_controller, "test_controller");
-  EXPECT_EQ(1u, cm.get_loaded_controller().size());
+  EXPECT_EQ(1u, cm.get_loaded_controllers().size());
 
   EXPECT_EQ(controller_interface::CONTROLLER_INTERFACE_RET_SUCCESS, cm.update());
   EXPECT_EQ(1u, test_controller->internal_counter);

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -77,10 +77,10 @@ TEST_F(TestControllerManager, load1_known_controller)
 {
   controller_manager::ControllerManager cm(robot, executor, "test_controller_manager");
   ASSERT_NO_THROW(cm.load_controller("test_controller_01", "test_controller"));
-  EXPECT_EQ(1u, cm.get_loaded_controller().size());
+  EXPECT_EQ(1u, cm.get_loaded_controllers().size());
 
   std::shared_ptr<controller_interface::ControllerInterface> abstract_test_controller =
-    cm.get_loaded_controller()[0];
+    cm.get_loaded_controllers()[0];
 
   auto lifecycle_node = abstract_test_controller->get_lifecycle_node();
   lifecycle_node->configure();
@@ -97,9 +97,9 @@ TEST_F(TestControllerManager, load2_known_controller)
   // load the controller with name1
   std::string controller_name1 = "test_controller1";
   ASSERT_NO_THROW(cm.load_controller(controller_name1, controller_type));
-  EXPECT_EQ(1u, cm.get_loaded_controller().size());
+  EXPECT_EQ(1u, cm.get_loaded_controllers().size());
   std::shared_ptr<controller_interface::ControllerInterface> abstract_test_controller1 =
-    cm.get_loaded_controller()[0];
+    cm.get_loaded_controllers()[0];
   EXPECT_STREQ(
     controller_name1.c_str(), abstract_test_controller1->get_lifecycle_node()->get_name());
   abstract_test_controller1->get_lifecycle_node()->configure();
@@ -110,9 +110,9 @@ TEST_F(TestControllerManager, load2_known_controller)
   // load the same controller again with a different name
   std::string controller_name2 = "test_controller2";
   ASSERT_NO_THROW(cm.load_controller(controller_name2, controller_type));
-  EXPECT_EQ(2u, cm.get_loaded_controller().size());
+  EXPECT_EQ(2u, cm.get_loaded_controllers().size());
   std::shared_ptr<controller_interface::ControllerInterface> abstract_test_controller2 =
-    cm.get_loaded_controller()[1];
+    cm.get_loaded_controllers()[1];
   EXPECT_STREQ(
     controller_name2.c_str(), abstract_test_controller2->get_lifecycle_node()->get_name());
   abstract_test_controller2->get_lifecycle_node()->configure();
@@ -127,7 +127,7 @@ TEST_F(TestControllerManager, update)
   ASSERT_NO_THROW(cm.load_controller("test_controller_01", "test_controller"));
 
   std::shared_ptr<controller_interface::ControllerInterface> abstract_test_controller =
-    cm.get_loaded_controller()[0];
+    cm.get_loaded_controllers()[0];
 
   auto lifecycle_node = abstract_test_controller->get_lifecycle_node();
   lifecycle_node->configure();
@@ -157,10 +157,10 @@ TEST_F(TestControllerManager, register_controller_loader)
   .WillOnce(Return(mock_controller));
 
   ASSERT_NO_THROW(cm.load_controller(mock_controller_name, mock_controller_type));
-  EXPECT_EQ(1u, cm.get_loaded_controller().size());
+  EXPECT_EQ(1u, cm.get_loaded_controllers().size());
 
   std::shared_ptr<controller_interface::ControllerInterface> abstract_test_controller =
-    cm.get_loaded_controller()[0];
+    cm.get_loaded_controllers()[0];
 
   auto lifecycle_node = abstract_test_controller->get_lifecycle_node();
   lifecycle_node->configure();


### PR DESCRIPTION
If there's any reasoning to keep the current name please let me know.

If you prefer, I can keep the old method with a deprecation warning instead of removing it altogether for API compatibility.