### PR TITLE
Add ActuatorHandle and Implement string-based interface handle-handling using DynamicJointState message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: ros-tooling/action-ros-ci@0.0.17
         with:
           package-name: controller_interface controller_manager hardware_interface test_robot_hardware ros2_control
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
+            https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     steps:
       - uses: ros-tooling/setup-ros@0.0.23
       - uses: ros-tooling/action-ros-ci@0.0.17
         with:
-          package-name: controller_interface controller_manager hardware_interface test_robot_hardware
+          package-name: controller_interface controller_manager hardware_interface test_robot_hardware ros2_control
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v1

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -68,6 +68,12 @@ if(BUILD_TESTING)
   target_include_directories(test_register_actuators PRIVATE include)
   target_link_libraries(test_register_actuators hardware_interface)
   ament_target_dependencies(test_register_actuators rcpputils)
+
+  ament_add_gmock(test_actuator_handle test/test_actuator_handle.cpp)
+  target_include_directories(test_actuator_handle PRIVATE include)
+  target_link_libraries(test_actuator_handle hardware_interface)
+  ament_target_dependencies(test_actuator_handle rcpputils)
+
 endif()
 
 ament_export_include_directories(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(control_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 
@@ -28,6 +29,7 @@ target_include_directories(
   include)
 ament_target_dependencies(
   hardware_interface
+  control_msgs
   rclcpp
   rcpputils
 )
@@ -53,6 +55,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
+
   ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
   ament_target_dependencies(test_macros rcpputils)
@@ -60,6 +63,11 @@ if(BUILD_TESTING)
   ament_add_gmock(test_robot_hardware_interfaces test/test_robot_hardware_interface.cpp)
   target_include_directories(test_robot_hardware_interfaces PRIVATE include)
   target_link_libraries(test_robot_hardware_interfaces hardware_interface)
+
+  ament_add_gmock(test_register_actuators test/test_register_actuators.cpp)
+  target_include_directories(test_register_actuators PRIVATE include)
+  target_link_libraries(test_register_actuators hardware_interface)
+  ament_target_dependencies(test_register_actuators rcpputils)
 endif()
 
 ament_export_include_directories(
@@ -67,4 +75,6 @@ ament_export_include_directories(
 )
 ament_export_libraries(
   hardware_interface)
+ament_export_dependencies(
+  control_msgs)
 ament_package()

--- a/hardware_interface/include/hardware_interface/actuator_handle.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_handle.hpp
@@ -1,0 +1,75 @@
+// Copyright 2020 ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HARDWARE_INTERFACE__ACTUATOR_HANDLE_HPP_
+#define HARDWARE_INTERFACE__ACTUATOR_HANDLE_HPP_
+
+#include <string>
+
+#include "hardware_interface/actuator_handle.hpp"
+#include "hardware_interface/visibility_control.h"
+
+namespace hardware_interface
+{
+/** A handle used to get and set the command of an actuator on a given interface. */
+class ActuatorHandle
+{
+public:
+  HARDWARE_INTERFACE_PUBLIC
+  ActuatorHandle(
+    const std::string & name, const std::string & interface_name,
+    double * value_ptr = nullptr)
+  : name_(name), interface_name_(interface_name), value_ptr_(value_ptr)
+  {
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  ActuatorHandle with_value_ptr(double * value_ptr)
+  {
+    return ActuatorHandle(name_, interface_name_, value_ptr);
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  const std::string & get_name() const
+  {
+    return name_;
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  const std::string & get_interface_name() const
+  {
+    return interface_name_;
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  double get_value() const
+  {
+    return *value_ptr_;
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  void set_value(double value)
+  {
+    *value_ptr_ = value;
+  }
+
+protected:
+  std::string name_;
+  std::string interface_name_;
+  double * value_ptr_;
+};
+
+}  // namespace hardware_interface
+
+#endif  // HARDWARE_INTERFACE__ACTUATOR_HANDLE_HPP_

--- a/hardware_interface/include/hardware_interface/actuator_handle.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_handle.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "hardware_interface/actuator_handle.hpp"
+#include "hardware_interface/macros.hpp"
 #include "hardware_interface/visibility_control.h"
 
 namespace hardware_interface
@@ -55,12 +56,14 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   double get_value() const
   {
+    THROW_ON_NULLPTR(value_ptr_);
     return *value_ptr_;
   }
 
   HARDWARE_INTERFACE_PUBLIC
   void set_value(double value)
   {
+    THROW_ON_NULLPTR(value_ptr_);
     *value_ptr_ = value;
   }
 

--- a/hardware_interface/include/hardware_interface/robot_hardware.hpp
+++ b/hardware_interface/include/hardware_interface/robot_hardware.hpp
@@ -15,9 +15,12 @@
 #ifndef HARDWARE_INTERFACE__ROBOT_HARDWARE_HPP_
 #define HARDWARE_INTERFACE__ROBOT_HARDWARE_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "control_msgs/msg/dynamic_joint_state.hpp"
+#include "hardware_interface/actuator_handle.hpp"
 #include "hardware_interface/joint_command_handle.hpp"
 #include "hardware_interface/joint_state_handle.hpp"
 #include "hardware_interface/operation_mode_handle.hpp"
@@ -27,7 +30,6 @@
 
 namespace hardware_interface
 {
-
 class RobotHardware : public RobotHardwareInterface
 {
 public:
@@ -82,11 +84,28 @@ public:
   std::vector<OperationModeHandle *>
   get_registered_operation_mode_handles();
 
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface_ret_t register_actuator(
+    const std::string & name, const std::string & interface_name, double default_value = 0.0);
+
+  HARDWARE_INTERFACE_PUBLIC
+  hardware_interface_ret_t get_actuator_handle(ActuatorHandle & actuator_handle);
+
+  HARDWARE_INTERFACE_PUBLIC
+  const std::vector<std::string> & get_registered_actuator_names();
+
+  HARDWARE_INTERFACE_PUBLIC
+  std::vector<ActuatorHandle> get_registered_actuators();
+
 private:
   std::vector<const JointStateHandle *> registered_joint_state_handles_;
   std::vector<JointCommandHandle *> registered_joint_command_handles_;
   std::vector<OperationModeHandle *> registered_operation_mode_handles_;
+
+  control_msgs::msg::DynamicJointState registered_actuators_;
 };
+
+using RobotHardwareSharedPtr = std::shared_ptr<RobotHardware>;
 
 }  // namespace hardware_interface
 

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -3,7 +3,6 @@
   <name>hardware_interface</name>
   <version>0.0.0</version>
   <description>ROS2 ros_control hardware interface</description>
-
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <license>Apache License 2.0</license>
@@ -12,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>rcpputils</depend>
+  <depend>control_msgs</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -27,6 +27,7 @@ namespace
 constexpr auto kJointStateLoggerName = "joint state handle";
 constexpr auto kJointCommandLoggerName = "joint cmd handle";
 constexpr auto kOperationModeLoggerName = "joint operation mode handle";
+constexpr auto kActuatorLoggerName = "actuator handle";
 }
 
 namespace hardware_interface
@@ -212,6 +213,110 @@ std::vector<OperationModeHandle *>
 RobotHardware::get_registered_operation_mode_handles()
 {
   return registered_operation_mode_handles_;
+}
+
+hardware_interface_ret_t RobotHardware::register_actuator(
+  const std::string & actuator_name,
+  const std::string & interface_name, const double default_value)
+{
+  if (actuator_name.empty() || interface_name.empty()) {
+    RCLCPP_ERROR(rclcpp::get_logger(kActuatorLoggerName), "actuator name or interface is empty!");
+    return HW_RET_ERROR;
+  }
+
+  const auto & names_list = registered_actuators_.joint_names;
+  const auto it = std::find(names_list.cbegin(), names_list.cend(), actuator_name);
+  if (it == names_list.cend()) {
+    registered_actuators_.joint_names.push_back(actuator_name);
+    control_msgs::msg::InterfaceValue iv;
+    iv.interface_names = {interface_name};
+    iv.values = {default_value};
+    registered_actuators_.interface_values.push_back(iv);
+    return HW_RET_OK;
+  } else {
+    const auto index = std::distance(names_list.cbegin(), it);
+    auto & ivs = registered_actuators_.interface_values[index];
+    const auto interface_names = ivs.interface_names;
+    const auto it = std::find(interface_names.cbegin(), interface_names.cend(), interface_name);
+    if (it == interface_names.cend()) {
+      ivs.interface_names.push_back(interface_name);
+      ivs.values.push_back(default_value);
+      return HW_RET_OK;
+    } else {
+      RCLCPP_ERROR_STREAM(
+        rclcpp::get_logger(kActuatorLoggerName), "actuator with interface (" <<
+          actuator_name << ":" << interface_name <<
+          ") is already registered!");
+      return HW_RET_ERROR;
+    }
+  }
+}
+
+hardware_interface_ret_t RobotHardware::get_actuator_handle(ActuatorHandle & actuator_handle)
+{
+  const auto & actuator_name = actuator_handle.get_name();
+  const auto & interface_name = actuator_handle.get_interface_name();
+
+  if (actuator_name.empty() || interface_name.empty()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(
+        kActuatorLoggerName), "actuator name or interface is ill-defined!");
+    return HW_RET_ERROR;
+  }
+
+  const auto & names_list = registered_actuators_.joint_names;
+  const auto it = std::find(names_list.cbegin(), names_list.cend(), actuator_name);
+  if (it == names_list.cend()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(
+        kActuatorLoggerName), "actuator with name %s not found!", actuator_name);
+    return HW_RET_ERROR;
+  }
+
+  const auto index = std::distance(names_list.cbegin(), it);
+  auto & ivs = registered_actuators_.interface_values[index];
+  const auto interface_names = ivs.interface_names;
+  const auto if_it = std::find(interface_names.cbegin(), interface_names.cend(), interface_name);
+  if (if_it != interface_names.cend()) {
+    const auto value_index = std::distance(interface_names.cbegin(), if_it);
+    actuator_handle = actuator_handle.with_value_ptr(&(ivs.values[value_index]));
+    return HW_RET_OK;
+  } else {
+    RCLCPP_ERROR_STREAM(
+      rclcpp::get_logger(kActuatorLoggerName),
+      "actuator with interface (" << actuator_name << ":" << interface_name << ") wasn't found!");
+    return HW_RET_ERROR;
+  }
+
+  return HW_RET_ERROR;
+}
+
+std::vector<ActuatorHandle> RobotHardware::get_registered_actuators()
+{
+  std::vector<ActuatorHandle> result;
+  result.reserve(registered_actuators_.joint_names.size());    // rough estimate
+
+  auto & actuator_names = registered_actuators_.joint_names;
+  auto & interface_values = registered_actuators_.interface_values;
+
+  assert(registered_actuators_.joint_names.size() == registered_actuators_.interface_values.size());
+  for (size_t i = 0; i < actuator_names.size(); ++i) {
+    auto & actuator_interfaces = interface_values[i];
+    assert(actuator_interfaces.interface_names.size() == actuator_interfaces.values.size());
+
+    for (size_t j = 0; j < actuator_interfaces.interface_names.size(); ++j) {
+      result.emplace_back(
+        actuator_names[i], actuator_interfaces.interface_names[j],
+        &actuator_interfaces.values[j]);
+    }
+  }
+
+  return result;
+}
+
+const std::vector<std::string> & RobotHardware::get_registered_actuator_names()
+{
+  return registered_actuators_.joint_names;
 }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -221,7 +221,7 @@ hardware_interface_ret_t RobotHardware::register_actuator(
 {
   if (actuator_name.empty() || interface_name.empty()) {
     RCLCPP_ERROR(rclcpp::get_logger(kActuatorLoggerName), "actuator name or interface is empty!");
-    return HW_RET_ERROR;
+    return return_type::ERROR;
   }
 
   const auto & names_list = registered_actuators_.joint_names;
@@ -232,7 +232,7 @@ hardware_interface_ret_t RobotHardware::register_actuator(
     iv.interface_names = {interface_name};
     iv.values = {default_value};
     registered_actuators_.interface_values.push_back(iv);
-    return HW_RET_OK;
+    return return_type::OK;
   } else {
     const auto index = std::distance(names_list.cbegin(), it);
     auto & ivs = registered_actuators_.interface_values[index];
@@ -241,13 +241,13 @@ hardware_interface_ret_t RobotHardware::register_actuator(
     if (it == interface_names.cend()) {
       ivs.interface_names.push_back(interface_name);
       ivs.values.push_back(default_value);
-      return HW_RET_OK;
+      return return_type::OK;
     } else {
       RCLCPP_ERROR_STREAM(
         rclcpp::get_logger(kActuatorLoggerName), "actuator with interface (" <<
           actuator_name << ":" << interface_name <<
           ") is already registered!");
-      return HW_RET_ERROR;
+      return return_type::ERROR;
     }
   }
 }
@@ -261,7 +261,7 @@ hardware_interface_ret_t RobotHardware::get_actuator_handle(ActuatorHandle & act
     RCLCPP_ERROR(
       rclcpp::get_logger(
         kActuatorLoggerName), "actuator name or interface is ill-defined!");
-    return HW_RET_ERROR;
+    return return_type::ERROR;
   }
 
   const auto & names_list = registered_actuators_.joint_names;
@@ -270,7 +270,7 @@ hardware_interface_ret_t RobotHardware::get_actuator_handle(ActuatorHandle & act
     RCLCPP_ERROR(
       rclcpp::get_logger(
         kActuatorLoggerName), "actuator with name %s not found!", actuator_name);
-    return HW_RET_ERROR;
+    return return_type::ERROR;
   }
 
   const auto index = std::distance(names_list.cbegin(), it);
@@ -280,15 +280,15 @@ hardware_interface_ret_t RobotHardware::get_actuator_handle(ActuatorHandle & act
   if (if_it != interface_names.cend()) {
     const auto value_index = std::distance(interface_names.cbegin(), if_it);
     actuator_handle = actuator_handle.with_value_ptr(&(ivs.values[value_index]));
-    return HW_RET_OK;
+    return return_type::OK;
   } else {
     RCLCPP_ERROR_STREAM(
       rclcpp::get_logger(kActuatorLoggerName),
       "actuator with interface (" << actuator_name << ":" << interface_name << ") wasn't found!");
-    return HW_RET_ERROR;
+    return return_type::ERROR;
   }
 
-  return HW_RET_ERROR;
+  return return_type::ERROR;
 }
 
 std::vector<ActuatorHandle> RobotHardware::get_registered_actuators()

--- a/hardware_interface/test/test_actuator_handle.cpp
+++ b/hardware_interface/test/test_actuator_handle.cpp
@@ -1,0 +1,56 @@
+// Copyright 2020 ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include "hardware_interface/actuator_handle.hpp"
+
+using hardware_interface::ActuatorHandle;
+
+namespace
+{
+constexpr auto ACTUATOR_NAME = "actuator_1";
+constexpr auto FOO_INTERFACE = "FooInterface";
+}  // namespace
+
+TEST(TestActuatorHandle, name_getters_work)
+{
+  ActuatorHandle handle{ACTUATOR_NAME, FOO_INTERFACE};
+  EXPECT_EQ(handle.get_name(), ACTUATOR_NAME);
+  EXPECT_EQ(handle.get_interface_name(), FOO_INTERFACE);
+}
+
+TEST(TestActuatorHandle, value_methods_throw_for_nullptr)
+{
+  ActuatorHandle handle{ACTUATOR_NAME, FOO_INTERFACE};
+  EXPECT_ANY_THROW(handle.get_value());
+  EXPECT_ANY_THROW(handle.set_value(0.0));
+}
+
+TEST(TestActuatorHandle, value_methods_work_on_non_nullptr)
+{
+  double value = 1.337;
+  ActuatorHandle handle{ACTUATOR_NAME, FOO_INTERFACE, &value};
+  EXPECT_DOUBLE_EQ(handle.get_value(), value);
+  EXPECT_NO_THROW(handle.set_value(0.0));
+  EXPECT_DOUBLE_EQ(handle.get_value(), 0.0);
+}
+
+TEST(TestActuatorHandle, with_value_ptr_initializes_new_handle_correctly)
+{
+  double value = 1.337;
+  ActuatorHandle handle{ACTUATOR_NAME, FOO_INTERFACE};
+  auto new_handle = handle.with_value_ptr(&value);
+  EXPECT_ANY_THROW(handle.get_value());
+  EXPECT_DOUBLE_EQ(new_handle.get_value(), value);
+}

--- a/hardware_interface/test/test_register_actuators.cpp
+++ b/hardware_interface/test/test_register_actuators.cpp
@@ -18,8 +18,6 @@
 #include "hardware_interface/robot_hardware.hpp"
 
 namespace hw = hardware_interface;
-using hardware_interface::HW_RET_OK;
-using hardware_interface::HW_RET_ERROR;
 using testing::SizeIs;
 using testing::IsEmpty;
 using testing::Each;
@@ -39,19 +37,19 @@ class TestActuators : public testing::Test
 {
   class DummyRobotHardware : public hw::RobotHardware
   {
-    hw::hardware_interface_ret_t init() override
+    hw::return_type init() override
     {
-      return HW_RET_OK;
+      return hw::return_type::OK;
     }
 
-    hw::hardware_interface_ret_t read() override
+    hw::return_type read() override
     {
-      return HW_RET_OK;
+      return hw::return_type::OK;
     }
 
-    hw::hardware_interface_ret_t write() override
+    hw::return_type write() override
     {
-      return HW_RET_OK;
+      return hw::return_type::OK;
     }
   };
 
@@ -70,45 +68,45 @@ TEST_F(TestActuators, no_actuators_registered_return_empty_on_all_fronts)
   EXPECT_THAT(robot_hw_.get_registered_actuator_names(), IsEmpty());
 
   hw::ActuatorHandle handle{"", ""};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.get_actuator_handle(handle));
 }
 
 TEST_F(TestActuators, can_register_actuator_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_double_register_actuator_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_register_with_empty_fields)
 {
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator("", ""));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, ""));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator("", FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.register_actuator("", ""));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, ""));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.register_actuator("", FOO_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_get_non_registered_actuators_or_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, BAR_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR2_NAME, BAR_INTERFACE));
 
   hw::ActuatorHandle handle1{ACTUATOR_NAME, BAR_INTERFACE};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle1));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.get_actuator_handle(handle1));
   hw::ActuatorHandle handle2{ACTUATOR2_NAME, FOO_INTERFACE};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle2));
