### PR TITLE
Remove rclcpp users note from our visibility headers

### DIFF
--- a/controller_interface/include/controller_interface/visibility_control.h
+++ b/controller_interface/include/controller_interface/visibility_control.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* This header must be included by all rclcpp headers which declare symbols
- * which are defined in the rclcpp library. When not building the rclcpp
- * library, i.e. when using the headers in other package's code, the contents
- * of this header change the visibility of certain symbols which the rclcpp
- * library cannot have, but the consuming code must have inorder to link.
- */
-
 #ifndef CONTROLLER_INTERFACE__VISIBILITY_CONTROL_H_
 #define CONTROLLER_INTERFACE__VISIBILITY_CONTROL_H_
 

--- a/controller_manager/include/controller_manager/visibility_control.h
+++ b/controller_manager/include/controller_manager/visibility_control.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* This header must be included by all rclcpp headers which declare symbols
- * which are defined in the rclcpp library. When not building the rclcpp
- * library, i.e. when using the headers in other package's code, the contents
- * of this header change the visibility of certain symbols which the rclcpp
- * library cannot have, but the consuming code must have inorder to link.
- */
-
 #ifndef CONTROLLER_MANAGER__VISIBILITY_CONTROL_H_
 #define CONTROLLER_MANAGER__VISIBILITY_CONTROL_H_
 

--- a/hardware_interface/include/hardware_interface/visibility_control.h
+++ b/hardware_interface/include/hardware_interface/visibility_control.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* This header must be included by all rclcpp headers which declare symbols
- * which are defined in the rclcpp library. When not building the rclcpp
- * library, i.e. when using the headers in other package's code, the contents
- * of this header change the visibility of certain symbols which the rclcpp
- * library cannot have, but the consuming code must have inorder to link.
- */
-
 #ifndef HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
 #define HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_
 

--- a/test_robot_hardware/include/test_robot_hardware/visibility_control.h
+++ b/test_robot_hardware/include/test_robot_hardware/visibility_control.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* This header must be included by all rclcpp headers which declare symbols
- * which are defined in the rclcpp library. When not building the rclcpp
- * library, i.e. when using the headers in other package's code, the contents
- * of this header change the visibility of certain symbols which the rclcpp
- * library cannot have, but the consuming code must have inorder to link.
- */
-
 #ifndef TEST_ROBOT_HARDWARE__VISIBILITY_CONTROL_H_
 #define TEST_ROBOT_HARDWARE__VISIBILITY_CONTROL_H_
 

--- a/transmission_interface/include/transmission_interface/visibility_control.h
+++ b/transmission_interface/include/transmission_interface/visibility_control.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* This header must be included by all rclcpp headers which declare symbols
- * which are defined in the rclcpp library. When not building the rclcpp
- * library, i.e. when using the headers in other package's code, the contents
- * of this header change the visibility of certain symbols which the rclcpp
- * library cannot have, but the consuming code must have inorder to link.
- */
-
 #ifndef TRANSMISSION_INTERFACE__VISIBILITY_CONTROL_H_
 #define TRANSMISSION_INTERFACE__VISIBILITY_CONTROL_H_
 


### PR DESCRIPTION
Found that we had some unrelated copy-pasta text