### PR TITLE
Add unit testing to robot hardware

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: ros-tooling/setup-ros@0.0.19
-      - uses: ros-tooling/action-ros-ci@0.0.15
+      - uses: ros-tooling/setup-ros@0.0.23
+      - uses: ros-tooling/action-ros-ci@0.0.17
         with:
           package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
           colcon-mixin-name: coverage-gcc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: ros-tooling/setup-ros@0.0.13
-      - uses: ros-tooling/action-ros-ci@0.0.13
+      - uses: ros-tooling/setup-ros@0.0.19
+      - uses: ros-tooling/action-ros-ci@0.0.15
         with:
           package-name: controller_interface controller_manager controller_parameter_server hardware_interface test_robot_hardware
           colcon-mixin-name: coverage-gcc

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -52,7 +52,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_macros test/test_macros.cpp)
+  ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
   ament_target_dependencies(test_macros rcpputils)
 endif()

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -60,7 +60,6 @@ if(BUILD_TESTING)
   ament_add_gmock(test_robot_hardware_interfaces test/test_robot_hardware_interface.cpp)
   target_include_directories(test_robot_hardware_interfaces PRIVATE include)
   target_link_libraries(test_robot_hardware_interfaces hardware_interface)
-
 endif()
 
 ament_export_include_directories(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -49,12 +49,18 @@ install(
   LIBRARY DESTINATION lib)
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
+  # find_package(ament_lint_auto REQUIRED)
+  # ament_lint_auto_find_test_dependencies()
 
+  find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
   ament_target_dependencies(test_macros rcpputils)
+
+  ament_add_gmock(test_robot_hardware_interfaces test/test_robot_hardware_interface.cpp)
+  target_include_directories(test_robot_hardware_interfaces PRIVATE include)
+  target_link_libraries(test_robot_hardware_interfaces hardware_interface)
+
 endif()
 
 ament_export_include_directories(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -49,8 +49,8 @@ install(
   LIBRARY DESTINATION lib)
 
 if(BUILD_TESTING)
-  # find_package(ament_lint_auto REQUIRED)
-  # ament_lint_auto_find_test_dependencies()
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
   ament_add_gmock(test_macros test/test_macros.cpp)

--- a/hardware_interface/include/hardware_interface/joint_command_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_command_handle.hpp
@@ -39,16 +39,21 @@ public:
    * \param cmd A pointer to the storage for this joint's command
    */
   HARDWARE_INTERFACE_PUBLIC
-  JointCommandHandle(const std::string & name, double * cmd);
+  JointCommandHandle(
+    const std::string & name,
+    double * cmd);
 
   HARDWARE_INTERFACE_PUBLIC
-  const std::string & get_name() const;
+  const std::string &
+  get_name() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  double get_cmd() const;
+  double
+  get_cmd() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  void set_cmd(double cmd);
+  void
+  set_cmd(double cmd);
 
   HARDWARE_INTERFACE_PUBLIC
   bool valid_pointers() const;

--- a/hardware_interface/include/hardware_interface/joint_command_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_command_handle.hpp
@@ -26,38 +26,36 @@ namespace hardware_interface
 /** A handle used to get and set the command of a single joint. */
 class JointCommandHandle
 {
-public:
-  HARDWARE_INTERFACE_PUBLIC
-  JointCommandHandle();
+  public:
+    HARDWARE_INTERFACE_PUBLIC
+    JointCommandHandle();
 
-  /**
-   * The commmand handles are passive in terms of ownership.
-   * That means that the handles are only allowed to read/write
-   * the storage, however are not allowed to delete or reallocate
-   * this memory.
-   * \param name The name of the joint
-   * \param cmd A pointer to the storage for this joint's command
-   */
-  HARDWARE_INTERFACE_PUBLIC
-  JointCommandHandle(
-    const std::string & name,
-    double * cmd);
+    /**
+     * The commmand handles are passive in terms of ownership.
+     * That means that the handles are only allowed to read/write
+     * the storage, however are not allowed to delete or reallocate
+     * this memory.
+     * \param name The name of the joint
+     * \param cmd A pointer to the storage for this joint's command
+     */
+    HARDWARE_INTERFACE_PUBLIC
+    JointCommandHandle(const std::string& name, double* cmd);
 
-  HARDWARE_INTERFACE_PUBLIC
-  const std::string &
-  get_name() const;
+    HARDWARE_INTERFACE_PUBLIC
+    const std::string& get_name() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  double
-  get_cmd() const;
+    HARDWARE_INTERFACE_PUBLIC
+    double get_cmd() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  void
-  set_cmd(double cmd);
+    HARDWARE_INTERFACE_PUBLIC
+    void set_cmd(double cmd);
 
-private:
-  std::string name_;
-  double * cmd_;
+    HARDWARE_INTERFACE_PUBLIC
+    bool valid_pointers() const;
+
+  private:
+    std::string name_;
+    double* cmd_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/joint_command_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_command_handle.hpp
@@ -26,36 +26,36 @@ namespace hardware_interface
 /** A handle used to get and set the command of a single joint. */
 class JointCommandHandle
 {
-  public:
-    HARDWARE_INTERFACE_PUBLIC
-    JointCommandHandle();
+public:
+  HARDWARE_INTERFACE_PUBLIC
+  JointCommandHandle();
 
-    /**
-     * The commmand handles are passive in terms of ownership.
-     * That means that the handles are only allowed to read/write
-     * the storage, however are not allowed to delete or reallocate
-     * this memory.
-     * \param name The name of the joint
-     * \param cmd A pointer to the storage for this joint's command
-     */
-    HARDWARE_INTERFACE_PUBLIC
-    JointCommandHandle(const std::string& name, double* cmd);
+  /**
+   * The commmand handles are passive in terms of ownership.
+   * That means that the handles are only allowed to read/write
+   * the storage, however are not allowed to delete or reallocate
+   * this memory.
+   * \param name The name of the joint
+   * \param cmd A pointer to the storage for this joint's command
+   */
+  HARDWARE_INTERFACE_PUBLIC
+  JointCommandHandle(const std::string & name, double * cmd);
 
-    HARDWARE_INTERFACE_PUBLIC
-    const std::string& get_name() const;
+  HARDWARE_INTERFACE_PUBLIC
+  const std::string & get_name() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    double get_cmd() const;
+  HARDWARE_INTERFACE_PUBLIC
+  double get_cmd() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    void set_cmd(double cmd);
+  HARDWARE_INTERFACE_PUBLIC
+  void set_cmd(double cmd);
 
-    HARDWARE_INTERFACE_PUBLIC
-    bool valid_pointers() const;
+  HARDWARE_INTERFACE_PUBLIC
+  bool valid_pointers() const;
 
-  private:
-    std::string name_;
-    double* cmd_;
+private:
+  std::string name_;
+  double * cmd_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/joint_state_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_state_handle.hpp
@@ -25,43 +25,45 @@ namespace hardware_interface
 /** A handle used to read the state of a single joint. */
 class JointStateHandle
 {
-  public:
-    HARDWARE_INTERFACE_PUBLIC
-    JointStateHandle();
+public:
+  HARDWARE_INTERFACE_PUBLIC
+  JointStateHandle();
 
-    /**
-     * The joint handles are passive in terms of ownership.
-     * That means that the handles are only allowed to read/write
-     * the storage, however are not allowed to delete or reallocate
-     * this memory.
-     * \param name The name of the joint
-     * \param pos A pointer to the storage for this joint's position
-     * \param vel A pointer to the storage for this joint's velocity
-     * \param eff A pointer to the storage for this joint's effort (force or torque)
-     */
-    HARDWARE_INTERFACE_PUBLIC
-    JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff);
+  /**
+   * The joint handles are passive in terms of ownership.
+   * That means that the handles are only allowed to read/write
+   * the storage, however are not allowed to delete or reallocate
+   * this memory.
+   * \param name The name of the joint
+   * \param pos A pointer to the storage for this joint's position
+   * \param vel A pointer to the storage for this joint's velocity
+   * \param eff A pointer to the storage for this joint's effort (force or torque)
+   */
+  HARDWARE_INTERFACE_PUBLIC
+  JointStateHandle(
+    const std::string & name, const double * pos, const double * vel,
+    const double * eff);
 
-    HARDWARE_INTERFACE_PUBLIC
-    const std::string& get_name() const;
+  HARDWARE_INTERFACE_PUBLIC
+  const std::string & get_name() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    double get_position() const;
+  HARDWARE_INTERFACE_PUBLIC
+  double get_position() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    double get_velocity() const;
+  HARDWARE_INTERFACE_PUBLIC
+  double get_velocity() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    double get_effort() const;
+  HARDWARE_INTERFACE_PUBLIC
+  double get_effort() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    bool valid_pointers() const;
+  HARDWARE_INTERFACE_PUBLIC
+  bool valid_pointers() const;
 
-  private:
-    std::string name_;
-    const double* pos_;
-    const double* vel_;
-    const double* eff_;
+private:
+  std::string name_;
+  const double * pos_;
+  const double * vel_;
+  const double * eff_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/joint_state_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_state_handle.hpp
@@ -25,48 +25,43 @@ namespace hardware_interface
 /** A handle used to read the state of a single joint. */
 class JointStateHandle
 {
-public:
-  HARDWARE_INTERFACE_PUBLIC
-  JointStateHandle();
+  public:
+    HARDWARE_INTERFACE_PUBLIC
+    JointStateHandle();
 
-  /**
-   * The joint handles are passive in terms of ownership.
-   * That means that the handles are only allowed to read/write
-   * the storage, however are not allowed to delete or reallocate
-   * this memory.
-   * \param name The name of the joint
-   * \param pos A pointer to the storage for this joint's position
-   * \param vel A pointer to the storage for this joint's velocity
-   * \param eff A pointer to the storage for this joint's effort (force or torque)
-   */
-  HARDWARE_INTERFACE_PUBLIC
-  JointStateHandle(
-    const std::string & name,
-    const double * pos,
-    const double * vel,
-    const double * eff);
+    /**
+     * The joint handles are passive in terms of ownership.
+     * That means that the handles are only allowed to read/write
+     * the storage, however are not allowed to delete or reallocate
+     * this memory.
+     * \param name The name of the joint
+     * \param pos A pointer to the storage for this joint's position
+     * \param vel A pointer to the storage for this joint's velocity
+     * \param eff A pointer to the storage for this joint's effort (force or torque)
+     */
+    HARDWARE_INTERFACE_PUBLIC
+    JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff);
 
-  HARDWARE_INTERFACE_PUBLIC
-  const std::string &
-  get_name() const;
+    HARDWARE_INTERFACE_PUBLIC
+    const std::string& get_name() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  double
-  get_position() const;
+    HARDWARE_INTERFACE_PUBLIC
+    double get_position() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  double
-  get_velocity() const;
+    HARDWARE_INTERFACE_PUBLIC
+    double get_velocity() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  double
-  get_effort() const;
+    HARDWARE_INTERFACE_PUBLIC
+    double get_effort() const;
 
-private:
-  std::string name_;
-  const double * pos_;
-  const double * vel_;
-  const double * eff_;
+    HARDWARE_INTERFACE_PUBLIC
+    bool valid_pointers() const;
+
+  private:
+    std::string name_;
+    const double* pos_;
+    const double* vel_;
+    const double* eff_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/joint_state_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_state_handle.hpp
@@ -41,20 +41,26 @@ public:
    */
   HARDWARE_INTERFACE_PUBLIC
   JointStateHandle(
-    const std::string & name, const double * pos, const double * vel,
+    const std::string & name,
+    const double * pos,
+    const double * vel,
     const double * eff);
 
   HARDWARE_INTERFACE_PUBLIC
-  const std::string & get_name() const;
+  const std::string &
+  get_name() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  double get_position() const;
+  double
+  get_position() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  double get_velocity() const;
+  double
+  get_velocity() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  double get_effort() const;
+  double
+  get_effort() const;
 
   HARDWARE_INTERFACE_PUBLIC
   bool valid_pointers() const;

--- a/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
+++ b/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
@@ -23,43 +23,43 @@ namespace hardware_interface
 {
 /// Enum for Operation Mode.
 /** Operation can either be active or inactive */
-enum class HARDWARE_INTERFACE_PUBLIC_TYPE OperationMode : bool
+enum class HARDWARE_INTERFACE_PUBLIC_TYPE OperationMode: bool
 {
-    ACTIVE = true,
-    INACTIVE = false
+  ACTIVE = true,
+  INACTIVE = false
 };
 
 /// A handle for Operation Mode.
 /** Used to set status to active or inactive for operation such as read/write. */
 class OperationModeHandle
 {
-  public:
-    HARDWARE_INTERFACE_PUBLIC
-    OperationModeHandle();
+public:
+  HARDWARE_INTERFACE_PUBLIC
+  OperationModeHandle();
 
-    /// Constructor of Operation Mode.
-    /**
-     * The mode handles are passive in terms of ownership for the mode pointer.
-     * This means the handle is allowed to read and write the respective mode,
-     * however is not allowed to reallocate or delete the memory storage.
-     * \param name The name of the joint
-     * \param mode A pointer to the storage for this hardware's operation mode
-     */
-    HARDWARE_INTERFACE_PUBLIC
-    OperationModeHandle(const std::string& name, OperationMode* mode);
+  /// Constructor of Operation Mode.
+  /**
+   * The mode handles are passive in terms of ownership for the mode pointer.
+   * This means the handle is allowed to read and write the respective mode,
+   * however is not allowed to reallocate or delete the memory storage.
+   * \param name The name of the joint
+   * \param mode A pointer to the storage for this hardware's operation mode
+   */
+  HARDWARE_INTERFACE_PUBLIC
+  OperationModeHandle(const std::string & name, OperationMode * mode);
 
-    HARDWARE_INTERFACE_PUBLIC
-    const std::string& get_name() const;
+  HARDWARE_INTERFACE_PUBLIC
+  const std::string & get_name() const;
 
-    HARDWARE_INTERFACE_PUBLIC
-    void set_mode(OperationMode mode);
+  HARDWARE_INTERFACE_PUBLIC
+  void set_mode(OperationMode mode);
 
-    HARDWARE_INTERFACE_PUBLIC
-    bool valid_pointers() const;
+  HARDWARE_INTERFACE_PUBLIC
+  bool valid_pointers() const;
 
-  private:
-    std::string name_;
-    OperationMode* mode_;
+private:
+  std::string name_;
+  OperationMode * mode_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
+++ b/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
@@ -23,44 +23,43 @@ namespace hardware_interface
 {
 /// Enum for Operation Mode.
 /** Operation can either be active or inactive */
-enum class HARDWARE_INTERFACE_PUBLIC_TYPE OperationMode: bool
+enum class HARDWARE_INTERFACE_PUBLIC_TYPE OperationMode : bool
 {
-  ACTIVE = true,
-  INACTIVE = false
+    ACTIVE = true,
+    INACTIVE = false
 };
 
 /// A handle for Operation Mode.
 /** Used to set status to active or inactive for operation such as read/write. */
 class OperationModeHandle
 {
-public:
-  HARDWARE_INTERFACE_PUBLIC
-  OperationModeHandle();
+  public:
+    HARDWARE_INTERFACE_PUBLIC
+    OperationModeHandle();
 
-  /// Constructor of Operation Mode.
-  /**
-   * The mode handles are passive in terms of ownership for the mode pointer.
-   * This means the handle is allowed to read and write the respective mode,
-   * however is not allowed to reallocate or delete the memory storage.
-   * \param name The name of the joint
-   * \param mode A pointer to the storage for this hardware's operation mode
-   */
-  HARDWARE_INTERFACE_PUBLIC
-  OperationModeHandle(
-    const std::string & name,
-    OperationMode * mode);
+    /// Constructor of Operation Mode.
+    /**
+     * The mode handles are passive in terms of ownership for the mode pointer.
+     * This means the handle is allowed to read and write the respective mode,
+     * however is not allowed to reallocate or delete the memory storage.
+     * \param name The name of the joint
+     * \param mode A pointer to the storage for this hardware's operation mode
+     */
+    HARDWARE_INTERFACE_PUBLIC
+    OperationModeHandle(const std::string& name, OperationMode* mode);
 
-  HARDWARE_INTERFACE_PUBLIC
-  const std::string &
-  get_name() const;
+    HARDWARE_INTERFACE_PUBLIC
+    const std::string& get_name() const;
 
-  HARDWARE_INTERFACE_PUBLIC
-  void
-  set_mode(OperationMode mode);
+    HARDWARE_INTERFACE_PUBLIC
+    void set_mode(OperationMode mode);
 
-private:
-  std::string name_;
-  OperationMode * mode_;
+    HARDWARE_INTERFACE_PUBLIC
+    bool valid_pointers() const;
+
+  private:
+    std::string name_;
+    OperationMode* mode_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
+++ b/hardware_interface/include/hardware_interface/operation_mode_handle.hpp
@@ -46,13 +46,17 @@ public:
    * \param mode A pointer to the storage for this hardware's operation mode
    */
   HARDWARE_INTERFACE_PUBLIC
-  OperationModeHandle(const std::string & name, OperationMode * mode);
+  OperationModeHandle(
+    const std::string & name,
+    OperationMode * mode);
 
   HARDWARE_INTERFACE_PUBLIC
-  const std::string & get_name() const;
+  const std::string &
+  get_name() const;
 
   HARDWARE_INTERFACE_PUBLIC
-  void set_mode(OperationMode mode);
+  void
+  set_mode(OperationMode mode);
 
   HARDWARE_INTERFACE_PUBLIC
   bool valid_pointers() const;

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -5,6 +5,7 @@
   <description>ROS2 ros_control hardware interface</description>
 
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -12,7 +12,7 @@
   <depend>rclcpp</depend>
   <depend>rcpputils</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/hardware_interface/src/joint_command_handle.cpp
+++ b/hardware_interface/src/joint_command_handle.cpp
@@ -21,30 +21,36 @@
 
 namespace hardware_interface
 {
-JointCommandHandle::JointCommandHandle()
-: name_(), cmd_(nullptr)
-{
-}
 
-JointCommandHandle::JointCommandHandle(const std::string & name, double * cmd)
+JointCommandHandle::JointCommandHandle()
+: name_(),
+  cmd_(nullptr)
+{}
+
+JointCommandHandle::JointCommandHandle(
+  const std::string & name,
+  double * cmd)
 : name_(name), cmd_(cmd)
 {
   THROW_ON_NULLPTR(cmd)
 }
 
-const std::string & JointCommandHandle::get_name() const
+const std::string &
+JointCommandHandle::get_name() const
 {
   return name_;
 }
 
-double JointCommandHandle::get_cmd() const
+double
+JointCommandHandle::get_cmd() const
 {
   THROW_ON_NULLPTR(cmd_)
 
   return *cmd_;
 }
 
-void JointCommandHandle::set_cmd(double cmd)
+void
+JointCommandHandle::set_cmd(double cmd)
 {
   THROW_ON_NULLPTR(cmd_)
 

--- a/hardware_interface/src/joint_command_handle.cpp
+++ b/hardware_interface/src/joint_command_handle.cpp
@@ -21,37 +21,39 @@
 
 namespace hardware_interface
 {
-JointCommandHandle::JointCommandHandle() : name_(), cmd_(nullptr)
+JointCommandHandle::JointCommandHandle()
+: name_(), cmd_(nullptr)
 {
 }
 
-JointCommandHandle::JointCommandHandle(const std::string& name, double* cmd) : name_(name), cmd_(cmd)
+JointCommandHandle::JointCommandHandle(const std::string & name, double * cmd)
+: name_(name), cmd_(cmd)
 {
-    THROW_ON_NULLPTR(cmd)
+  THROW_ON_NULLPTR(cmd)
 }
 
-const std::string& JointCommandHandle::get_name() const
+const std::string & JointCommandHandle::get_name() const
 {
-    return name_;
+  return name_;
 }
 
 double JointCommandHandle::get_cmd() const
 {
-    THROW_ON_NULLPTR(cmd_)
+  THROW_ON_NULLPTR(cmd_)
 
-    return *cmd_;
+  return *cmd_;
 }
 
 void JointCommandHandle::set_cmd(double cmd)
 {
-    THROW_ON_NULLPTR(cmd_)
+  THROW_ON_NULLPTR(cmd_)
 
-    *cmd_ = cmd;
+  * cmd_ = cmd;
 }
 
 bool JointCommandHandle::valid_pointers() const
 {
-    return cmd_;
+  return cmd_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/joint_command_handle.cpp
+++ b/hardware_interface/src/joint_command_handle.cpp
@@ -21,38 +21,37 @@
 
 namespace hardware_interface
 {
-
-JointCommandHandle::JointCommandHandle()
-: name_(),
-  cmd_(nullptr)
-{}
-
-JointCommandHandle::JointCommandHandle(
-  const std::string & name,
-  double * cmd)
-: name_(name), cmd_(cmd)
+JointCommandHandle::JointCommandHandle() : name_(), cmd_(nullptr)
 {
-  THROW_ON_NULLPTR(cmd)
 }
 
-const std::string &
-JointCommandHandle::get_name() const
+JointCommandHandle::JointCommandHandle(const std::string& name, double* cmd) : name_(name), cmd_(cmd)
 {
-  return name_;
+    THROW_ON_NULLPTR(cmd)
 }
 
-double
-JointCommandHandle::get_cmd() const
+const std::string& JointCommandHandle::get_name() const
 {
-  return *cmd_;
+    return name_;
 }
 
-void
-JointCommandHandle::set_cmd(double cmd)
+double JointCommandHandle::get_cmd() const
 {
-  THROW_ON_NULLPTR(cmd_)
+    THROW_ON_NULLPTR(cmd_)
 
-  * cmd_ = cmd;
+    return *cmd_;
+}
+
+void JointCommandHandle::set_cmd(double cmd)
+{
+    THROW_ON_NULLPTR(cmd_)
+
+    *cmd_ = cmd;
+}
+
+bool JointCommandHandle::valid_pointers() const
+{
+    return cmd_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/joint_state_handle.cpp
+++ b/hardware_interface/src/joint_state_handle.cpp
@@ -21,13 +21,18 @@
 
 namespace hardware_interface
 {
+
 JointStateHandle::JointStateHandle()
-: name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr)
-{
-}
+: name_(),
+  pos_(nullptr),
+  vel_(nullptr),
+  eff_(nullptr)
+{}
 
 JointStateHandle::JointStateHandle(
-  const std::string & name, const double * pos, const double * vel,
+  const std::string & name,
+  const double * pos,
+  const double * vel,
   const double * eff)
 : name_(name), pos_(pos), vel_(vel), eff_(eff)
 {
@@ -36,26 +41,30 @@ JointStateHandle::JointStateHandle(
   THROW_ON_NULLPTR(eff)
 }
 
-const std::string & JointStateHandle::get_name() const
+const std::string &
+JointStateHandle::get_name() const
 {
   return name_;
 }
 
-double JointStateHandle::get_position() const
+double
+JointStateHandle::get_position() const
 {
   THROW_ON_NULLPTR(pos_)
 
   return *pos_;
 }
 
-double JointStateHandle::get_velocity() const
+double
+JointStateHandle::get_velocity() const
 {
   THROW_ON_NULLPTR(vel_)
 
   return *vel_;
 }
 
-double JointStateHandle::get_effort() const
+double
+JointStateHandle::get_effort() const
 {
   THROW_ON_NULLPTR(eff_)
 

--- a/hardware_interface/src/joint_state_handle.cpp
+++ b/hardware_interface/src/joint_state_handle.cpp
@@ -21,47 +21,50 @@
 
 namespace hardware_interface
 {
-JointStateHandle::JointStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr)
+JointStateHandle::JointStateHandle()
+: name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr)
 {
 }
 
-JointStateHandle::JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
-  : name_(name), pos_(pos), vel_(vel), eff_(eff)
+JointStateHandle::JointStateHandle(
+  const std::string & name, const double * pos, const double * vel,
+  const double * eff)
+: name_(name), pos_(pos), vel_(vel), eff_(eff)
 {
-    THROW_ON_NULLPTR(pos)
-    THROW_ON_NULLPTR(vel)
-    THROW_ON_NULLPTR(eff)
+  THROW_ON_NULLPTR(pos)
+  THROW_ON_NULLPTR(vel)
+  THROW_ON_NULLPTR(eff)
 }
 
-const std::string& JointStateHandle::get_name() const
+const std::string & JointStateHandle::get_name() const
 {
-    return name_;
+  return name_;
 }
 
 double JointStateHandle::get_position() const
 {
-    THROW_ON_NULLPTR(pos_)
+  THROW_ON_NULLPTR(pos_)
 
-    return *pos_;
+  return *pos_;
 }
 
 double JointStateHandle::get_velocity() const
 {
-    THROW_ON_NULLPTR(vel_)
+  THROW_ON_NULLPTR(vel_)
 
-    return *vel_;
+  return *vel_;
 }
 
 double JointStateHandle::get_effort() const
 {
-    THROW_ON_NULLPTR(eff_)
+  THROW_ON_NULLPTR(eff_)
 
-    return *eff_;
+  return *eff_;
 }
 
 bool JointStateHandle::valid_pointers() const
 {
-    return pos_ && vel_ && eff_;
+  return pos_ && vel_ && eff_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/joint_state_handle.cpp
+++ b/hardware_interface/src/joint_state_handle.cpp
@@ -21,53 +21,47 @@
 
 namespace hardware_interface
 {
-
-JointStateHandle::JointStateHandle()
-: name_(),
-  pos_(nullptr),
-  vel_(nullptr),
-  eff_(nullptr)
-{}
-
-JointStateHandle::JointStateHandle(
-  const std::string & name,
-  const double * pos,
-  const double * vel,
-  const double * eff)
-: name_(name), pos_(pos), vel_(vel), eff_(eff)
+JointStateHandle::JointStateHandle() : name_(), pos_(nullptr), vel_(nullptr), eff_(nullptr)
 {
-  THROW_ON_NULLPTR(pos)
-  THROW_ON_NULLPTR(vel)
-  THROW_ON_NULLPTR(eff)
 }
 
-const std::string &
-JointStateHandle::get_name() const
+JointStateHandle::JointStateHandle(const std::string& name, const double* pos, const double* vel, const double* eff)
+  : name_(name), pos_(pos), vel_(vel), eff_(eff)
 {
-  return name_;
+    THROW_ON_NULLPTR(pos)
+    THROW_ON_NULLPTR(vel)
+    THROW_ON_NULLPTR(eff)
 }
 
-double
-JointStateHandle::get_position() const
+const std::string& JointStateHandle::get_name() const
 {
-  THROW_ON_NULLPTR(pos_)
-
-  return *pos_;
+    return name_;
 }
 
-double
-JointStateHandle::get_velocity() const
+double JointStateHandle::get_position() const
 {
-  THROW_ON_NULLPTR(vel_)
+    THROW_ON_NULLPTR(pos_)
 
-  return *vel_;
+    return *pos_;
 }
 
-double
-JointStateHandle::get_effort() const
+double JointStateHandle::get_velocity() const
 {
-  THROW_ON_NULLPTR(eff_)
+    THROW_ON_NULLPTR(vel_)
 
-  return *eff_;
+    return *vel_;
 }
+
+double JointStateHandle::get_effort() const
+{
+    THROW_ON_NULLPTR(eff_)
+
+    return *eff_;
+}
+
+bool JointStateHandle::valid_pointers() const
+{
+    return pos_ && vel_ && eff_;
+}
+
 }  // namespace hardware_interface

--- a/hardware_interface/src/operation_mode_handle.cpp
+++ b/hardware_interface/src/operation_mode_handle.cpp
@@ -21,33 +21,30 @@
 
 namespace hardware_interface
 {
-
-OperationModeHandle::OperationModeHandle()
-: name_(),
-  mode_(nullptr)
-{}
-
-OperationModeHandle::OperationModeHandle(
-  const std::string & name,
-  OperationMode * mode)
-: name_(name),
-  mode_(mode)
+OperationModeHandle::OperationModeHandle() : name_(), mode_(nullptr)
 {
-  THROW_ON_NULLPTR(mode)
 }
 
-const std::string &
-OperationModeHandle::get_name() const
+OperationModeHandle::OperationModeHandle(const std::string& name, OperationMode* mode) : name_(name), mode_(mode)
 {
-  return name_;
+    THROW_ON_NULLPTR(mode)
 }
 
-void
-OperationModeHandle::set_mode(OperationMode mode)
+const std::string& OperationModeHandle::get_name() const
 {
-  THROW_ON_NULLPTR(mode_)
+    return name_;
+}
 
-  * mode_ = mode;
+void OperationModeHandle::set_mode(OperationMode mode)
+{
+    THROW_ON_NULLPTR(mode_)
+
+    *mode_ = mode;
+}
+
+bool OperationModeHandle::valid_pointers() const
+{
+    return mode_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/operation_mode_handle.cpp
+++ b/hardware_interface/src/operation_mode_handle.cpp
@@ -21,30 +21,32 @@
 
 namespace hardware_interface
 {
-OperationModeHandle::OperationModeHandle() : name_(), mode_(nullptr)
+OperationModeHandle::OperationModeHandle()
+: name_(), mode_(nullptr)
 {
 }
 
-OperationModeHandle::OperationModeHandle(const std::string& name, OperationMode* mode) : name_(name), mode_(mode)
+OperationModeHandle::OperationModeHandle(const std::string & name, OperationMode * mode)
+: name_(name), mode_(mode)
 {
-    THROW_ON_NULLPTR(mode)
+  THROW_ON_NULLPTR(mode)
 }
 
-const std::string& OperationModeHandle::get_name() const
+const std::string & OperationModeHandle::get_name() const
 {
-    return name_;
+  return name_;
 }
 
 void OperationModeHandle::set_mode(OperationMode mode)
 {
-    THROW_ON_NULLPTR(mode_)
+  THROW_ON_NULLPTR(mode_)
 
-    *mode_ = mode;
+  * mode_ = mode;
 }
 
 bool OperationModeHandle::valid_pointers() const
 {
-    return mode_;
+  return mode_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/operation_mode_handle.cpp
+++ b/hardware_interface/src/operation_mode_handle.cpp
@@ -21,23 +21,29 @@
 
 namespace hardware_interface
 {
-OperationModeHandle::OperationModeHandle()
-: name_(), mode_(nullptr)
-{
-}
 
-OperationModeHandle::OperationModeHandle(const std::string & name, OperationMode * mode)
-: name_(name), mode_(mode)
+OperationModeHandle::OperationModeHandle()
+: name_(),
+  mode_(nullptr)
+{}
+
+OperationModeHandle::OperationModeHandle(
+  const std::string & name,
+  OperationMode * mode)
+: name_(name),
+  mode_(mode)
 {
   THROW_ON_NULLPTR(mode)
 }
 
-const std::string & OperationModeHandle::get_name() const
+const std::string &
+OperationModeHandle::get_name() const
 {
   return name_;
 }
 
-void OperationModeHandle::set_mode(OperationMode mode)
+void
+OperationModeHandle::set_mode(OperationMode mode)
 {
   THROW_ON_NULLPTR(mode_)
 

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -27,7 +27,6 @@ namespace
 constexpr auto kJointStateLoggerName = "joint state handle";
 constexpr auto kJointCommandLoggerName = "joint cmd handle";
 constexpr auto kOperationModeLoggerName = "joint operation mode handle";
-constexpr auto kActuatorLoggerName = "register actuator";
 }
 
 namespace hardware_interface
@@ -40,9 +39,8 @@ namespace hardware_interface
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
 template<typename T>
-hardware_interface_ret_t register_handle(
-  std::vector<T *> & registered_handles, T * handle,
-  const std::string & logger_name)
+hardware_interface_ret_t
+register_handle(std::vector<T *> & registered_handles, T * handle, const std::string & logger_name)
 {
   if (handle->get_name().empty()) {
     RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! No name is specified");
@@ -55,40 +53,46 @@ hardware_interface_ret_t register_handle(
   }
 
   auto handle_pos = std::find_if(
-    registered_handles.begin(), registered_handles.end(), [&](auto handle_ptr) -> bool {
+    registered_handles.begin(), registered_handles.end(),
+    [&](auto handle_ptr) -> bool {
       return handle_ptr->get_name() == handle->get_name();
     });
 
   // handle exists already
   if (handle_pos != registered_handles.end()) {
-    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Handle exists already");
+    RCLCPP_ERROR(
+      rclcpp::get_logger(logger_name),
+      "cannot register handle! Handle exists already");
     return HW_RET_ERROR;
   }
   registered_handles.push_back(handle);
   return HW_RET_OK;
 }
 
-hardware_interface_ret_t RobotHardware::register_joint_state_handle(
-  const JointStateHandle * joint_handle)
+hardware_interface_ret_t
+RobotHardware::register_joint_state_handle(const JointStateHandle * joint_handle)
 {
   return register_handle<const JointStateHandle>(
-    registered_joint_state_handles_, joint_handle,
+    registered_joint_state_handles_,
+    joint_handle,
     kJointStateLoggerName);
 }
 
-hardware_interface_ret_t RobotHardware::register_joint_command_handle(
-  JointCommandHandle * joint_handle)
+hardware_interface_ret_t
+RobotHardware::register_joint_command_handle(JointCommandHandle * joint_handle)
 {
   return register_handle<JointCommandHandle>(
-    registered_joint_command_handles_, joint_handle,
+    registered_joint_command_handles_,
+    joint_handle,
     kJointCommandLoggerName);
 }
 
-hardware_interface_ret_t RobotHardware::register_operation_mode_handle(
-  OperationModeHandle * operation_mode_handle)
+hardware_interface_ret_t
+RobotHardware::register_operation_mode_handle(OperationModeHandle * operation_mode_handle)
 {
   return register_handle<OperationModeHandle>(
-    registered_operation_mode_handles_, operation_mode_handle,
+    registered_operation_mode_handles_,
+    operation_mode_handle,
     kOperationModeLoggerName);
 }
 
@@ -101,23 +105,30 @@ hardware_interface_ret_t RobotHardware::register_operation_mode_handle(
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
 template<typename T>
-hardware_interface_ret_t get_handle(
-  std::vector<T *> & registered_handles, const std::string & name,
-  const std::string & logger_name, T ** handle)
+hardware_interface_ret_t
+get_handle(
+  std::vector<T *> & registered_handles,
+  const std::string & name,
+  const std::string & logger_name,
+  T ** handle)
 {
   if (name.empty()) {
-    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle! No name given");
+    RCLCPP_ERROR(
+      rclcpp::get_logger(logger_name),
+      "cannot get handle! No name given");
     return HW_RET_ERROR;
   }
 
   auto handle_pos = std::find_if(
     registered_handles.begin(), registered_handles.end(),
-    [&](auto handle_ptr) -> bool {return handle_ptr->get_name() == name;});
+    [&](auto handle_ptr) -> bool {
+      return handle_ptr->get_name() == name;
+    });
 
   if (handle_pos == registered_handles.end()) {
     RCLCPP_ERROR(
-      rclcpp::get_logger(
-        logger_name), "cannot get handle. No joint %s found.\n", name.c_str());
+      rclcpp::get_logger(logger_name),
+      "cannot get handle. No joint %s found.\n", name.c_str());
     return HW_RET_ERROR;
   }
 
@@ -125,38 +136,45 @@ hardware_interface_ret_t get_handle(
   return HW_RET_OK;
 }
 
-hardware_interface_ret_t RobotHardware::get_joint_state_handle(
-  const std::string & name,
-  const JointStateHandle ** joint_state_handle)
+hardware_interface_ret_t
+RobotHardware::get_joint_state_handle(
+  const std::string & name, const JointStateHandle ** joint_state_handle)
 {
   THROW_ON_NOT_NULLPTR(*joint_state_handle)
   return get_handle<const JointStateHandle>(
-    registered_joint_state_handles_, name, kJointStateLoggerName,
+    registered_joint_state_handles_,
+    name,
+    kJointStateLoggerName,
     joint_state_handle);
 }
 
-hardware_interface_ret_t RobotHardware::get_joint_command_handle(
-  const std::string & name,
-  JointCommandHandle ** joint_command_handle)
+hardware_interface_ret_t
+RobotHardware::get_joint_command_handle(
+  const std::string & name, JointCommandHandle ** joint_command_handle)
 {
   THROW_ON_NOT_NULLPTR(*joint_command_handle)
   return get_handle<JointCommandHandle>(
-    registered_joint_command_handles_, name, kJointCommandLoggerName,
+    registered_joint_command_handles_,
+    name,
+    kJointCommandLoggerName,
     joint_command_handle);
 }
 
-hardware_interface_ret_t RobotHardware::get_operation_mode_handle(
-  const std::string & name,
-  OperationModeHandle ** operation_mode_handle)
+hardware_interface_ret_t
+RobotHardware::get_operation_mode_handle(
+  const std::string & name, OperationModeHandle ** operation_mode_handle)
 {
   THROW_ON_NOT_NULLPTR(*operation_mode_handle)
   return get_handle<OperationModeHandle>(
-    registered_operation_mode_handles_, name, kOperationModeLoggerName,
+    registered_operation_mode_handles_,
+    name,
+    kOperationModeLoggerName,
     operation_mode_handle);
 }
 
 template<typename T>
-std::vector<std::string> get_registered_names(std::vector<T *> & registered_handles)
+std::vector<std::string>
+get_registered_names(std::vector<T *> & registered_handles)
 {
   std::vector<std::string> names;
   names.reserve(registered_handles.size());
@@ -166,27 +184,32 @@ std::vector<std::string> get_registered_names(std::vector<T *> & registered_hand
   return names;
 }
 
-std::vector<std::string> RobotHardware::get_registered_joint_names()
+std::vector<std::string>
+RobotHardware::get_registered_joint_names()
 {
   return get_registered_names<const JointStateHandle>(registered_joint_state_handles_);
 }
 
-std::vector<std::string> RobotHardware::get_registered_write_op_names()
+std::vector<std::string>
+RobotHardware::get_registered_write_op_names()
 {
   return get_registered_names<OperationModeHandle>(registered_operation_mode_handles_);
 }
 
-std::vector<const JointStateHandle *> RobotHardware::get_registered_joint_state_handles()
+std::vector<const JointStateHandle *>
+RobotHardware::get_registered_joint_state_handles()
 {
   return registered_joint_state_handles_;
 }
 
-std::vector<JointCommandHandle *> RobotHardware::get_registered_joint_command_handles()
+std::vector<JointCommandHandle *>
+RobotHardware::get_registered_joint_command_handles()
 {
   return registered_joint_command_handles_;
 }
 
-std::vector<OperationModeHandle *> RobotHardware::get_registered_operation_mode_handles()
+std::vector<OperationModeHandle *>
+RobotHardware::get_registered_operation_mode_handles()
 {
   return registered_operation_mode_handles_;
 }

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -22,13 +22,16 @@
 #include "hardware_interface/operation_mode_handle.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+namespace
+{
+constexpr auto kJointStateLoggerName = "joint state handle";
+constexpr auto kJointCommandLoggerName = "joint cmd handle";
+constexpr auto kOperationModeLoggerName = "joint operation mode handle";
+constexpr auto kActuatorLoggerName = "register actuator";
+}
+
 namespace hardware_interface
 {
-
-constexpr char kJointStateLoggerName[] = "joint state handle";
-constexpr char kJointCommandLoggerName[] = "joint cmd handle";
-constexpr char kOperationModeLoggerName[] = "joint operation mode handle";
-
 /// Register the handle to the handle list if the handle's name is not found.
 /**
  * \param[in] registered_handles The handle list.
@@ -36,52 +39,51 @@ constexpr char kOperationModeLoggerName[] = "joint operation mode handle";
  * \param[in] logger_name The name of the logger.
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
-template<typename T>
-hardware_interface_ret_t
-register_handle(std::vector<T *> & registered_handles, T * handle, const std::string & logger_name)
+template <typename T>
+hardware_interface_ret_t register_handle(std::vector<T*>& registered_handles, T* handle, const std::string& logger_name)
 {
-  auto handle_pos = std::find_if(
-    registered_handles.begin(), registered_handles.end(),
-    [&](auto handle_ptr) -> bool {
-      return handle_ptr->get_name() == handle->get_name();
+    if (handle->get_name().empty())
+    {
+        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! No name is specified");
+        return HW_RET_ERROR;
+    }
+
+    if (not handle->valid_pointers())
+    {
+        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Points to nullptr!");
+        return HW_RET_ERROR;
+    }
+
+    auto handle_pos = std::find_if(registered_handles.begin(), registered_handles.end(), [&](auto handle_ptr) -> bool {
+        return handle_ptr->get_name() == handle->get_name();
     });
 
-  // handle exists already
-  if (handle_pos != registered_handles.end()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(logger_name),
-      "cannot register handle! Handle exists already");
-    return HW_RET_ERROR;
-  }
-  registered_handles.push_back(handle);
-  return HW_RET_OK;
+    // handle exists already
+    if (handle_pos != registered_handles.end())
+    {
+        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Handle exists already");
+        return HW_RET_ERROR;
+    }
+    registered_handles.push_back(handle);
+    return HW_RET_OK;
 }
 
-hardware_interface_ret_t
-RobotHardware::register_joint_state_handle(const JointStateHandle * joint_handle)
+hardware_interface_ret_t RobotHardware::register_joint_state_handle(const JointStateHandle* joint_handle)
 {
-  return register_handle<const JointStateHandle>(
-    registered_joint_state_handles_,
-    joint_handle,
-    kJointStateLoggerName);
+    return register_handle<const JointStateHandle>(registered_joint_state_handles_, joint_handle,
+                                                   kJointStateLoggerName);
 }
 
-hardware_interface_ret_t
-RobotHardware::register_joint_command_handle(JointCommandHandle * joint_handle)
+hardware_interface_ret_t RobotHardware::register_joint_command_handle(JointCommandHandle* joint_handle)
 {
-  return register_handle<JointCommandHandle>(
-    registered_joint_command_handles_,
-    joint_handle,
-    kJointCommandLoggerName);
+    return register_handle<JointCommandHandle>(registered_joint_command_handles_, joint_handle,
+                                               kJointCommandLoggerName);
 }
 
-hardware_interface_ret_t
-RobotHardware::register_operation_mode_handle(OperationModeHandle * operation_mode_handle)
+hardware_interface_ret_t RobotHardware::register_operation_mode_handle(OperationModeHandle* operation_mode_handle)
 {
-  return register_handle<OperationModeHandle>(
-    registered_operation_mode_handles_,
-    operation_mode_handle,
-    kOperationModeLoggerName);
+    return register_handle<OperationModeHandle>(registered_operation_mode_handles_, operation_mode_handle,
+                                                kOperationModeLoggerName);
 }
 
 /// Find the handle by name from the registered handle list.
@@ -92,114 +94,88 @@ RobotHardware::register_operation_mode_handle(OperationModeHandle * operation_mo
  * \param[out] handle the handle if found.
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
-template<typename T>
-hardware_interface_ret_t
-get_handle(
-  std::vector<T *> & registered_handles,
-  const std::string & name,
-  const std::string & logger_name,
-  T ** handle)
+template <typename T>
+hardware_interface_ret_t get_handle(std::vector<T*>& registered_handles, const std::string& name,
+                                    const std::string& logger_name, T** handle)
 {
-  if (name.empty()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(logger_name),
-      "cannot get handle! No name given");
-    return HW_RET_ERROR;
-  }
+    if (name.empty())
+    {
+        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle! No name given");
+        return HW_RET_ERROR;
+    }
 
-  auto handle_pos = std::find_if(
-    registered_handles.begin(), registered_handles.end(),
-    [&](auto handle_ptr) -> bool {
-      return handle_ptr->get_name() == name;
-    });
+    auto handle_pos = std::find_if(registered_handles.begin(), registered_handles.end(),
+                                   [&](auto handle_ptr) -> bool { return handle_ptr->get_name() == name; });
 
-  if (handle_pos == registered_handles.end()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(logger_name),
-      "cannot get handle. No joint %s found.\n", name.c_str());
-    return HW_RET_ERROR;
-  }
+    if (handle_pos == registered_handles.end())
+    {
+        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle. No joint %s found.\n", name.c_str());
+        return HW_RET_ERROR;
+    }
 
-  *handle = *handle_pos;
-  return HW_RET_OK;
+    *handle = *handle_pos;
+    return HW_RET_OK;
 }
 
-hardware_interface_ret_t
-RobotHardware::get_joint_state_handle(
-  const std::string & name, const JointStateHandle ** joint_state_handle)
+hardware_interface_ret_t RobotHardware::get_joint_state_handle(const std::string& name,
+                                                               const JointStateHandle** joint_state_handle)
 {
-  THROW_ON_NOT_NULLPTR(*joint_state_handle)
-  return get_handle<const JointStateHandle>(
-    registered_joint_state_handles_,
-    name,
-    kJointStateLoggerName,
-    joint_state_handle);
+    THROW_ON_NOT_NULLPTR(*joint_state_handle)
+    return get_handle<const JointStateHandle>(registered_joint_state_handles_, name, kJointStateLoggerName,
+                                              joint_state_handle);
 }
 
-hardware_interface_ret_t
-RobotHardware::get_joint_command_handle(
-  const std::string & name, JointCommandHandle ** joint_command_handle)
+hardware_interface_ret_t RobotHardware::get_joint_command_handle(const std::string& name,
+                                                                 JointCommandHandle** joint_command_handle)
 {
-  THROW_ON_NOT_NULLPTR(*joint_command_handle)
-  return get_handle<JointCommandHandle>(
-    registered_joint_command_handles_,
-    name,
-    kJointCommandLoggerName,
-    joint_command_handle);
+    THROW_ON_NOT_NULLPTR(*joint_command_handle)
+    return get_handle<JointCommandHandle>(registered_joint_command_handles_, name, kJointCommandLoggerName,
+                                          joint_command_handle);
 }
 
-hardware_interface_ret_t
-RobotHardware::get_operation_mode_handle(
-  const std::string & name, OperationModeHandle ** operation_mode_handle)
+hardware_interface_ret_t RobotHardware::get_operation_mode_handle(const std::string& name,
+                                                                  OperationModeHandle** operation_mode_handle)
 {
-  THROW_ON_NOT_NULLPTR(*operation_mode_handle)
-  return get_handle<OperationModeHandle>(
-    registered_operation_mode_handles_,
-    name,
-    kOperationModeLoggerName,
-    operation_mode_handle);
+    THROW_ON_NOT_NULLPTR(*operation_mode_handle)
+    return get_handle<OperationModeHandle>(registered_operation_mode_handles_, name, kOperationModeLoggerName,
+                                           operation_mode_handle);
 }
 
-template<typename T>
-std::vector<std::string>
-get_registered_names(std::vector<T *> & registered_handles)
+template <typename T>
+std::vector<std::string> get_registered_names(std::vector<T*>& registered_handles)
 {
-  std::vector<std::string> names;
-  names.reserve(registered_handles.size());
-  for (auto handle : registered_handles) {
-    names.push_back(handle->get_name());
-  }
-  return names;
+    std::vector<std::string> names;
+    names.reserve(registered_handles.size());
+    for (auto handle : registered_handles)
+    {
+        names.push_back(handle->get_name());
+    }
+    return names;
 }
 
-std::vector<std::string>
-RobotHardware::get_registered_joint_names()
+std::vector<std::string> RobotHardware::get_registered_joint_names()
 {
-  return get_registered_names<const JointStateHandle>(registered_joint_state_handles_);
+    return get_registered_names<const JointStateHandle>(registered_joint_state_handles_);
 }
 
-std::vector<std::string>
-RobotHardware::get_registered_write_op_names()
+std::vector<std::string> RobotHardware::get_registered_write_op_names()
 {
-  return get_registered_names<OperationModeHandle>(registered_operation_mode_handles_);
+    return get_registered_names<OperationModeHandle>(registered_operation_mode_handles_);
 }
 
-std::vector<const JointStateHandle *>
-RobotHardware::get_registered_joint_state_handles()
+std::vector<const JointStateHandle*> RobotHardware::get_registered_joint_state_handles()
 {
-  return registered_joint_state_handles_;
+    return registered_joint_state_handles_;
 }
 
-std::vector<JointCommandHandle *>
-RobotHardware::get_registered_joint_command_handles()
+std::vector<JointCommandHandle*> RobotHardware::get_registered_joint_command_handles()
 {
-  return registered_joint_command_handles_;
+    return registered_joint_command_handles_;
 }
 
-std::vector<OperationModeHandle *>
-RobotHardware::get_registered_operation_mode_handles()
+std::vector<OperationModeHandle*> RobotHardware::get_registered_operation_mode_handles()
 {
-  return registered_operation_mode_handles_;
+    return registered_operation_mode_handles_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -39,51 +39,57 @@ namespace hardware_interface
  * \param[in] logger_name The name of the logger.
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
-template <typename T>
-hardware_interface_ret_t register_handle(std::vector<T*>& registered_handles, T* handle, const std::string& logger_name)
+template<typename T>
+hardware_interface_ret_t register_handle(
+  std::vector<T *> & registered_handles, T * handle,
+  const std::string & logger_name)
 {
-    if (handle->get_name().empty())
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! No name is specified");
-        return HW_RET_ERROR;
-    }
+  if (handle->get_name().empty()) {
+    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! No name is specified");
+    return HW_RET_ERROR;
+  }
 
-    if (not handle->valid_pointers())
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Points to nullptr!");
-        return HW_RET_ERROR;
-    }
+  if (!handle->valid_pointers()) {
+    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Points to nullptr!");
+    return HW_RET_ERROR;
+  }
 
-    auto handle_pos = std::find_if(registered_handles.begin(), registered_handles.end(), [&](auto handle_ptr) -> bool {
-        return handle_ptr->get_name() == handle->get_name();
+  auto handle_pos = std::find_if(
+    registered_handles.begin(), registered_handles.end(), [&](auto handle_ptr) -> bool {
+      return handle_ptr->get_name() == handle->get_name();
     });
 
-    // handle exists already
-    if (handle_pos != registered_handles.end())
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Handle exists already");
-        return HW_RET_ERROR;
-    }
-    registered_handles.push_back(handle);
-    return HW_RET_OK;
+  // handle exists already
+  if (handle_pos != registered_handles.end()) {
+    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot register handle! Handle exists already");
+    return HW_RET_ERROR;
+  }
+  registered_handles.push_back(handle);
+  return HW_RET_OK;
 }
 
-hardware_interface_ret_t RobotHardware::register_joint_state_handle(const JointStateHandle* joint_handle)
+hardware_interface_ret_t RobotHardware::register_joint_state_handle(
+  const JointStateHandle * joint_handle)
 {
-    return register_handle<const JointStateHandle>(registered_joint_state_handles_, joint_handle,
-                                                   kJointStateLoggerName);
+  return register_handle<const JointStateHandle>(
+    registered_joint_state_handles_, joint_handle,
+    kJointStateLoggerName);
 }
 
-hardware_interface_ret_t RobotHardware::register_joint_command_handle(JointCommandHandle* joint_handle)
+hardware_interface_ret_t RobotHardware::register_joint_command_handle(
+  JointCommandHandle * joint_handle)
 {
-    return register_handle<JointCommandHandle>(registered_joint_command_handles_, joint_handle,
-                                               kJointCommandLoggerName);
+  return register_handle<JointCommandHandle>(
+    registered_joint_command_handles_, joint_handle,
+    kJointCommandLoggerName);
 }
 
-hardware_interface_ret_t RobotHardware::register_operation_mode_handle(OperationModeHandle* operation_mode_handle)
+hardware_interface_ret_t RobotHardware::register_operation_mode_handle(
+  OperationModeHandle * operation_mode_handle)
 {
-    return register_handle<OperationModeHandle>(registered_operation_mode_handles_, operation_mode_handle,
-                                                kOperationModeLoggerName);
+  return register_handle<OperationModeHandle>(
+    registered_operation_mode_handles_, operation_mode_handle,
+    kOperationModeLoggerName);
 }
 
 /// Find the handle by name from the registered handle list.
@@ -94,88 +100,95 @@ hardware_interface_ret_t RobotHardware::register_operation_mode_handle(Operation
  * \param[out] handle the handle if found.
  * \return The return code, one of `HW_RET_OK` or `HW_RET_ERROR`.
  */
-template <typename T>
-hardware_interface_ret_t get_handle(std::vector<T*>& registered_handles, const std::string& name,
-                                    const std::string& logger_name, T** handle)
+template<typename T>
+hardware_interface_ret_t get_handle(
+  std::vector<T *> & registered_handles, const std::string & name,
+  const std::string & logger_name, T ** handle)
 {
-    if (name.empty())
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle! No name given");
-        return HW_RET_ERROR;
-    }
+  if (name.empty()) {
+    RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle! No name given");
+    return HW_RET_ERROR;
+  }
 
-    auto handle_pos = std::find_if(registered_handles.begin(), registered_handles.end(),
-                                   [&](auto handle_ptr) -> bool { return handle_ptr->get_name() == name; });
+  auto handle_pos = std::find_if(
+    registered_handles.begin(), registered_handles.end(),
+    [&](auto handle_ptr) -> bool {return handle_ptr->get_name() == name;});
 
-    if (handle_pos == registered_handles.end())
-    {
-        RCLCPP_ERROR(rclcpp::get_logger(logger_name), "cannot get handle. No joint %s found.\n", name.c_str());
-        return HW_RET_ERROR;
-    }
+  if (handle_pos == registered_handles.end()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(
+        logger_name), "cannot get handle. No joint %s found.\n", name.c_str());
+    return HW_RET_ERROR;
+  }
 
-    *handle = *handle_pos;
-    return HW_RET_OK;
+  *handle = *handle_pos;
+  return HW_RET_OK;
 }
 
-hardware_interface_ret_t RobotHardware::get_joint_state_handle(const std::string& name,
-                                                               const JointStateHandle** joint_state_handle)
+hardware_interface_ret_t RobotHardware::get_joint_state_handle(
+  const std::string & name,
+  const JointStateHandle ** joint_state_handle)
 {
-    THROW_ON_NOT_NULLPTR(*joint_state_handle)
-    return get_handle<const JointStateHandle>(registered_joint_state_handles_, name, kJointStateLoggerName,
-                                              joint_state_handle);
+  THROW_ON_NOT_NULLPTR(*joint_state_handle)
+  return get_handle<const JointStateHandle>(
+    registered_joint_state_handles_, name, kJointStateLoggerName,
+    joint_state_handle);
 }
 
-hardware_interface_ret_t RobotHardware::get_joint_command_handle(const std::string& name,
-                                                                 JointCommandHandle** joint_command_handle)
+hardware_interface_ret_t RobotHardware::get_joint_command_handle(
+  const std::string & name,
+  JointCommandHandle ** joint_command_handle)
 {
-    THROW_ON_NOT_NULLPTR(*joint_command_handle)
-    return get_handle<JointCommandHandle>(registered_joint_command_handles_, name, kJointCommandLoggerName,
-                                          joint_command_handle);
+  THROW_ON_NOT_NULLPTR(*joint_command_handle)
+  return get_handle<JointCommandHandle>(
+    registered_joint_command_handles_, name, kJointCommandLoggerName,
+    joint_command_handle);
 }
 
-hardware_interface_ret_t RobotHardware::get_operation_mode_handle(const std::string& name,
-                                                                  OperationModeHandle** operation_mode_handle)
+hardware_interface_ret_t RobotHardware::get_operation_mode_handle(
+  const std::string & name,
+  OperationModeHandle ** operation_mode_handle)
 {
-    THROW_ON_NOT_NULLPTR(*operation_mode_handle)
-    return get_handle<OperationModeHandle>(registered_operation_mode_handles_, name, kOperationModeLoggerName,
-                                           operation_mode_handle);
+  THROW_ON_NOT_NULLPTR(*operation_mode_handle)
+  return get_handle<OperationModeHandle>(
+    registered_operation_mode_handles_, name, kOperationModeLoggerName,
+    operation_mode_handle);
 }
 
-template <typename T>
-std::vector<std::string> get_registered_names(std::vector<T*>& registered_handles)
+template<typename T>
+std::vector<std::string> get_registered_names(std::vector<T *> & registered_handles)
 {
-    std::vector<std::string> names;
-    names.reserve(registered_handles.size());
-    for (auto handle : registered_handles)
-    {
-        names.push_back(handle->get_name());
-    }
-    return names;
+  std::vector<std::string> names;
+  names.reserve(registered_handles.size());
+  for (auto handle : registered_handles) {
+    names.push_back(handle->get_name());
+  }
+  return names;
 }
 
 std::vector<std::string> RobotHardware::get_registered_joint_names()
 {
-    return get_registered_names<const JointStateHandle>(registered_joint_state_handles_);
+  return get_registered_names<const JointStateHandle>(registered_joint_state_handles_);
 }
 
 std::vector<std::string> RobotHardware::get_registered_write_op_names()
 {
-    return get_registered_names<OperationModeHandle>(registered_operation_mode_handles_);
+  return get_registered_names<OperationModeHandle>(registered_operation_mode_handles_);
 }
 
-std::vector<const JointStateHandle*> RobotHardware::get_registered_joint_state_handles()
+std::vector<const JointStateHandle *> RobotHardware::get_registered_joint_state_handles()
 {
-    return registered_joint_state_handles_;
+  return registered_joint_state_handles_;
 }
 
-std::vector<JointCommandHandle*> RobotHardware::get_registered_joint_command_handles()
+std::vector<JointCommandHandle *> RobotHardware::get_registered_joint_command_handles()
 {
-    return registered_joint_command_handles_;
+  return registered_joint_command_handles_;
 }
 
-std::vector<OperationModeHandle*> RobotHardware::get_registered_operation_mode_handles()
+std::vector<OperationModeHandle *> RobotHardware::get_registered_operation_mode_handles()
 {
-    return registered_operation_mode_handles_;
+  return registered_operation_mode_handles_;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/test/test_macros.cpp
+++ b/hardware_interface/test/test_macros.cpp
@@ -16,7 +16,7 @@
 
 #include "hardware_interface/macros.hpp"
 
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 class TestMacros : public ::testing::Test
 {

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -65,12 +65,12 @@ TEST_F(TestRobotHardwareInterface, initialize)
 
 TEST_F(TestRobotHardwareInterface, can_not_register_broken_handles)
 {
-    JointCommandHandle command_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&command_handle));
-    JointStateHandle state_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
-    OperationModeHandle op_mode_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
+    JointCommandHandle broken_command_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&broken_command_handle));
+    JointStateHandle broken_state_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&broken_state_handle));
+    OperationModeHandle broken_op_mode_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&broken_op_mode_handle));
 }
 
 }  // namespace testing

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -1,0 +1,76 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+
+#include "hardware_interface/robot_hardware.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+
+using namespace hardware_interface;
+
+namespace
+{
+class MyTestRobotHardware : public RobotHardware
+{
+  public:
+    hardware_interface_ret_t init() override
+    {
+        return HW_RET_OK;
+    }
+
+    hardware_interface_ret_t read() override
+    {
+        return HW_RET_OK;
+    }
+
+    hardware_interface_ret_t write() override
+    {
+        return HW_RET_OK;
+    }
+};
+}
+
+namespace testing
+{
+class TestRobotHardwareInterface : public Test
+{
+  protected:
+    void SetUp()
+    {
+        robot.init();
+    }
+
+    MyTestRobotHardware robot;
+};
+
+TEST_F(TestRobotHardwareInterface, initialize)
+{
+    MyTestRobotHardware local_robot;
+    EXPECT_EQ(HW_RET_OK, local_robot.init());
+}
+
+TEST_F(TestRobotHardwareInterface, can_not_register_broken_handles)
+{
+    JointCommandHandle command_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&command_handle));
+    JointStateHandle state_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
+    OperationModeHandle op_mode_handle;
+    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
+}
+
+}  // namespace testing

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -21,6 +21,11 @@
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 
 namespace hw = hardware_interface;
+using testing::SizeIs;
+using testing::Each;
+using testing::NotNull;
+using testing::UnorderedElementsAre;
+using testing::ElementsAre;
 
 namespace
 {
@@ -43,110 +48,129 @@ public:
   }
 };
 
-const auto JOINT_NAME = "joint_1";
-const auto NEW_JOINT_NAME = "joint_2";
+constexpr auto JOINT_NAME = "joint_1";
+constexpr auto NEW_JOINT_NAME = "joint_2";
 }  // namespace
 
-namespace testing
-{
-class TestRobotHardwareInterface : public Test
+class TestRobotHardwareInterface : public testing::Test
 {
 protected:
   void SetUp()
   {
-    robot.init();
+    robot_.init();
   }
 
   void SetUpHandles()
   {
-    robot.register_joint_command_handle(&pos_command_handle);
-    robot.register_joint_state_handle(&state_handle);
-    robot.register_operation_mode_handle(&op_mode_handle);
+    robot_.register_joint_command_handle(&pos_command_handle_);
+    robot_.register_joint_state_handle(&state_handle_);
+    robot_.register_operation_mode_handle(&op_mode_handle_);
   }
 
   void SetUpNewHandles()
   {
-    robot.register_joint_command_handle(&new_pos_command_handle);
-    robot.register_joint_state_handle(&new_state_handle);
-    robot.register_operation_mode_handle(&new_op_mode_handle);
+    robot_.register_joint_command_handle(&new_pos_command_handle_);
+    robot_.register_joint_state_handle(&new_state_handle_);
+    robot_.register_operation_mode_handle(&new_op_mode_handle_);
   }
 
-  MyTestRobotHardware robot;
-  double pos_command_value = 0.0;
-  hw::JointCommandHandle pos_command_handle{JOINT_NAME, &pos_command_value};
-  double velocity_state_value = 0.0;
-  double effort_state_value = 0.0;
-  hw::JointStateHandle state_handle{JOINT_NAME, &pos_command_value, &velocity_state_value,
-    &effort_state_value};
-  hw::OperationMode mode = hw::OperationMode::ACTIVE;
-  hw::OperationModeHandle op_mode_handle{JOINT_NAME, &mode};
+  MyTestRobotHardware robot_;
+  double pos_command_value_ = 0.0;
+  hw::JointCommandHandle pos_command_handle_{JOINT_NAME, &pos_command_value_};
+  double velocity_state_value_ = 0.0;
+  double effort_state_value_ = 0.0;
+  hw::JointStateHandle state_handle_{JOINT_NAME, &pos_command_value_, &velocity_state_value_,
+    &effort_state_value_};
+  hw::OperationMode mode_ = hw::OperationMode::ACTIVE;
+  hw::OperationModeHandle op_mode_handle_{JOINT_NAME, &mode_};
 
-  hw::JointCommandHandle new_pos_command_handle{NEW_JOINT_NAME, &pos_command_value};
-  hw::JointStateHandle new_state_handle{NEW_JOINT_NAME, &pos_command_value, &velocity_state_value,
-    &effort_state_value};
-  hw::OperationModeHandle new_op_mode_handle{NEW_JOINT_NAME, &mode};
+  hw::JointCommandHandle new_pos_command_handle_{NEW_JOINT_NAME, &pos_command_value_};
+  hw::JointStateHandle new_state_handle_{NEW_JOINT_NAME, &pos_command_value_,
+    &velocity_state_value_,
+    &effort_state_value_};
+  hw::OperationModeHandle new_op_mode_handle_{NEW_JOINT_NAME, &mode_};
 };
 
 TEST_F(TestRobotHardwareInterface, can_not_register_broken_handles)
 {
   hw::JointCommandHandle broken_command_handle;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_command_handle(&broken_command_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_joint_command_handle(&broken_command_handle));
   hw::JointStateHandle broken_state_handle;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_state_handle(&broken_state_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_joint_state_handle(&broken_state_handle));
   hw::OperationModeHandle broken_op_mode_handle;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_operation_mode_handle(&broken_op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_operation_mode_handle(&broken_op_mode_handle));
 }
 
 TEST_F(TestRobotHardwareInterface, can_register_proper_handles)
 {
-  EXPECT_EQ(hw::HW_RET_OK, robot.register_joint_command_handle(&pos_command_handle));
-  EXPECT_EQ(hw::HW_RET_OK, robot.register_joint_state_handle(&state_handle));
-  EXPECT_EQ(hw::HW_RET_OK, robot.register_operation_mode_handle(&op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.register_joint_command_handle(&pos_command_handle_));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.register_joint_state_handle(&state_handle_));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.register_operation_mode_handle(&op_mode_handle_));
 }
 
 TEST_F(TestRobotHardwareInterface, cannot_double_register_handles)
 {
   SetUpHandles();
 
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_command_handle(&pos_command_handle));
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_joint_command_handle(&pos_command_handle_));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_joint_state_handle(&state_handle_));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.register_operation_mode_handle(&op_mode_handle_));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_joint_names)
 {
   SetUpHandles();
-  EXPECT_THAT(robot.get_registered_joint_names(), ElementsAre(JOINT_NAME));
+  EXPECT_THAT(robot_.get_registered_joint_names(), ElementsAre(JOINT_NAME));
 
   SetUpNewHandles();
-  EXPECT_THAT(robot.get_registered_joint_names(), UnorderedElementsAre(JOINT_NAME, NEW_JOINT_NAME));
+  EXPECT_THAT(
+    robot_.get_registered_joint_names(),
+    UnorderedElementsAre(JOINT_NAME, NEW_JOINT_NAME));
+}
+
+TEST_F(TestRobotHardwareInterface, returned_joint_handles_are_not_null)
+{
+  SetUpHandles();
+  SetUpNewHandles();
+
+  const auto state_handles = robot_.get_registered_joint_state_handles();
+  EXPECT_THAT(state_handles, SizeIs(2));
+  EXPECT_THAT(state_handles, Each(NotNull()));
+
+  const auto command_handles = robot_.get_registered_joint_command_handles();
+  EXPECT_THAT(command_handles, SizeIs(2));
+  EXPECT_THAT(command_handles, Each(NotNull()));
+
+  const auto op_mode_handles = robot_.get_registered_operation_mode_handles();
+  EXPECT_THAT(op_mode_handles, SizeIs(2));
+  EXPECT_THAT(op_mode_handles, Each(NotNull()));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_state_handles)
 {
   SetUpHandles();
-  EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(1));
+  EXPECT_THAT(robot_.get_registered_joint_state_handles(), SizeIs(1));
 
   SetUpNewHandles();
-  EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(2));
+  EXPECT_THAT(robot_.get_registered_joint_state_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_command_handles)
 {
   SetUpHandles();
-  EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(1));
+  EXPECT_THAT(robot_.get_registered_joint_command_handles(), SizeIs(1));
 
   SetUpNewHandles();
-  EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(2));
+  EXPECT_THAT(robot_.get_registered_joint_command_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_op_mode_handles)
 {
   SetUpHandles();
-  EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(1));
+  EXPECT_THAT(robot_.get_registered_operation_mode_handles(), SizeIs(1));
 
   SetUpNewHandles();
-  EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(2));
+  EXPECT_THAT(robot_.get_registered_operation_mode_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_handles_by_name)
@@ -154,27 +178,25 @@ TEST_F(TestRobotHardwareInterface, can_get_handles_by_name)
   SetUpHandles();
 
   const hw::JointStateHandle * state_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_state_handle(JOINT_NAME, &state_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_joint_state_handle(JOINT_NAME, &state_handle));
   state_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
 
   hw::JointCommandHandle * cmd_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_command_handle(JOINT_NAME, &cmd_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_joint_command_handle(JOINT_NAME, &cmd_handle));
   cmd_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
 
   hw::OperationModeHandle * op_mode_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_operation_mode_handle(JOINT_NAME, &op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_operation_mode_handle(JOINT_NAME, &op_mode_handle));
   op_mode_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot_.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
 
   SetUpNewHandles();
   state_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
   cmd_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
   op_mode_handle = nullptr;
-  EXPECT_EQ(hw::HW_RET_OK, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot_.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
 }
-
-}  // namespace testing

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -160,4 +160,21 @@ TEST_F(TestRobotHardwareInterface, can_get_registered_op_mode_handles)
     EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(2));
 }
 
+TEST_F(TestRobotHardwareInterface, can_get_handles_by_name)
+{
+    SetUpHandles();
+
+    const JointStateHandle* state_handle;
+    EXPECT_EQ(HW_RET_OK, robot.get_joint_state_handle(JOINT_NAME, &state_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.get_joint_state_handle(JOINT_NAME, &state_handle));
+
+    JointCommandHandle* cmd_handle;
+    EXPECT_EQ(HW_RET_OK, robot.get_joint_command_handle(JOINT_NAME, &cmd_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
+
+    OperationModeHandle* op_mode_handle;
+    EXPECT_EQ(HW_RET_OK, robot.get_operation_mode_handle(JOINT_NAME, &op_mode_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
+}
+
 }  // namespace testing

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -42,6 +42,8 @@ class MyTestRobotHardware : public RobotHardware
         return HW_RET_OK;
     }
 };
+
+const auto JOINT_NAME = "joint_1";
 }
 
 namespace testing
@@ -55,6 +57,13 @@ class TestRobotHardwareInterface : public Test
     }
 
     MyTestRobotHardware robot;
+    double pos_command_value = 0.0;
+    JointCommandHandle pos_command_handle{ JOINT_NAME, &pos_command_value };
+    double velocity_state_value = 0.0;
+    double effort_state_value = 0.0;
+    JointStateHandle state_handle{ JOINT_NAME, &pos_command_value, &velocity_state_value, &effort_state_value };
+    OperationMode mode = OperationMode::ACTIVE;
+    OperationModeHandle op_mode_handle{ JOINT_NAME, &mode };
 };
 
 TEST_F(TestRobotHardwareInterface, initialize)
@@ -71,6 +80,25 @@ TEST_F(TestRobotHardwareInterface, can_not_register_broken_handles)
     EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&broken_state_handle));
     OperationModeHandle broken_op_mode_handle;
     EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&broken_op_mode_handle));