+  EXPECT_EQ(hw::return_type::ERROR, robot_hw_.get_actuator_handle(handle2));
 }
 
 TEST_F(TestActuators, can_get_registered_actuators)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
   EXPECT_THAT(robot_hw_.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
   const auto registered_actuators = robot_hw_.get_registered_actuators();
   EXPECT_THAT(registered_actuators, SizeIs(1));
@@ -116,10 +114,10 @@ TEST_F(TestActuators, can_get_registered_actuators)
   EXPECT_EQ(actuator_handle.get_name(), ACTUATOR_NAME);
   EXPECT_EQ(actuator_handle.get_interface_name(), FOO_INTERFACE);
 
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
   EXPECT_THAT(robot_hw_.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
 
-  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
+  EXPECT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
   EXPECT_THAT(
     robot_hw_.get_registered_actuator_names(),
     UnorderedElementsAre(ACTUATOR_NAME, ACTUATOR2_NAME));
@@ -129,15 +127,15 @@ TEST_F(TestActuators, can_get_registered_actuators)
     {ACTUATOR2_NAME, FOO_INTERFACE}};
 
   for (auto & handle : handles) {
-    EXPECT_EQ(HW_RET_OK, robot_hw_.get_actuator_handle(handle));
+    EXPECT_EQ(hw::return_type::OK, robot_hw_.get_actuator_handle(handle));
   }
 }
 
 TEST_F(TestActuators, set_get_works_on_registered_actuators)
 {
-  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
-  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
+  ASSERT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  ASSERT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  ASSERT_EQ(hw::return_type::OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
   auto actuator_handles = robot_hw_.get_registered_actuators();
 
   for (auto & handle : actuator_handles) {
@@ -154,7 +152,7 @@ TEST_F(TestActuators, set_get_works_on_registered_actuators)
     EXPECT_ANY_THROW(handle.get_value());
     EXPECT_ANY_THROW(handle.set_value(0.0));
 
-    EXPECT_EQ(HW_RET_OK, robot_hw_.get_actuator_handle(handle));
+    EXPECT_EQ(hw::return_type::OK, robot_hw_.get_actuator_handle(handle));
     const auto new_value = handle.get_value() + 1.337;
     EXPECT_NO_THROW(handle.set_value(new_value));
     EXPECT_DOUBLE_EQ(handle.get_value(), new_value);

--- a/hardware_interface/test/test_register_actuators.cpp
+++ b/hardware_interface/test/test_register_actuators.cpp
@@ -14,6 +14,7 @@
 
 #include <gmock/gmock.h>
 #include <string>
+#include <vector>
 #include "hardware_interface/robot_hardware.hpp"
 
 namespace hw = hardware_interface;
@@ -60,66 +61,102 @@ public:
   }
 
 protected:
-  DummyRobotHardware robot_hw;
+  DummyRobotHardware robot_hw_;
 };
 
 TEST_F(TestActuators, no_actuators_registered_return_empty_on_all_fronts)
 {
-  EXPECT_THAT(robot_hw.get_registered_actuators(), IsEmpty());
-  EXPECT_THAT(robot_hw.get_registered_actuator_names(), IsEmpty());
+  EXPECT_THAT(robot_hw_.get_registered_actuators(), IsEmpty());
+  EXPECT_THAT(robot_hw_.get_registered_actuator_names(), IsEmpty());
 
   hw::ActuatorHandle handle{"", ""};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle));
 }
 
 TEST_F(TestActuators, can_register_actuator_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_double_register_actuator_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_register_with_empty_fields)
 {
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator("", ""));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, ""));
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator("", FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator("", ""));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator(ACTUATOR_NAME, ""));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.register_actuator("", FOO_INTERFACE));
 }
 
 TEST_F(TestActuators, can_not_get_non_registered_actuators_or_interfaces)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR2_NAME, BAR_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, BAR_INTERFACE));
 
   hw::ActuatorHandle handle1{ACTUATOR_NAME, BAR_INTERFACE};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle1));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle1));
   hw::ActuatorHandle handle2{ACTUATOR2_NAME, FOO_INTERFACE};
