### PR TITLE
dll export for transmission info

### DIFF
--- a/transmission_interface/include/transmission_interface/transmission_info.hpp
+++ b/transmission_interface/include/transmission_interface/transmission_info.hpp
@@ -23,10 +23,10 @@
 namespace transmission_interface
 {
 
-struct TRANSMISSION_INTERFACE_PUBLIC_TYPE TransmissionInfo
+struct TransmissionInfo
 {
-  std::string joint_name;
-  std::string joint_control_type;
+  TRANSMISSION_INTERFACE_PUBLIC std::string joint_name;
+  TRANSMISSION_INTERFACE_PUBLIC std::string joint_control_type;
 };
 
 }  // namespace transmission_interface

--- a/transmission_interface/include/transmission_interface/transmission_info.hpp
+++ b/transmission_interface/include/transmission_interface/transmission_info.hpp
@@ -18,15 +18,14 @@
 #include <string>
 
 #include "hardware_interface/control_type.hpp"
-#include "transmission_interface/visibility_control.h"
 
 namespace transmission_interface
 {
 
 struct TransmissionInfo
 {
-  TRANSMISSION_INTERFACE_PUBLIC std::string joint_name;
-  TRANSMISSION_INTERFACE_PUBLIC std::string joint_control_type;
+  std::string joint_name;
+  std::string joint_control_type;
 };
 
 }  // namespace transmission_interface


### PR DESCRIPTION
fixes msbuild warning shown here: https://ci.ros2.org/job/ci_windows/11050/msbuild/fileName.106703594/

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11141)](http://ci.ros2.org/job/ci_linux/11141/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6434)](http://ci.ros2.org/job/ci_linux-aarch64/6434/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9088)](http://ci.ros2.org/job/ci_osx/9088/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11070)](https://ci.ros2.org/job/ci_windows/11070/)