+}
+
+TEST_F(TestRobotHardwareInterface, can_register_proper_handles)
+{
+    EXPECT_EQ(HW_RET_OK, robot.register_joint_command_handle(&pos_command_handle));
+    EXPECT_EQ(HW_RET_OK, robot.register_joint_state_handle(&state_handle));
+    EXPECT_EQ(HW_RET_OK, robot.register_operation_mode_handle(&op_mode_handle));
+}
+
+TEST_F(TestRobotHardwareInterface, cannot_double_register_handles)
+{
+    EXPECT_EQ(HW_RET_OK, robot.register_joint_command_handle(&pos_command_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&pos_command_handle));
+
+    EXPECT_EQ(HW_RET_OK, robot.register_joint_state_handle(&state_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
+
+    EXPECT_EQ(HW_RET_OK, robot.register_operation_mode_handle(&op_mode_handle));
+    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
 }
 
 }  // namespace testing

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2020 ros2_control development team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/hardware_interface/test/test_robot_hardware_interface.cpp
+++ b/hardware_interface/test/test_robot_hardware_interface.cpp
@@ -20,165 +20,161 @@
 #include "hardware_interface/robot_hardware.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 
-using namespace hardware_interface;
+namespace hw = hardware_interface;
 
 namespace
 {
-class MyTestRobotHardware : public RobotHardware
+class MyTestRobotHardware : public hw::RobotHardware
 {
-  public:
-    hardware_interface_ret_t init() override
-    {
-        return HW_RET_OK;
-    }
+public:
+  hw::hardware_interface_ret_t init() override
+  {
+    return hw::HW_RET_OK;
+  }
 
-    hardware_interface_ret_t read() override
-    {
-        return HW_RET_OK;
-    }
+  hw::hardware_interface_ret_t read() override
+  {
+    return hw::HW_RET_OK;
+  }
 
-    hardware_interface_ret_t write() override
-    {
-        return HW_RET_OK;
-    }
+  hw::hardware_interface_ret_t write() override
+  {
+    return hw::HW_RET_OK;
+  }
 };
 
 const auto JOINT_NAME = "joint_1";
 const auto NEW_JOINT_NAME = "joint_2";
-}
+}  // namespace
 
 namespace testing
 {
 class TestRobotHardwareInterface : public Test
 {
-  protected:
-    void SetUp()
-    {
-        robot.init();
-    }
+protected:
+  void SetUp()
+  {
+    robot.init();
+  }
 
-    void SetUpHandles()
-    {
-        robot.register_joint_command_handle(&pos_command_handle);
-        robot.register_joint_state_handle(&state_handle);
-        robot.register_operation_mode_handle(&op_mode_handle);
-    }
+  void SetUpHandles()
+  {
+    robot.register_joint_command_handle(&pos_command_handle);
+    robot.register_joint_state_handle(&state_handle);
+    robot.register_operation_mode_handle(&op_mode_handle);
+  }
 
-    void SetUpNewHandles()
-    {
-        robot.register_joint_command_handle(&new_pos_command_handle);
-        robot.register_joint_state_handle(&new_state_handle);
-        robot.register_operation_mode_handle(&new_op_mode_handle);
-    }
+  void SetUpNewHandles()
+  {
+    robot.register_joint_command_handle(&new_pos_command_handle);
+    robot.register_joint_state_handle(&new_state_handle);
+    robot.register_operation_mode_handle(&new_op_mode_handle);
+  }
 
-    MyTestRobotHardware robot;
-    double pos_command_value = 0.0;
-    JointCommandHandle pos_command_handle{ JOINT_NAME, &pos_command_value };
-    double velocity_state_value = 0.0;
-    double effort_state_value = 0.0;
-    JointStateHandle state_handle{ JOINT_NAME, &pos_command_value, &velocity_state_value, &effort_state_value };
-    OperationMode mode = OperationMode::ACTIVE;
-    OperationModeHandle op_mode_handle{ JOINT_NAME, &mode };
+  MyTestRobotHardware robot;
+  double pos_command_value = 0.0;
+  hw::JointCommandHandle pos_command_handle{JOINT_NAME, &pos_command_value};
+  double velocity_state_value = 0.0;
+  double effort_state_value = 0.0;
+  hw::JointStateHandle state_handle{JOINT_NAME, &pos_command_value, &velocity_state_value,
+    &effort_state_value};
+  hw::OperationMode mode = hw::OperationMode::ACTIVE;
+  hw::OperationModeHandle op_mode_handle{JOINT_NAME, &mode};
 
-    JointCommandHandle new_pos_command_handle{ NEW_JOINT_NAME, &pos_command_value };
-    JointStateHandle new_state_handle{ NEW_JOINT_NAME, &pos_command_value, &velocity_state_value, &effort_state_value };
-    OperationModeHandle new_op_mode_handle{ NEW_JOINT_NAME, &mode };
+  hw::JointCommandHandle new_pos_command_handle{NEW_JOINT_NAME, &pos_command_value};
+  hw::JointStateHandle new_state_handle{NEW_JOINT_NAME, &pos_command_value, &velocity_state_value,
+    &effort_state_value};
+  hw::OperationModeHandle new_op_mode_handle{NEW_JOINT_NAME, &mode};
 };
-
-TEST_F(TestRobotHardwareInterface, initialize)
-{
-    MyTestRobotHardware local_robot;
-    EXPECT_EQ(HW_RET_OK, local_robot.init());
-}
 
 TEST_F(TestRobotHardwareInterface, can_not_register_broken_handles)
 {
-    JointCommandHandle broken_command_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&broken_command_handle));
-    JointStateHandle broken_state_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&broken_state_handle));
-    OperationModeHandle broken_op_mode_handle;
-    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&broken_op_mode_handle));
+  hw::JointCommandHandle broken_command_handle;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_command_handle(&broken_command_handle));
+  hw::JointStateHandle broken_state_handle;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_state_handle(&broken_state_handle));
+  hw::OperationModeHandle broken_op_mode_handle;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_operation_mode_handle(&broken_op_mode_handle));
 }
 
 TEST_F(TestRobotHardwareInterface, can_register_proper_handles)
 {
-    EXPECT_EQ(HW_RET_OK, robot.register_joint_command_handle(&pos_command_handle));
-    EXPECT_EQ(HW_RET_OK, robot.register_joint_state_handle(&state_handle));
-    EXPECT_EQ(HW_RET_OK, robot.register_operation_mode_handle(&op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot.register_joint_command_handle(&pos_command_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot.register_joint_state_handle(&state_handle));
+  EXPECT_EQ(hw::HW_RET_OK, robot.register_operation_mode_handle(&op_mode_handle));
 }
 
 TEST_F(TestRobotHardwareInterface, cannot_double_register_handles)
 {
-    SetUpHandles();
+  SetUpHandles();
 
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_command_handle(&pos_command_handle));
-    EXPECT_EQ(HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
-    EXPECT_EQ(HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_command_handle(&pos_command_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_joint_state_handle(&state_handle));
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.register_operation_mode_handle(&op_mode_handle));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_joint_names)
 {
-    SetUpHandles();
-    EXPECT_THAT(robot.get_registered_joint_names(), ElementsAre(JOINT_NAME));
+  SetUpHandles();
+  EXPECT_THAT(robot.get_registered_joint_names(), ElementsAre(JOINT_NAME));
 
-    SetUpNewHandles();
-    EXPECT_THAT(robot.get_registered_joint_names(), UnorderedElementsAre(JOINT_NAME, NEW_JOINT_NAME));
+  SetUpNewHandles();
+  EXPECT_THAT(robot.get_registered_joint_names(), UnorderedElementsAre(JOINT_NAME, NEW_JOINT_NAME));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_state_handles)
 {
-    SetUpHandles();
-    EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(1));
+  SetUpHandles();
+  EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(1));
 
-    SetUpNewHandles();
-    EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(2));
+  SetUpNewHandles();
+  EXPECT_THAT(robot.get_registered_joint_state_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_command_handles)
 {
-    SetUpHandles();
-    EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(1));
+  SetUpHandles();
+  EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(1));
 
