### PR TITLE
hardware_interface and rclcpp need to be exported too

### DIFF
--- a/test_robot_hardware/CMakeLists.txt
+++ b/test_robot_hardware/CMakeLists.txt
@@ -49,6 +49,10 @@ if(BUILD_TESTING)
   endif()
 endif()
 
+ament_export_dependencies(
+  hardware_interface
+  rclcpp
+)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)
 ament_package()

--- a/test_robot_hardware/package.xml
+++ b/test_robot_hardware/package.xml
@@ -9,11 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>rclcpp</build_depend>
-
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
+  <depend>hardware_interface</depend>
+  <depend>rclcpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Need to add these exports otherwise users of `test_robot_hardware` will have to add them in their packages.