### PR TITLE
Add virtual modifier to the functions of Joint and Sensor component

### DIFF
--- a/hardware_interface/include/hardware_interface/components/joint.hpp
+++ b/hardware_interface/include/hardware_interface/components/joint.hpp
@@ -50,6 +50,7 @@ public:
    * return_type::ERROR otherwise.
    */
   HARDWARE_INTERFACE_PUBLIC
+  virtual
   return_type configure(const ComponentInfo & joint_info);
 
   /**
@@ -58,6 +59,7 @@ public:
    * \return string list with command interfaces.
    */
   HARDWARE_INTERFACE_PUBLIC
+  virtual
   std::vector<std::string> get_command_interfaces() const;
 
   /**
@@ -66,6 +68,7 @@ public:
    * \return string list with state interfaces.
    */
   HARDWARE_INTERFACE_PUBLIC
+  virtual
   std::vector<std::string> get_state_interfaces() const;
 
   /**
@@ -82,9 +85,9 @@ public:
    * is empty; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_command(
-    std::vector<double> & command,
-    const std::vector<std::string> & interfaces) const;
+    std::vector<double> & command, const std::vector<std::string> & interfaces) const;
 
   /**
    * \brief Get complete command list for the joint. This function is used by the hardware to get
@@ -95,6 +98,7 @@ public:
    * \return return_type::OK always.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_command(std::vector<double> & command) const;
 
   /**
@@ -114,9 +118,9 @@ public:
    * (see: https://github.com/ros-controls/ros2_control/issues/129)
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_command(
-    const std::vector<double> & command,
-    const std::vector<std::string> & interfaces);
+    const std::vector<double> & command, const std::vector<std::string> & interfaces);
 
   /**
    * \brief Get complete state list from the joint. This function is used by the hardware to get
@@ -129,6 +133,7 @@ public:
    * of limits; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_command(const std::vector<double> & command);
 
   /**
@@ -144,6 +149,7 @@ public:
    * is empty; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_state(
     std::vector<double> & state,
     const std::vector<std::string> & interfaces) const;
@@ -157,6 +163,7 @@ public:
    * \return return_type::OK always.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_state(std::vector<double> & state) const;
 
   /**
@@ -171,9 +178,9 @@ public:
    * defined for the joint; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_state(
-    const std::vector<double> & state,
-    const std::vector<std::string> & interfaces);
+    const std::vector<double> & state, const std::vector<std::string> & interfaces);
 
   /**
    * \brief Set complete state list from the joint.This function is used by the hardware to set its
@@ -185,6 +192,7 @@ public:
    * joint's state interfaces, return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_state(const std::vector<double> & state);
 
 protected:

--- a/hardware_interface/include/hardware_interface/components/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/components/sensor.hpp
@@ -50,6 +50,7 @@ public:
    * return_type::ERROR otherwise.
    */
   HARDWARE_INTERFACE_PUBLIC
+  virtual
   return_type configure(const ComponentInfo & joint_info);
 
   /**
@@ -58,7 +59,8 @@ public:
    * \return string list with state interfaces.
    */
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<std::string> get_state_interfaces();
+  virtual
+  std::vector<std::string> get_state_interfaces() const;
 
   /**
    * \brief Get state list from the sensor. This function is used by the controller to get the
@@ -73,9 +75,9 @@ public:
    * is empty; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_state(
-    std::vector<double> & state,
-    const std::vector<std::string> & interfaces) const;
+    std::vector<double> & state, const std::vector<std::string> & interfaces) const;
 
   /**
    * \brief Get complete state list from the sensor. This function is used by the controller to get
@@ -86,6 +88,7 @@ public:
    * \return return_type::OK always.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type get_state(std::vector<double> & state) const;
 
   /**
@@ -100,9 +103,9 @@ public:
    * defined for the sensor; return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_state(
-    const std::vector<double> & state,
-    const std::vector<std::string> & interfaces);
+    const std::vector<double> & state, const std::vector<std::string> & interfaces);
 
   /**
    * \brief Set complete state list from the sensor.This function is used by the hardware to set its
@@ -114,6 +117,7 @@ public:
    * sensor's state interfaces, return_type::OK otherwise.
    */
   HARDWARE_INTERFACE_EXPORT
+  virtual
   return_type set_state(const std::vector<double> & state);
 
 protected:

--- a/hardware_interface/src/components/joint.cpp
+++ b/hardware_interface/src/components/joint.cpp
@@ -16,9 +16,10 @@
 #include <vector>
 
 #include "hardware_interface/components/joint.hpp"
-
 #include "hardware_interface/components/component_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+
+#include "./component_lists_management.hpp"
 
 namespace hardware_interface
 {

--- a/hardware_interface/src/components/joint.cpp
+++ b/hardware_interface/src/components/joint.cpp
@@ -18,7 +18,6 @@
 #include "hardware_interface/components/joint.hpp"
 
 #include "hardware_interface/components/component_info.hpp"
-#include "hardware_interface/components/component_lists_management.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 
 namespace hardware_interface

--- a/hardware_interface/src/components/joint.cpp
+++ b/hardware_interface/src/components/joint.cpp
@@ -18,9 +18,8 @@
 #include "hardware_interface/components/joint.hpp"
 
 #include "hardware_interface/components/component_info.hpp"
+#include "hardware_interface/components/component_lists_management.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-
-#include "./component_lists_management.hpp"
 
 namespace hardware_interface
 {
@@ -61,8 +60,7 @@ return_type Joint::get_command(std::vector<double> & command) const
 }
 
 return_type Joint::set_command(
-  const std::vector<double> & command,
-  const std::vector<std::string> & interfaces)
+  const std::vector<double> & command, const std::vector<std::string> & interfaces)
 {
   return set_internal_values(command, interfaces, info_.command_interfaces, commands_);
 }

--- a/hardware_interface/src/components/sensor.cpp
+++ b/hardware_interface/src/components/sensor.cpp
@@ -16,9 +16,10 @@
 #include <vector>
 
 #include "hardware_interface/components/sensor.hpp"
-
 #include "hardware_interface/components/component_info.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+
+#include "./component_lists_management.hpp"
 
 namespace hardware_interface
 {

--- a/hardware_interface/src/components/sensor.cpp
+++ b/hardware_interface/src/components/sensor.cpp
@@ -18,7 +18,6 @@
 #include "hardware_interface/components/sensor.hpp"
 
 #include "hardware_interface/components/component_info.hpp"
-#include "hardware_interface/components/component_lists_management.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 
 namespace hardware_interface

--- a/hardware_interface/src/components/sensor.cpp
+++ b/hardware_interface/src/components/sensor.cpp
@@ -18,9 +18,8 @@
 #include "hardware_interface/components/sensor.hpp"
 
 #include "hardware_interface/components/component_info.hpp"
+#include "hardware_interface/components/component_lists_management.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
-
-#include "./component_lists_management.hpp"
 
 namespace hardware_interface
 {
@@ -36,7 +35,7 @@ return_type Sensor::configure(const ComponentInfo & joint_info)
   return return_type::OK;
 }
 
-std::vector<std::string> Sensor::get_state_interfaces()
+std::vector<std::string> Sensor::get_state_interfaces() const
 {
   return info_.state_interfaces;
 }


### PR DESCRIPTION
This PR adds virtual modifier I forgot to in the initial components PR.

- refractor parameters from two into one line
- added `const` modifier to the  `get_command_interfaces()` function for the Sensor component

The issue is referenced in [this comment](https://github.com/ros-controls/ros2_control/pull/165#issuecomment-700328452) by @Karsten1987 and I had to do the same changes in #147.