-    SetUpNewHandles();
-    EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(2));
+  SetUpNewHandles();
+  EXPECT_THAT(robot.get_registered_joint_command_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_registered_op_mode_handles)
 {
-    SetUpHandles();
-    EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(1));
+  SetUpHandles();
+  EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(1));
 
-    SetUpNewHandles();
-    EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(2));
+  SetUpNewHandles();
+  EXPECT_THAT(robot.get_registered_operation_mode_handles(), SizeIs(2));
 }
 
 TEST_F(TestRobotHardwareInterface, can_get_handles_by_name)
 {
-    SetUpHandles();
+  SetUpHandles();
 
-    const JointStateHandle* state_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_joint_state_handle(JOINT_NAME, &state_handle));
-    state_handle = nullptr;
-    EXPECT_EQ(HW_RET_ERROR, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
+  const hw::JointStateHandle * state_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_state_handle(JOINT_NAME, &state_handle));
+  state_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
 
-    JointCommandHandle* cmd_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_joint_command_handle(JOINT_NAME, &cmd_handle));
-    cmd_handle = nullptr;
-    EXPECT_EQ(HW_RET_ERROR, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
+  hw::JointCommandHandle * cmd_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_command_handle(JOINT_NAME, &cmd_handle));
+  cmd_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
 
