### PR TITLE
touchups in  metapackage

### DIFF
--- a/ros2_control/package.xml
+++ b/ros2_control/package.xml
@@ -16,6 +16,9 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>controller_parameter_server</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>transmision_interface</exec_depend>
+
+  <test_depend>test_robot_hardware</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_control/package.xml
+++ b/ros2_control/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>controller_parameter_server</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>transmision_interface</exec_depend>
+  <exec_depend>transmission_interface</exec_depend>
 
   <test_depend>test_robot_hardware</test_depend>
 

--- a/ros2_control/ros2_control.repos
+++ b/ros2_control/ros2_control.repos
@@ -1,0 +1,21 @@
+repositories:
+  ros-controls/ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros-controls/ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers.git
+    version: master
+  ros-controls/realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: ros2_devel
+  ros-controls/control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: foxy-devel
+  angles:
+    type: git
+    url: https://github.com/ros/angles.git
+    version: ros2


### PR DESCRIPTION
* add transmission interface to metapackage
* re-add test packages to `test_depend`, see https://github.com/ros-controls/ros2_control/pull/75#issuecomment-643418021
* add ros2 repos file, which can be used for GH actions or CI