### PR TITLE
Replace rclcpp by rcutils logging tools in hardware_interface pkg

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(control_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
 find_package(TinyXML2 REQUIRED)
 
@@ -34,7 +34,7 @@ target_include_directories(
 ament_target_dependencies(
   hardware_interface
   control_msgs
-  rclcpp
+  rcutils
   rcpputils
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -128,10 +128,6 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_component_parser TinyXML2)
 endif()
 
-ament_export_dependencies(
-  rclcpp
-  rcpputils
-)
 ament_export_include_directories(
   include
 )
@@ -142,7 +138,6 @@ ament_export_libraries(
 )
 ament_export_dependencies(
   control_msgs
-  rclcpp
   rcpputils
   tinyxml2_vendor
   TinyXML2

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -10,9 +10,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>control_msgs</depend>
-  <depend>rclcpp</depend>
   <depend>rcpputils</depend>
   <depend>tinyxml2_vendor</depend>
+
+  <build_depend>rcutils</build_depend>
+  <exec_depend>rcutils</exec_depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/hardware_interface/src/robot_hardware.cpp
+++ b/hardware_interface/src/robot_hardware.cpp
@@ -20,7 +20,7 @@
 
 #include "hardware_interface/macros.hpp"
 #include "hardware_interface/operation_mode_handle.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
 
 namespace
 {
@@ -43,16 +43,12 @@ return_type
 register_handle(std::vector<T *> & registered_handles, T * handle, const std::string & logger_name)
 {
   if (handle->get_name().empty()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(
-        logger_name), "cannot register handle! No name is specified");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "cannot register handle! No name is specified");
     return return_type::ERROR;
   }
 
   if (!handle->valid_pointers()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(
-        logger_name), "cannot register handle! Points to nullptr!");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "cannot register handle! Points to nullptr!");
     return return_type::ERROR;
   }
 
@@ -64,9 +60,7 @@ register_handle(std::vector<T *> & registered_handles, T * handle, const std::st
 
   // handle exists already
   if (handle_pos != registered_handles.end()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(logger_name),
-      "cannot register handle! Handle exists already");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "cannot register handle! Handle exists already");
     return return_type::ERROR;
   }
   registered_handles.push_back(handle);
@@ -99,9 +93,7 @@ get_handle(
   T ** handle)
 {
   if (name.empty()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(logger_name),
-      "cannot get handle! No name given");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "cannot get handle! No name given");
     return return_type::ERROR;
   }
 
@@ -112,9 +104,9 @@ get_handle(
     });
 
   if (handle_pos == registered_handles.end()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(
-        logger_name), "cannot get handle. No joint " << name << " found.");
+    RCUTILS_LOG_ERROR_NAMED(
+      logger_name.c_str(), "cannot get handle. No joint %s found.",
+      name.c_str());
     return return_type::ERROR;
   }
 
@@ -166,7 +158,7 @@ hardware_interface_ret_t register_handle(
   const std::string & logger_name)
 {
   if (handle_name.empty() || interface_name.empty()) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger(logger_name), "handle name or interface is empty!");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "handle name or interface is empty!");
     return return_type::ERROR;
   }
 
@@ -189,10 +181,9 @@ hardware_interface_ret_t register_handle(
       ivs.values.push_back(default_value);
       return return_type::OK;
     } else {
-      RCLCPP_ERROR_STREAM(
-        rclcpp::get_logger(logger_name), "handle with interface (" <<
-          handle_name << ":" << interface_name <<
-          ") is already registered!");
+      RCUTILS_LOG_ERROR_NAMED(
+        logger_name.c_str(), "handle with interface (%s: %s) is already registered!",
+        handle_name.c_str(), interface_name.c_str());
       return return_type::ERROR;
     }
   }
@@ -228,17 +219,16 @@ hardware_interface_ret_t get_handle(
   const auto & interface_name = handle.get_interface_name();
 
   if (handle_name.empty() || interface_name.empty()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(logger_name), "name or interface is ill-defined!");
+    RCUTILS_LOG_ERROR_NAMED(logger_name.c_str(), "name or interface is ill-defined!");
     return return_type::ERROR;
   }
 
   const auto & names_list = registered.joint_names;
   const auto it = std::find(names_list.cbegin(), names_list.cend(), handle_name);
   if (it == names_list.cend()) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(
-        logger_name), "handle with name " << handle_name << " not found!");
+    RCUTILS_LOG_ERROR_NAMED(
+      logger_name.c_str(), "handle with name %s not found!",
+      handle_name.c_str());
     return return_type::ERROR;
   }
 
@@ -251,10 +241,9 @@ hardware_interface_ret_t get_handle(
     handle = handle.with_value_ptr(&(ivs.values[static_cast<size_t>(value_index)]));
     return return_type::OK;
   } else {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger(
-        logger_name),
-      "handle with interface (" << handle_name << ":" << interface_name << ") wasn't found!");
+    RCUTILS_LOG_ERROR_NAMED(
+      logger_name.c_str(),
+      "handle with interface (%s: %s) wasn't found!", handle_name.c_str(), interface_name.c_str());
     return return_type::ERROR;
   }
 


### PR DESCRIPTION
Fix #200.

NOTE: I'm sorry for https://github.com/ros-controls/ros2_control/pull/204. It was easier to redo the updates instead of rebasing them.