-    OperationModeHandle* op_mode_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_operation_mode_handle(JOINT_NAME, &op_mode_handle));
-    op_mode_handle = nullptr;
-    EXPECT_EQ(HW_RET_ERROR, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
+  hw::OperationModeHandle * op_mode_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_operation_mode_handle(JOINT_NAME, &op_mode_handle));
+  op_mode_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_ERROR, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
 
-    SetUpNewHandles();
-    state_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
-    cmd_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
-    op_mode_handle = nullptr;
-    EXPECT_EQ(HW_RET_OK, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
+  SetUpNewHandles();
+  state_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_state_handle(NEW_JOINT_NAME, &state_handle));
+  cmd_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_joint_command_handle(NEW_JOINT_NAME, &cmd_handle));
+  op_mode_handle = nullptr;
+  EXPECT_EQ(hw::HW_RET_OK, robot.get_operation_mode_handle(NEW_JOINT_NAME, &op_mode_handle));
 }
 
 }  // namespace testing


### PR DESCRIPTION
As per mentioned during the last meeting that this package has no proper unit testing, I've added some for `RobotHardware`. The initial plan was to move the one from `test_robot_hardware` but it is very tied to what exactly is happening with that implementation and I wanted to have a more general set of tests.

There are some changes in this PR that should be credited to uncrustify...

On the other hand, @Karsten1987 if you could assist with the cppcheck failure I'd be glad. I am getting the same locally and don't know what to do with it really...
```
test/test_robot_hardware_interface.cpp:90]: (error: syntaxError) syntax error
```