-  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle2));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw_.get_actuator_handle(handle2));
 }
 
 TEST_F(TestActuators, can_get_registered_actuators)
 {
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
-  EXPECT_THAT(robot_hw.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
-  const auto registered_actuators = robot_hw.get_registered_actuators();
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_THAT(robot_hw_.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
+  const auto registered_actuators = robot_hw_.get_registered_actuators();
   EXPECT_THAT(registered_actuators, SizeIs(1));
   const auto & actuator_handle = registered_actuators[0];
   EXPECT_EQ(actuator_handle.get_name(), ACTUATOR_NAME);
   EXPECT_EQ(actuator_handle.get_interface_name(), FOO_INTERFACE);
 
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
-  EXPECT_THAT(robot_hw.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_THAT(robot_hw_.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
 
-  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
   EXPECT_THAT(
-    robot_hw.get_registered_actuator_names(),
+    robot_hw_.get_registered_actuator_names(),
     UnorderedElementsAre(ACTUATOR_NAME, ACTUATOR2_NAME));
+
+  std::vector<hw::ActuatorHandle> handles =
+  {{ACTUATOR_NAME, FOO_INTERFACE}, {ACTUATOR_NAME, BAR_INTERFACE},
+    {ACTUATOR2_NAME, FOO_INTERFACE}};
+
+  for (auto & handle : handles) {
+    EXPECT_EQ(HW_RET_OK, robot_hw_.get_actuator_handle(handle));
+  }
+}
+
+TEST_F(TestActuators, set_get_works_on_registered_actuators)
+{
+  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  ASSERT_EQ(HW_RET_OK, robot_hw_.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
+  auto actuator_handles = robot_hw_.get_registered_actuators();
+
+  for (auto & handle : actuator_handles) {
+    const auto new_value = handle.get_value() + 1.337;
+    EXPECT_NO_THROW(handle.set_value(new_value));
+    EXPECT_DOUBLE_EQ(handle.get_value(), new_value);
+  }
+
+  std::vector<hw::ActuatorHandle> handles =
+  {{ACTUATOR_NAME, FOO_INTERFACE}, {ACTUATOR_NAME, BAR_INTERFACE},
+    {ACTUATOR2_NAME, FOO_INTERFACE}};
+
+  for (auto & handle : handles) {
+    EXPECT_ANY_THROW(handle.get_value());
+    EXPECT_ANY_THROW(handle.set_value(0.0));
+
+    EXPECT_EQ(HW_RET_OK, robot_hw_.get_actuator_handle(handle));
+    const auto new_value = handle.get_value() + 1.337;
+    EXPECT_NO_THROW(handle.set_value(new_value));
+    EXPECT_DOUBLE_EQ(handle.get_value(), new_value);
+  }
 }

--- a/hardware_interface/test/test_register_actuators.cpp
+++ b/hardware_interface/test/test_register_actuators.cpp
@@ -1,0 +1,125 @@
+// Copyright 2020 ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <string>
+#include "hardware_interface/robot_hardware.hpp"
+
+namespace hw = hardware_interface;
+using hardware_interface::HW_RET_OK;
+using hardware_interface::HW_RET_ERROR;
+using testing::SizeIs;
+using testing::IsEmpty;
+using testing::Each;
+using testing::NotNull;
+using testing::UnorderedElementsAre;
+using testing::ElementsAre;
+
+namespace
+{
+constexpr auto ACTUATOR_NAME = "actuator_1";
+constexpr auto ACTUATOR2_NAME = "neck_tilt_motor";
+constexpr auto FOO_INTERFACE = "FooInterface";
+constexpr auto BAR_INTERFACE = "BarInterface";
+}  // namespace
+
+class TestActuators : public testing::Test
+{
+  class DummyRobotHardware : public hw::RobotHardware
+  {
+    hw::hardware_interface_ret_t init() override
+    {
+      return HW_RET_OK;
+    }
+
+    hw::hardware_interface_ret_t read() override
+    {
+      return HW_RET_OK;
+    }
+
+    hw::hardware_interface_ret_t write() override
+    {
+      return HW_RET_OK;
+    }
+  };
+
+public:
+  TestActuators()
+  {
+  }
+
+protected:
+  DummyRobotHardware robot_hw;
+};
+
+TEST_F(TestActuators, no_actuators_registered_return_empty_on_all_fronts)
+{
+  EXPECT_THAT(robot_hw.get_registered_actuators(), IsEmpty());
+  EXPECT_THAT(robot_hw.get_registered_actuator_names(), IsEmpty());
+
+  hw::ActuatorHandle handle{"", ""};
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle));
+}
+
+TEST_F(TestActuators, can_register_actuator_interfaces)
+{
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+}
+
+TEST_F(TestActuators, can_not_double_register_actuator_interfaces)
+{
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+}
+
+TEST_F(TestActuators, can_not_register_with_empty_fields)
+{
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator("", ""));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator(ACTUATOR_NAME, ""));
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.register_actuator("", FOO_INTERFACE));
+}
+
+TEST_F(TestActuators, can_not_get_non_registered_actuators_or_interfaces)
+{
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR2_NAME, BAR_INTERFACE));
+
+  hw::ActuatorHandle handle1{ACTUATOR_NAME, BAR_INTERFACE};
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle1));
+  hw::ActuatorHandle handle2{ACTUATOR2_NAME, FOO_INTERFACE};
+  EXPECT_EQ(HW_RET_ERROR, robot_hw.get_actuator_handle(handle2));
+}
+
+TEST_F(TestActuators, can_get_registered_actuators)
+{
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, FOO_INTERFACE));
+  EXPECT_THAT(robot_hw.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
+  const auto registered_actuators = robot_hw.get_registered_actuators();
+  EXPECT_THAT(registered_actuators, SizeIs(1));
+  const auto & actuator_handle = registered_actuators[0];
+  EXPECT_EQ(actuator_handle.get_name(), ACTUATOR_NAME);
+  EXPECT_EQ(actuator_handle.get_interface_name(), FOO_INTERFACE);
+
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR_NAME, BAR_INTERFACE));
+  EXPECT_THAT(robot_hw.get_registered_actuator_names(), ElementsAre(ACTUATOR_NAME));
+
+  EXPECT_EQ(HW_RET_OK, robot_hw.register_actuator(ACTUATOR2_NAME, FOO_INTERFACE));
+  EXPECT_THAT(
+    robot_hw.get_registered_actuator_names(),
+    UnorderedElementsAre(ACTUATOR_NAME, ACTUATOR2_NAME));
+}


### PR DESCRIPTION
This PR adds actuator handles and interfaces for handling them. 
It is all by using strings so it should support pretty much anything. The backing data structure is a DynamicJointState message which seems to be quite useful for this although a map-map structure may fare better, but I consider that an implementation improvement, the current code implements the functionality required by a transmission parser / loader which is coming soon.

There's extensive testing for all the basic cases.

What this PR *doesn't have* is refactoring all the functions using joint handles. If this approach is favoured, we could do that in a separate PR.

Since the role of handles are to remain pretty much the same this shouldn't conceptually conflict with #101 .

resolves #85 