### PR TITLE
Feature/191 joint limits without sharedptr

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -35,6 +35,18 @@ public:
   {
   }
 
+  HARDWARE_INTERFACE_PUBLIC
+  Handle(const std::string & interface_name)
+  : interface_name_(interface_name), value_ptr_(nullptr)
+  {
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  Handle(const char* interface_name)
+      : interface_name_(interface_name), value_ptr_(nullptr)
+  {
+  }
+
   /// \brief returns true if handle references a value
   inline operator bool() const {return value_ptr_ != nullptr;}
 
@@ -67,6 +79,22 @@ public:
   void set_value(double value)
   {
     THROW_ON_NULLPTR(value_ptr_);
+    *value_ptr_ = value;
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  void set_value(const std::string& name, double value)
+  {
+    THROW_ON_NULLPTR(value_ptr_);
+    name_ = name;
+    *value_ptr_ = value;
+  }
+
+  HARDWARE_INTERFACE_PUBLIC
+  void set_value(const char* name, double value)
+  {
+    THROW_ON_NULLPTR(value_ptr_);
+    name_ = name;
     *value_ptr_ = value;
   }
 

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -35,6 +35,9 @@ public:
   {
   }
 
+  /// \brief returns true if handle references a value
+  inline operator bool() const {return value_ptr_ != nullptr;}
+
   HARDWARE_INTERFACE_PUBLIC
   HandleType with_value_ptr(double * value_ptr)
   {

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -36,14 +36,14 @@ public:
   }
 
   HARDWARE_INTERFACE_PUBLIC
-  Handle(const std::string & interface_name)
+  explicit Handle(const std::string & interface_name)
   : interface_name_(interface_name), value_ptr_(nullptr)
   {
   }
 
   HARDWARE_INTERFACE_PUBLIC
-  Handle(const char* interface_name)
-      : interface_name_(interface_name), value_ptr_(nullptr)
+  explicit Handle(const char * interface_name)
+  : interface_name_(interface_name), value_ptr_(nullptr)
   {
   }
 
@@ -83,7 +83,7 @@ public:
   }
 
   HARDWARE_INTERFACE_PUBLIC
-  void set_value(const std::string& name, double value)
+  void set_value(const std::string & name, double value)
   {
     THROW_ON_NULLPTR(value_ptr_);
     name_ = name;
@@ -91,7 +91,7 @@ public:
   }
 
   HARDWARE_INTERFACE_PUBLIC
-  void set_value(const char* name, double value)
+  void set_value(const char * name, double value)
   {
     THROW_ON_NULLPTR(value_ptr_);
     name_ = name;

--- a/hardware_interface/include/hardware_interface/joint_handle.hpp
+++ b/hardware_interface/include/hardware_interface/joint_handle.hpp
@@ -27,13 +27,7 @@ namespace hardware_interface
 class JointHandle : public Handle<JointHandle>
 {
 public:
-  HARDWARE_INTERFACE_PUBLIC
-  JointHandle(
-    const std::string & name, const std::string & interface_name,
-    double * value_ptr = nullptr)
-  : Handle(name, interface_name, value_ptr)
-  {
-  }
+  using Handle<JointHandle>::Handle;
 };
 
 }  // namespace hardware_interface

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -54,9 +54,9 @@
 #include "joint_limits_interface/joint_limits_interface_exception.hpp"
 
 
-#define DEFAULT_POSITION_HANDLE { std::string(), "position" }
-#define DEFAULT_VELOCITY_HANDLE { std::string(), "velocity" }
-#define DEFAULT_COMMAND_HANDLE { std::string(), "position_command" }
+#define DEFAULT_POSITION_HANDLE {std::string(), "position"}
+#define DEFAULT_VELOCITY_HANDLE {std::string(), "velocity"}
+#define DEFAULT_COMMAND_HANDLE {std::string(), "position_command"}
 
 namespace joint_limits_interface
 {

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -380,7 +380,7 @@ public:
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : EffortJointSaturationHandle(jposh, "velocity", jcmdh, limits)
+  : EffortJointSaturationHandle(jposh, hardware_interface::JointHandle("velocity"), jcmdh, limits)
   {
   }
 
@@ -449,7 +449,8 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
-  : EffortJointSoftLimitsHandle(jposh, "velocity", jcmdh, limits, soft_limits)
+  : EffortJointSoftLimitsHandle(jposh,
+      hardware_interface::JointHandle("velocity"), jcmdh, limits, soft_limits)
   {
   }
 
@@ -518,7 +519,7 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle("position", jvelh, jcmdh, limits)
+  : JointLimitHandle(hardware_interface::JointHandle("position"), jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -530,7 +531,8 @@ public:
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle("position", "velocity", jcmdh, limits)
+  : JointLimitHandle(hardware_interface::JointHandle("position"),
+      hardware_interface::JointHandle("velocity"), jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -54,6 +54,10 @@
 #include "joint_limits_interface/joint_limits_interface_exception.hpp"
 
 
+#define DEFAULT_POSITION_HANDLE { std::string(), "position" }
+#define DEFAULT_VELOCITY_HANDLE { std::string(), "velocity" }
+#define DEFAULT_COMMAND_HANDLE { std::string(), "position_command" }
+
 namespace joint_limits_interface
 {
 
@@ -66,9 +70,9 @@ public:
   JointSaturationLimitHandle()
   : prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0),
-    jposh_(std::string(), "position"),
-    jvelh_(std::string(), "velocity"),
-    jcmdh_(std::string(), "position_command")
+    jposh_(DEFAULT_POSITION_HANDLE),
+    jvelh_(DEFAULT_VELOCITY_HANDLE),
+    jcmdh_(DEFAULT_COMMAND_HANDLE)
   {}
 
   JointSaturationLimitHandle(
@@ -76,7 +80,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
   : jposh_(jposh),
-    jvelh_(std::string(), "velocity"),
+    jvelh_(DEFAULT_VELOCITY_HANDLE),
     jcmdh_(jcmdh),
     limits_(limits),
     prev_pos_(std::numeric_limits<double>::quiet_NaN()),
@@ -380,7 +384,7 @@ public:
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : EffortJointSaturationHandle(jposh, {std::string(), "velocity"}, jcmdh, limits)
+  : EffortJointSaturationHandle(jposh, DEFAULT_VELOCITY_HANDLE, jcmdh, limits)
   {
   }
 
@@ -449,7 +453,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
-  : EffortJointSoftLimitsHandle(jposh, {std::string(), "velocity"}, jcmdh, limits, soft_limits)
+  : EffortJointSoftLimitsHandle(jposh, DEFAULT_VELOCITY_HANDLE, jcmdh, limits, soft_limits)
   {
   }
 
@@ -518,7 +522,7 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle({std::string(), "position"}, jvelh, jcmdh, limits)
+  : JointSaturationLimitHandle(DEFAULT_POSITION_HANDLE, jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -530,10 +534,7 @@ public:
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle(
-      {std::string(), "position"},
-      {std::string(), "velocity"},
-      jcmdh, limits)
+  : JointSaturationLimitHandle(DEFAULT_POSITION_HANDLE, DEFAULT_VELOCITY_HANDLE, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -60,10 +60,10 @@ namespace joint_limits_interface
 /** \brief The base class of limit handles for enforcing position, velocity, and effort limits of
  * an effort-controlled joint.
  */
-class JointSaturationLimitHandle
+class JointLimitHandle
 {
 public:
-  JointSaturationLimitHandle()
+  JointLimitHandle()
   : prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0),
     jposh_("position"),
@@ -71,7 +71,7 @@ public:
     jcmdh_("position_command")
   {}
 
-  JointSaturationLimitHandle(
+  JointLimitHandle(
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
@@ -83,7 +83,7 @@ public:
     prev_vel_(0.0)
   {}
 
-  JointSaturationLimitHandle(
+  JointLimitHandle(
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jvelh,
     const hardware_interface::JointHandle & jcmdh,
@@ -146,7 +146,7 @@ protected:
 /** \brief The base class of limit handles for enforcing position, velocity, and effort limits of
  * an effort-controlled joint that has soft-limits.
  */
-class JointSoftLimitsHandle : public JointSaturationLimitHandle
+class JointSoftLimitsHandle : public JointLimitHandle
 {
 public:
   JointSoftLimitsHandle() {}
@@ -156,7 +156,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits,
     const SoftJointLimits & soft_limits)
-  : JointSaturationLimitHandle(jposh, jcmdh, limits),
+  : JointLimitHandle(jposh, jcmdh, limits),
     soft_limits_(soft_limits)
   {}
 
@@ -166,7 +166,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits,
     const SoftJointLimits & soft_limits)
-  : JointSaturationLimitHandle(jposh, jvelh, jcmdh, limits),
+  : JointLimitHandle(jposh, jvelh, jcmdh, limits),
     soft_limits_(soft_limits)
   {}
 
@@ -177,7 +177,7 @@ protected:
 
 /** \brief A handle used to enforce position and velocity limits of a position-controlled joint that does not have
     soft limits. */
-class PositionJointSaturationHandle : public JointSaturationLimitHandle
+class PositionJointSaturationHandle : public JointLimitHandle
 {
 public:
   PositionJointSaturationHandle() {}
@@ -186,7 +186,7 @@ public:
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
-  : JointSaturationLimitHandle(jposh, jcmdh, limits)
+  : JointLimitHandle(jposh, jcmdh, limits)
   {
     if (limits_.has_position_limits) {
       min_pos_limit_ = limits_.min_position;
@@ -352,7 +352,7 @@ public:
 /** \brief A handle used to enforce position, velocity, and effort limits of an effort-controlled
  * joint that does not have soft limits.
  */
-class EffortJointSaturationHandle : public JointSaturationLimitHandle
+class EffortJointSaturationHandle : public JointLimitHandle
 {
 public:
   EffortJointSaturationHandle() {}
@@ -362,7 +362,7 @@ public:
     const hardware_interface::JointHandle & jvelh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle(jposh, jvelh, jcmdh, limits)
+  : JointLimitHandle(jposh, jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -509,7 +509,7 @@ public:
 
 /** \brief A handle used to enforce velocity and acceleration limits of a velocity-controlled joint.
   */
-class VelocityJointSaturationHandle : public JointSaturationLimitHandle
+class VelocityJointSaturationHandle : public JointLimitHandle
 {
 public:
   VelocityJointSaturationHandle() {}
@@ -518,7 +518,7 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle("position", jvelh, jcmdh, limits)
+  : JointLimitHandle("position", jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -530,7 +530,7 @@ public:
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle("position", "velocity", jcmdh, limits)
+  : JointLimitHandle("position", "velocity", jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -54,10 +54,6 @@
 #include "joint_limits_interface/joint_limits_interface_exception.hpp"
 
 
-#define DEFAULT_POSITION_HANDLE {std::string(), "position"}
-#define DEFAULT_VELOCITY_HANDLE {std::string(), "velocity"}
-#define DEFAULT_COMMAND_HANDLE {std::string(), "position_command"}
-
 namespace joint_limits_interface
 {
 
@@ -70,9 +66,9 @@ public:
   JointSaturationLimitHandle()
   : prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0),
-    jposh_(DEFAULT_POSITION_HANDLE),
-    jvelh_(DEFAULT_VELOCITY_HANDLE),
-    jcmdh_(DEFAULT_COMMAND_HANDLE)
+    jposh_("position"),
+    jvelh_("velocity"),
+    jcmdh_("position_command")
   {}
 
   JointSaturationLimitHandle(
@@ -80,7 +76,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
   : jposh_(jposh),
-    jvelh_(DEFAULT_VELOCITY_HANDLE),
+    jvelh_("velocity"),
     jcmdh_(jcmdh),
     limits_(limits),
     prev_pos_(std::numeric_limits<double>::quiet_NaN()),
@@ -384,7 +380,7 @@ public:
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : EffortJointSaturationHandle(jposh, DEFAULT_VELOCITY_HANDLE, jcmdh, limits)
+  : EffortJointSaturationHandle(jposh, "velocity", jcmdh, limits)
   {
   }
 
@@ -453,7 +449,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
-  : EffortJointSoftLimitsHandle(jposh, DEFAULT_VELOCITY_HANDLE, jcmdh, limits, soft_limits)
+  : EffortJointSoftLimitsHandle(jposh, "velocity", jcmdh, limits, soft_limits)
   {
   }
 
@@ -522,7 +518,7 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle(DEFAULT_POSITION_HANDLE, jvelh, jcmdh, limits)
+  : JointSaturationLimitHandle("position", jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -534,7 +530,7 @@ public:
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointSaturationLimitHandle(DEFAULT_POSITION_HANDLE, DEFAULT_VELOCITY_HANDLE, jcmdh, limits)
+  : JointSaturationLimitHandle("position", "velocity", jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -103,7 +103,7 @@ public:
 
   /** \brief Sub-class implementation of limit enforcing policy.
    */
-  virtual void enforceLimits(const rclcpp::Duration & period) = 0;
+  virtual void enforce_limits(const rclcpp::Duration & period) = 0;
 
   /** \brief  clear stored state, causing it to reset next iteration
    */
@@ -198,7 +198,7 @@ public:
  *
  * \param period Control period.
  */
-  void enforceLimits(const rclcpp::Duration & period)
+  void enforce_limits(const rclcpp::Duration & period)
   {
     if (std::isnan(prev_pos_)) {
       prev_pos_ = jposh_->get_value();
@@ -287,7 +287,7 @@ public:
    * enforced.
    * \param period Control period.
    */
-  void enforceLimits(const rclcpp::Duration & period) override
+  void enforce_limits(const rclcpp::Duration & period) override
   {
     assert(period.seconds() > 0.0);
 
@@ -384,7 +384,7 @@ public:
    * \brief Enforce position, velocity, and effort limits for a joint that is not subject
    * to soft limits.
    */
-  void enforceLimits(const rclcpp::Duration & period) override
+  void enforce_limits(const rclcpp::Duration & period) override
   {
     double min_eff = -limits_.max_effort;
     double max_eff = limits_.max_effort;
@@ -455,7 +455,7 @@ public:
    * If the joint has no position limits (eg. a continuous joint), only velocity and effort limits
    * will be enforced.
    */
-  void enforceLimits(const rclcpp::Duration & period) override
+  void enforce_limits(const rclcpp::Duration & period) override
   {
     // Current state
     const double pos = jposh_->get_value();
@@ -539,7 +539,7 @@ public:
    * \brief Enforce joint velocity and acceleration limits.
    * \param period Control period.
    */
-  void enforceLimits(const rclcpp::Duration & period) override
+  void enforce_limits(const rclcpp::Duration & period) override
   {
     // Velocity bounds
     double vel_low;
@@ -597,7 +597,7 @@ public:
    *
    * \param period Control period.
    */
-  void enforceLimits(const rclcpp::Duration & period)
+  void enforce_limits(const rclcpp::Duration & period)
   {
     double min_vel, max_vel;
     if (limits_.has_position_limits) {
@@ -634,7 +634,7 @@ private:
 //  *
 //  * \tparam HandleType %Handle type. Must implement the following methods:
 //  *  \code
-//  *   void enforceLimits();
+//  *   void enforce_limits();
 //  *   std::string get_name() const;
 //  *  \endcode
 //  */
@@ -656,10 +656,10 @@ private:
 //   /** \name Real-Time Safe Functions
 //    *\{*/
 //   /** \brief Enforce limits for all managed handles. */
-//   void enforceLimits(const rclcpp::Duration & period)
+//   void enforce_limits(const rclcpp::Duration & period)
 //   {
 //     for (auto && resource_name_and_handle : this->resource_map_) {
-//       resource_name_and_handle.second.enforceLimits(period);
+//       resource_name_and_handle.second.enforce_limits(period);
 //     }
 //   }
 //   /*\}*/

--- a/joint_limits_interface/mainpage.dox
+++ b/joint_limits_interface/mainpage.dox
@@ -125,8 +125,8 @@ public:
   void write(ros::Time time, ros::Duration period)
   {
     // Enforce joint limits for all registered handles
-    // Note: one can also enforce limits on a per-handle basis: handle.enforceLimits(period)
-    jnt_limits_interface_.enforceLimits(period);
+    // Note: one can also enforce limits on a per-handle basis: handle.enforce_limits(period)
+    jnt_limits_interface_.enforce_limits(period);
 
     // Propagate joint commands to actuators...
 

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -214,7 +214,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = max_increment / 2.0;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
   }
   {
@@ -222,7 +222,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -max_increment / 2.0;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
   }
 
@@ -232,7 +232,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = max_increment;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
   }
   {
@@ -240,7 +240,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -max_increment;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
   }
 
@@ -250,7 +250,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = 2.0 * max_increment;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(max_increment, cmd_handle->get_value(), EPS);
   }
   {
@@ -258,7 +258,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -2.0 * max_increment;
     cmd_handle->set_value(cmd);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(-max_increment, cmd_handle->get_value(), EPS);
   }
 }
@@ -279,13 +279,13 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     pos = soft_limits.max_position;
     // Try to get closer to the hard limit
     cmd_handle->set_value(limits.max_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(pos_handle->get_value(), cmd_handle->get_value(), EPS);
 
     // OK to move away from hard limit
     // Try to go to workspace center
     cmd_handle->set_value(workspace_center);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
   }
 
@@ -298,13 +298,13 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     pos = soft_limits.min_position;
     // Try to get closer to the hard limit
     cmd_handle->set_value(limits.min_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(pos_handle->get_value(), cmd_handle->get_value(), EPS);
 
     // OK to move away from hard limit
     // Try to go to workspace center
     cmd_handle->set_value(workspace_center);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
   }
 
@@ -318,13 +318,13 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     pos = (soft_limits.max_position + limits.max_position) / 2.0;
     // Try to get closer to the hard limit
     cmd_handle->set_value(limits.max_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
 
     // OK to move away from hard limit
     // Try to go to workspace center
     cmd_handle->set_value(workspace_center);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
   }
 
@@ -338,13 +338,13 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     pos = (soft_limits.min_position + limits.min_position) / 2.0;
     // Try to get closer to the hard limit
     cmd_handle->set_value(limits.min_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
 
     // OK to move away from hard limit
     // Try to go to workspace center
     cmd_handle->set_value(workspace_center);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
   }
 }
@@ -367,7 +367,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
     pos = limits.max_position;
     // Way beyond hard limit
     cmd_handle->set_value(2.0 * limits.max_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(limits.max_position, cmd_handle->get_value(), EPS);
   }
 
@@ -381,7 +381,7 @@ TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
     pos = limits.min_position;
     // Way beyond hard limit
     cmd_handle->set_value(2.0 * limits.min_position);
-    limits_handle.enforceLimits(period);
+    limits_handle.enforce_limits(period);
     EXPECT_NEAR(limits.min_position, cmd_handle->get_value(), EPS);
   }
 }
@@ -400,34 +400,34 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceVelocityBounds)
   // Velocity within bounds
   cmd = limits.max_velocity / 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
 
   cmd = -limits.max_velocity / 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
 
   // Velocity at bounds
   cmd = limits.max_velocity;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
 
   cmd = -limits.max_velocity;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
 
   // Velocity beyond bounds
   cmd = 2.0 * limits.max_velocity;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(limits.max_velocity, cmd_handle->get_value(), EPS);
 
   cmd = -2.0 * limits.max_velocity;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   EXPECT_NEAR(-limits.max_velocity, cmd_handle->get_value(), EPS);
 }
 
@@ -449,12 +449,12 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
   cmd_handle->set_value(limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
-  limits_handle.enforceLimits(long_enough);
+  limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond +max velocity
   cmd = limits.max_velocity * 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   // Max velocity bounded by velocity limit
   EXPECT_NEAR(limits.max_velocity, cmd_handle->get_value(), EPS);
 
@@ -462,12 +462,12 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
   cmd_handle->set_value(limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
-  limits_handle.enforceLimits(long_enough);
+  limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond -max velocity
   cmd = -limits.max_velocity * 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   // Max velocity bounded by acceleration limit
   EXPECT_NEAR(-limits.max_velocity / 2.0, cmd_handle->get_value(), EPS);
 
@@ -476,12 +476,12 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
   cmd_handle->set_value(-limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
-  limits_handle.enforceLimits(long_enough);
+  limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond +max velocity
   cmd = limits.max_velocity * 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   // Max velocity bounded by acceleration limit
   EXPECT_NEAR(limits.max_velocity / 2.0, cmd_handle->get_value(), EPS);
 
@@ -489,12 +489,12 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
   cmd_handle->set_value(-limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
-  limits_handle.enforceLimits(long_enough);
+  limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond -max velocity
   cmd = -limits.max_velocity * 2.0;
   cmd_handle->set_value(cmd);
-  limits_handle.enforceLimits(period);
+  limits_handle.enforce_limits(period);
   // Max velocity bounded by velocity limit
   EXPECT_NEAR(-limits.max_velocity, cmd_handle->get_value(), EPS);
 }
@@ -558,7 +558,7 @@ protected:
 //   // Try to get closer to the hard limit
 //   cmd_handle->set_value(limits.max_position);
 //   cmd_handle2.set_cmd(limits.max_position);
-//   iface.enforceLimits(period);
+//   iface.enforce_limits(period);
 //   EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
 //   EXPECT_GT(cmd_handle2.getPosition(), cmd_handle2.get_cmd());
 // }
@@ -573,19 +573,19 @@ TEST_F(JointLimitsHandleTest, ResetSaturationInterface)
   PositionJointSaturationInterface iface;
   iface.registerHandle(limits_handle1);
 
-  iface.enforceLimits(period);  // initialize limit handles
+  iface.enforce_limits(period);  // initialize limit handles
 
   const double max_increment = period.seconds() * limits.max_velocity;
 
   cmd_handle->set_value(limits.max_position);
-  iface.enforceLimits(period);
+  iface.enforce_limits(period);
 
   EXPECT_NEAR(cmd_handle->get_value(), max_increment, EPS);
 
   iface.reset();
   pos = limits.max_position;
   cmd_handle->set_value(limits.max_position);
-  iface.enforceLimits(period);
+  iface.enforce_limits(period);
 
   EXPECT_NEAR(cmd_handle->get_value(), limits.max_position, EPS);
 }
@@ -599,19 +599,19 @@ TEST_F(JointLimitsHandleTest, ResetSaturationInterface)
 //   PositionJointSoftLimitsInterface iface;
 //   iface.registerHandle(limits_handle1);
 //
-//   iface.enforceLimits(period); // initialize limit handles
+//   iface.enforce_limits(period); // initialize limit handles
 //
 //   const double max_increment = period.seconds() * limits.max_velocity;
 //
 //   cmd_handle->set_value(limits.max_position);
-//   iface.enforceLimits(period);
+//   iface.enforce_limits(period);
 //
 //   EXPECT_NEAR(cmd_handle->get_value(), max_increment, EPS);
 //
 //   iface.reset();
 //   pos = limits.max_position;
 //   cmd_handle->set_value(soft_limits.max_position);
-//   iface.enforceLimits(period);
+//   iface.enforce_limits(period);
 //
 //   EXPECT_NEAR(cmd_handle->get_value(), soft_limits.max_position, EPS);
 //

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -81,10 +81,10 @@ public:
   : pos(0.0), vel(0.0), eff(0.0), cmd(0.0),
     name("joint_name"),
     period(0, 100000000),
-    cmd_handle(std::make_shared<hardware_interface::JointHandle>(name, "position_command", &cmd)),
-    pos_handle(std::make_shared<hardware_interface::JointHandle>(name, "position", &pos)),
-    vel_handle(std::make_shared<hardware_interface::JointHandle>(name, "velocity", &vel)),
-    eff_handle(std::make_shared<hardware_interface::JointHandle>(name, "effort", &eff))
+    cmd_handle(hardware_interface::JointHandle(name, "position_command", &cmd)),
+    pos_handle(hardware_interface::JointHandle(name, "position", &pos)),
+    vel_handle(hardware_interface::JointHandle(name, "velocity", &vel)),
+    eff_handle(hardware_interface::JointHandle(name, "effort", &eff))
   {
     limits.has_position_limits = true;
     limits.min_position = -1.0;
@@ -107,8 +107,8 @@ protected:
   double pos, vel, eff, cmd;
   std::string name;
   rclcpp::Duration period;
-  std::shared_ptr<hardware_interface::JointHandle> cmd_handle;
-  std::shared_ptr<hardware_interface::JointHandle> pos_handle, vel_handle, eff_handle;
+  hardware_interface::JointHandle cmd_handle;
+  hardware_interface::JointHandle pos_handle, vel_handle, eff_handle;
   joint_limits_interface::JointLimits limits;
   joint_limits_interface::SoftJointLimits soft_limits;
 };
@@ -213,17 +213,17 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = max_increment / 2.0;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
   }
   {
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -max_increment / 2.0;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
   }
 
   // Move at maximum velocity
@@ -231,17 +231,17 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = max_increment;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
   }
   {
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -max_increment;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
   }
 
   // Try to move faster than the maximum velocity, enforce velocity limits
@@ -249,17 +249,17 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = 2.0 * max_increment;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(max_increment, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(max_increment, cmd_handle.get_value(), EPS);
   }
   {
     joint_limits_interface::PositionJointSoftLimitsHandle limits_handle(
       pos_handle, cmd_handle, limits, soft_limits);
     cmd = -2.0 * max_increment;
-    cmd_handle->set_value(cmd);
+    cmd_handle.set_value(cmd);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(-max_increment, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(-max_increment, cmd_handle.get_value(), EPS);
   }
 }
 
@@ -278,15 +278,15 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     // Can't get any closer to hard limit (zero max velocity)
     pos = soft_limits.max_position;
     // Try to get closer to the hard limit
-    cmd_handle->set_value(limits.max_position);
+    cmd_handle.set_value(limits.max_position);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(pos_handle->get_value(), cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(pos_handle.get_value(), cmd_handle.get_value(), EPS);
 
     // OK to move away from hard limit
     // Try to go to workspace center
-    cmd_handle->set_value(workspace_center);
+    cmd_handle.set_value(workspace_center);
     limits_handle.enforce_limits(period);
-    EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_GT(pos_handle.get_value(), cmd_handle.get_value());
   }
 
   // Current position == lower soft limit
@@ -297,15 +297,15 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     // Can't get any closer to hard limit (zero min velocity)
     pos = soft_limits.min_position;
     // Try to get closer to the hard limit
-    cmd_handle->set_value(limits.min_position);
+    cmd_handle.set_value(limits.min_position);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(pos_handle->get_value(), cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(pos_handle.get_value(), cmd_handle.get_value(), EPS);
 
     // OK to move away from hard limit
     // Try to go to workspace center
-    cmd_handle->set_value(workspace_center);
+    cmd_handle.set_value(workspace_center);
     limits_handle.enforce_limits(period);
-    EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_LT(pos_handle.get_value(), cmd_handle.get_value());
   }
 
   // Current position > upper soft limit
@@ -317,15 +317,15 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     // Halfway between soft and hard limit
     pos = (soft_limits.max_position + limits.max_position) / 2.0;
     // Try to get closer to the hard limit
-    cmd_handle->set_value(limits.max_position);
+    cmd_handle.set_value(limits.max_position);
     limits_handle.enforce_limits(period);
-    EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_GT(pos_handle.get_value(), cmd_handle.get_value());
 
     // OK to move away from hard limit
     // Try to go to workspace center
-    cmd_handle->set_value(workspace_center);
+    cmd_handle.set_value(workspace_center);
     limits_handle.enforce_limits(period);
-    EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_GT(pos_handle.get_value(), cmd_handle.get_value());
   }
 
   // Current position < lower soft limit
@@ -337,15 +337,15 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
     // Halfway between soft and hard limit
     pos = (soft_limits.min_position + limits.min_position) / 2.0;
     // Try to get closer to the hard limit
-    cmd_handle->set_value(limits.min_position);
+    cmd_handle.set_value(limits.min_position);
     limits_handle.enforce_limits(period);
-    EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_LT(pos_handle.get_value(), cmd_handle.get_value());
 
     // OK to move away from hard limit
     // Try to go to workspace center
-    cmd_handle->set_value(workspace_center);
+    cmd_handle.set_value(workspace_center);
     limits_handle.enforce_limits(period);
-    EXPECT_LT(pos_handle->get_value(), cmd_handle->get_value());
+    EXPECT_LT(pos_handle.get_value(), cmd_handle.get_value());
   }
 }
 
@@ -366,9 +366,9 @@ TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
     // On hard limit
     pos = limits.max_position;
     // Way beyond hard limit
-    cmd_handle->set_value(2.0 * limits.max_position);
+    cmd_handle.set_value(2.0 * limits.max_position);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(limits.max_position, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(limits.max_position, cmd_handle.get_value(), EPS);
   }
 
   // Current position == lower hard limit
@@ -380,9 +380,9 @@ TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
     // On hard limit
     pos = limits.min_position;
     // Way beyond hard limit
-    cmd_handle->set_value(2.0 * limits.min_position);
+    cmd_handle.set_value(2.0 * limits.min_position);
     limits_handle.enforce_limits(period);
-    EXPECT_NEAR(limits.min_position, cmd_handle->get_value(), EPS);
+    EXPECT_NEAR(limits.min_position, cmd_handle.get_value(), EPS);
   }
 }
 
@@ -399,36 +399,36 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceVelocityBounds)
 
   // Velocity within bounds
   cmd = limits.max_velocity / 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
 
   cmd = -limits.max_velocity / 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
 
   // Velocity at bounds
   cmd = limits.max_velocity;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
 
   cmd = -limits.max_velocity;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(cmd, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(cmd, cmd_handle.get_value(), EPS);
 
   // Velocity beyond bounds
   cmd = 2.0 * limits.max_velocity;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(limits.max_velocity, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(limits.max_velocity, cmd_handle.get_value(), EPS);
 
   cmd = -2.0 * limits.max_velocity;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
-  EXPECT_NEAR(-limits.max_velocity, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(-limits.max_velocity, cmd_handle.get_value(), EPS);
 }
 
 TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
@@ -446,57 +446,57 @@ TEST_F(VelocityJointSaturationHandleTest, EnforceAccelerationBounds)
 
   // Positive velocity
   // register last command
-  cmd_handle->set_value(limits.max_velocity / 2.0);
+  cmd_handle.set_value(limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
   limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond +max velocity
   cmd = limits.max_velocity * 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
   // Max velocity bounded by velocity limit
-  EXPECT_NEAR(limits.max_velocity, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(limits.max_velocity, cmd_handle.get_value(), EPS);
 
   // register last command
-  cmd_handle->set_value(limits.max_velocity / 2.0);
+  cmd_handle.set_value(limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
   limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond -max velocity
   cmd = -limits.max_velocity * 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
   // Max velocity bounded by acceleration limit
-  EXPECT_NEAR(-limits.max_velocity / 2.0, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(-limits.max_velocity / 2.0, cmd_handle.get_value(), EPS);
 
   // Negative velocity
   // register last command
-  cmd_handle->set_value(-limits.max_velocity / 2.0);
+  cmd_handle.set_value(-limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
   limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond +max velocity
   cmd = limits.max_velocity * 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
   // Max velocity bounded by acceleration limit
-  EXPECT_NEAR(limits.max_velocity / 2.0, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(limits.max_velocity / 2.0, cmd_handle.get_value(), EPS);
 
   // register last command
-  cmd_handle->set_value(-limits.max_velocity / 2.0);
+  cmd_handle.set_value(-limits.max_velocity / 2.0);
   // make sure the prev_cmd is registered
   // without triggering the acceleration limits
   limits_handle.enforce_limits(long_enough);
 
   // Try to go beyond -max velocity
   cmd = -limits.max_velocity * 2.0;
-  cmd_handle->set_value(cmd);
+  cmd_handle.set_value(cmd);
   limits_handle.enforce_limits(period);
   // Max velocity bounded by velocity limit
-  EXPECT_NEAR(-limits.max_velocity, cmd_handle->get_value(), EPS);
+  EXPECT_NEAR(-limits.max_velocity, cmd_handle.get_value(), EPS);
 }
 
 class JointLimitsInterfaceTest : public JointLimitsTest, public ::testing::Test
@@ -556,10 +556,10 @@ protected:
 //   // Halfway between soft and hard limit
 //   pos = pos2 = (soft_limits.max_position + limits.max_position) / 2.0;
 //   // Try to get closer to the hard limit
-//   cmd_handle->set_value(limits.max_position);
+//   cmd_handle.set_value(limits.max_position);
 //   cmd_handle2.set_cmd(limits.max_position);
 //   iface.enforce_limits(period);
-//   EXPECT_GT(pos_handle->get_value(), cmd_handle->get_value());
+//   EXPECT_GT(pos_handle.get_value(), cmd_handle.get_value());
 //   EXPECT_GT(cmd_handle2.getPosition(), cmd_handle2.get_cmd());
 // }
 //
@@ -577,17 +577,17 @@ TEST_F(JointLimitsHandleTest, ResetSaturationInterface)
 
   const double max_increment = period.seconds() * limits.max_velocity;
 
-  cmd_handle->set_value(limits.max_position);
+  cmd_handle.set_value(limits.max_position);
   iface.enforce_limits(period);
 
-  EXPECT_NEAR(cmd_handle->get_value(), max_increment, EPS);
+  EXPECT_NEAR(cmd_handle.get_value(), max_increment, EPS);
 
   iface.reset();
   pos = limits.max_position;
-  cmd_handle->set_value(limits.max_position);
+  cmd_handle.set_value(limits.max_position);
   iface.enforce_limits(period);
 
-  EXPECT_NEAR(cmd_handle->get_value(), limits.max_position, EPS);
+  EXPECT_NEAR(cmd_handle.get_value(), limits.max_position, EPS);
 }
 #endif
 
@@ -603,17 +603,17 @@ TEST_F(JointLimitsHandleTest, ResetSaturationInterface)
 //
 //   const double max_increment = period.seconds() * limits.max_velocity;
 //
-//   cmd_handle->set_value(limits.max_position);
+//   cmd_handle.set_value(limits.max_position);
 //   iface.enforce_limits(period);
 //
-//   EXPECT_NEAR(cmd_handle->get_value(), max_increment, EPS);
+//   EXPECT_NEAR(cmd_handle.get_value(), max_increment, EPS);
 //
 //   iface.reset();
 //   pos = limits.max_position;
-//   cmd_handle->set_value(soft_limits.max_position);
+//   cmd_handle.set_value(soft_limits.max_position);
 //   iface.enforce_limits(period);
 //
-//   EXPECT_NEAR(cmd_handle->get_value(), soft_limits.max_position, EPS);
+//   EXPECT_NEAR(cmd_handle.get_value(), soft_limits.max_position, EPS);
 //
 // }
 


### PR DESCRIPTION
Removed use of std::shared_ptr<> around JointHandles. JointLimit Saturation and SoftLimit handles are now using plain value semantics.

Using value semantics and JointHandle not having a default no-arg constructor requires I use these defaults which I defined as macros and then used in default constructors for the Joint Limit handles:
```
#define DEFAULT_POSITION_HANDLE { std::string(), "position" }
#define DEFAULT_VELOCITY_HANDLE { std::string(), "velocity" }
#define DEFAULT_COMMAND_HANDLE { std::string(), "position_command" }
```

JointHandle (or base Handle<>) has no method for testing if the handle's value_ptr_ has been set. I added an operator-bool to Handle<> template which just tests if the value ptr is null. I think this is an appropriate add to Handle/JointHandle but if you feel otherwise, we could do one of the following instead:
* instead of operator-bool, we could add an equality nullptr_t operator. This would at least allow us to use `(jposh != nullptr) ? this : that` but `jposh ? this : that` wouldnt work.
` inline bool operator==(nullptr_t) { return value_ptr_ != nullptr_; }`
* add an actual is_set() or is_valid() method
* or I can modify all the joint limits code to explicity check jposh.value_ptr field

