### PR TITLE
Update controller_manager CMakeLists

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -35,8 +35,7 @@ target_compile_definitions(controller_manager PUBLIC "PLUGINLIB__DISABLE_BOOST_F
 
 install(TARGETS controller_manager
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  DESTINATION lib/controller_manager
+  LIBRARY DESTINATION lib/controller_manager
   ARCHIVE DESTINATION lib
 )
 install(DIRECTORY include/

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -36,6 +36,7 @@ target_compile_definitions(controller_manager PUBLIC "PLUGINLIB__DISABLE_BOOST_F
 install(TARGETS controller_manager
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
+  DESTINATION lib/controller_manager
   ARCHIVE DESTINATION lib
 )
 install(DIRECTORY include/

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -34,12 +34,10 @@ target_compile_definitions(controller_manager PRIVATE "CONTROLLER_MANAGER_BUILDI
 target_compile_definitions(controller_manager PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
 install(TARGETS controller_manager
-  RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib/controller_manager
-  ARCHIVE DESTINATION lib
 )
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/controller_manager
 )
 
 if(BUILD_TESTING)
@@ -88,7 +86,7 @@ if(BUILD_TESTING)
   pluginlib_export_plugin_description_file(controller_interface test/test_controller.xml)
 
   install(TARGETS test_controller
-    DESTINATION lib
+    DESTINATION lib/controller_manager
   )
 endif()
 


### PR DESCRIPTION
Prior to this fix, I was getting this error when trying to launch the controller manager:

`[ERROR] [launch]: Caught exception in launch (see debug for traceback): package 'controller_manager' found at '/home/andy/ws_control2_demos/install/controller_manager', but libexec directory '/home/andy/ws_control2_demos/install/controller_manager/lib/controller_manager' does not exist`

The launch command looked like so:

    return LaunchDescription([
      Node(
        package='controller_manager',
        node_name='ros2_control_node',
        node_executable='ros2_control_node',
        parameters=[robot_description],
        output={
          'stdout': 'screen',
          'stderr': 'screen',
          },
        )