### PR TITLE
Ros2 control node

### DIFF
--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -26,7 +26,10 @@ ControllerInterface::init(
   const std::string & controller_name)
 {
   robot_hardware_ = robot_hardware;
-  lifecycle_node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name);
+  lifecycle_node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
+    controller_name,
+    rclcpp::NodeOptions().allow_undeclared_parameters(true).
+    automatically_declare_parameters_from_overrides(true));
 
   lifecycle_node_->register_on_configure(
     std::bind(&ControllerInterface::on_configure, this, std::placeholders::_1));

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -37,11 +37,25 @@ target_compile_definitions(controller_manager PRIVATE "CONTROLLER_MANAGER_BUILDI
 # prevent pluginlib from using boost
 target_compile_definitions(controller_manager PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 
+add_executable(ros2_control_node src/ros2_control_node.cpp)
+target_include_directories(ros2_control_node PRIVATE include)
+target_link_libraries(ros2_control_node controller_manager)
+ament_target_dependencies(ros2_control_node
+  controller_interface
+  hardware_interface
+  rclcpp
+)
+
 install(TARGETS controller_manager
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
+
+install(TARGETS ros2_control_node
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
 install(DIRECTORY include/
   DESTINATION include
 )
@@ -116,6 +130,8 @@ ament_export_include_directories(
 ament_export_dependencies(
   controller_interface
   controller_manager_msgs
+  hardware_interface
   pluginlib
+  rclcpp
 )
 ament_package()

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(controller_manager_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+#TODO(anyone): remove this when using ResourceManager
+find_package(test_robot_hardware REQUIRED)
 
 add_library(controller_manager SHARED
   src/controller_manager.cpp
@@ -44,6 +46,8 @@ ament_target_dependencies(ros2_control_node
   controller_interface
   hardware_interface
   rclcpp
+  #TODO(anyone): remove this when using ResourceManager
+  test_robot_hardware
 )
 
 install(TARGETS controller_manager

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -111,6 +111,13 @@ public:
   controller_interface::return_type
   update();
 
+  /// Deterministic (real-time safe) callback group, e.g., update function.
+  /**
+   * @brief Deterministic (real-time safe) callback group for the update function. Default behavior
+   * is read hardware, update controller and finally write new values to the hardware.
+   */
+  rclcpp::callback_group::CallbackGroup::SharedPtr deterministic_callback_group_;
+
 protected:
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceSharedPtr
@@ -165,10 +172,12 @@ private:
   std::shared_ptr<rclcpp::Executor> executor_;
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ControllerInterface>> loader_;
 
-  rclcpp::callback_group::CallbackGroup::SharedPtr realtime_callback_group_;
-  rclcpp::callback_group::CallbackGroup::SharedPtr services_callback_group_;
-
-  rclcpp::TimerBase::SharedPtr timer_;
+  /// Best effort (non real-time safe) callback group, e.g., service callbacks.
+  /**
+   * @brief Best effort (non real-time safe) callback group for callbacks that can possibly break
+   * real-time requirements, for example, service callbacks.
+   */
+  rclcpp::callback_group::CallbackGroup::SharedPtr best_effort_callback_group_;
 
   /**
    * @brief The RTControllerListWrapper class wraps a double-buffered list of controllers

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -174,7 +174,7 @@ private:
 
   /// Best effort (non real-time safe) callback group, e.g., service callbacks.
   /**
-   * @brief Best effort (non real-time safe) callback group for callbacks that can possibly break
+   * Best effort (non real-time safe) callback group for callbacks that can possibly break
    * real-time requirements, for example, service callbacks.
    */
   rclcpp::callback_group::CallbackGroup::SharedPtr best_effort_callback_group_;

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -44,8 +44,8 @@ namespace controller_manager
 class ControllerManager : public rclcpp::Node
 {
 public:
-  static constexpr bool WAIT_FOR_ALL_RESOURCES = false;
-  static constexpr double INFINITE_TIMEOUT = 0.0;
+  static constexpr bool kWaitForAllResources = false;
+  static constexpr double kInfiniteTimeout = 0.0;
 
   CONTROLLER_MANAGER_PUBLIC
   ControllerManager(
@@ -104,8 +104,8 @@ public:
     const std::vector<std::string> & start_controllers,
     const std::vector<std::string> & stop_controllers,
     int strictness,
-    bool start_asap = WAIT_FOR_ALL_RESOURCES,
-    const rclcpp::Duration & timeout = rclcpp::Duration(INFINITE_TIMEOUT));
+    bool start_asap = kWaitForAllResources,
+    const rclcpp::Duration & timeout = rclcpp::Duration(kInfiniteTimeout));
 
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::return_type
@@ -116,7 +116,7 @@ public:
    * Deterministic (real-time safe) callback group for the update function. Default behavior
    * is read hardware, update controller and finally write new values to the hardware.
    */
-  rclcpp::callback_group::CallbackGroup::SharedPtr deterministic_callback_group_;
+  rclcpp::CallbackGroup::SharedPtr deterministic_callback_group_;
 
 protected:
   CONTROLLER_MANAGER_PUBLIC
@@ -177,7 +177,7 @@ private:
    * Best effort (non real-time safe) callback group for callbacks that can possibly break
    * real-time requirements, for example, service callbacks.
    */
-  rclcpp::callback_group::CallbackGroup::SharedPtr best_effort_callback_group_;
+  rclcpp::CallbackGroup::SharedPtr best_effort_callback_group_;
 
   /**
    * @brief The RTControllerListWrapper class wraps a double-buffered list of controllers

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -113,7 +113,7 @@ public:
 
   /// Deterministic (real-time safe) callback group, e.g., update function.
   /**
-   * @brief Deterministic (real-time safe) callback group for the update function. Default behavior
+   * Deterministic (real-time safe) callback group for the update function. Default behavior
    * is read hardware, update controller and finally write new values to the hardware.
    */
   rclcpp::callback_group::CallbackGroup::SharedPtr deterministic_callback_group_;

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -165,6 +165,11 @@ private:
   std::shared_ptr<rclcpp::Executor> executor_;
   std::shared_ptr<pluginlib::ClassLoader<controller_interface::ControllerInterface>> loader_;
 
+  rclcpp::callback_group::CallbackGroup::SharedPtr realtime_callback_group_;
+  rclcpp::callback_group::CallbackGroup::SharedPtr services_callback_group_;
+
+  rclcpp::TimerBase::SharedPtr timer_;
+
   /**
    * @brief The RTControllerListWrapper class wraps a double-buffered list of controllers
    * to avoid needing to lock the real-time thread when switching controllers in

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -51,7 +51,7 @@ public:
   ControllerManager(
     std::shared_ptr<hardware_interface::RobotHardware> hw,
     std::shared_ptr<rclcpp::Executor> executor,
-    const std::string & name = "controller_manager");
+    const std::string & manager_node_name = "controller_manager");
 
   CONTROLLER_MANAGER_PUBLIC
   virtual

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -64,9 +64,9 @@ ControllerManager::ControllerManager(
       kControllerInterfaceName, kControllerInterface))
 {
   deterministic_callback_group_ = create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   best_effort_callback_group_ = create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+    rclcpp::CallbackGroupType::MutuallyExclusive);
 
   using namespace std::placeholders;
   list_controllers_service_ = create_service<controller_manager_msgs::srv::ListControllers>(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -102,13 +102,16 @@ ControllerManager::ControllerManager(
     rmw_qos_profile_services_default,
     services_callback_group_);
 
-  // TODO(all): Should we declare paramters? #168
+  // TODO(all): Should we declare paramters? #168 - for now yes because of the tests
+  declare_parameter("robot_description", "");
   // load robot_description parameter
   std::string robot_description;
   if (!get_parameter("robot_description", robot_description)) {
     throw std::runtime_error("No robot_description parameter found");
   }
 
+  // Declare default controller manager rate of 100Hz
+  declare_parameter("update_time_ms", 10);
   // load controller_manager update time parameter
   int update_time_ms;
   if (!get_parameter("update_time_ms", update_time_ms)) {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 ROS2-Control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "controller_manager/controller_manager.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  std::shared_ptr<rclcpp::Executor> executor =
+    std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  std::string manager_node_name = "controller_manager";
+
+  auto cm = std::make_shared<controller_manager::ControllerManager>(
+    executor,
+    manager_node_name);
+
+  executor->add_node(cm);
+  executor->spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -16,7 +16,9 @@
 #include <string>
 
 #include "controller_manager/controller_manager.hpp"
+#include "hardware_interface/robot_hardware.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "test_robot_hardware/test_robot_hardware.hpp"
 
 using namespace std::chrono_literals;
 
@@ -24,11 +26,15 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
+
   std::shared_ptr<rclcpp::Executor> executor =
     std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   std::string manager_node_name = "controller_manager";
 
   auto cm = std::make_shared<controller_manager::ControllerManager>(
+    // TODO(anyone): remove robot_hw when ResourceManager is added
+    // since RobotHW is not a plugin we had to take some type of robot
+    std::make_shared<test_robot_hardware::TestRobotHardware>(),
     executor,
     manager_node_name);
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -41,16 +41,16 @@ int main(int argc, char ** argv)
     manager_node_name);
 
   // Declare default controller manager rate of 100Hz
-  cm->declare_parameter("update_time_ms", 10);
+  cm->declare_parameter("update_rate", 100);
   // load controller_manager update time parameter
-  int update_time_ms;
-  if (!cm->get_parameter("update_time_ms", update_time_ms)) {
-    throw std::runtime_error("update_time parameter not existing or empty");
+  int update_rate;
+  if (!cm->get_parameter("update_rate", update_rate)) {
+    throw std::runtime_error("update_rate parameter not existing or empty");
   }
-  RCLCPP_INFO(rclcpp::get_logger(kLoggerName), "update time is %.3f ms", update_time_ms);
+  RCLCPP_INFO(rclcpp::get_logger(kLoggerName), "update rate is %d Hz", update_rate);
 
   timer = cm->create_wall_timer(
-    std::chrono::milliseconds(update_time_ms),
+    std::chrono::milliseconds(1000/update_rate),
     std::bind(&controller_manager::ControllerManager::update, cm.get()),
     cm->deterministic_callback_group_);
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -50,7 +50,7 @@ int main(int argc, char ** argv)
   RCLCPP_INFO(rclcpp::get_logger(kLoggerName), "update rate is %d Hz", update_rate);
 
   timer = cm->create_wall_timer(
-    std::chrono::milliseconds(1000/update_rate),
+    std::chrono::milliseconds(1000 / update_rate),
     std::bind(&controller_manager::ControllerManager::update, cm.get()),
     cm->deterministic_callback_group_);
 

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -29,7 +29,6 @@ TEST_F(TestControllerManager, controller_lifecycle) {
     robot_, executor_,
     "test_controller_manager");
 
-
   auto test_controller = std::make_shared<test_controller::TestController>();
   cm->add_controller(
     test_controller, test_controller::TEST_CONTROLLER_NAME,


### PR DESCRIPTION
rework of #147.

Changes:
* `controller_manager` - callback groups for services and update loop
* `controller_interface` - enable undeclared parameters for now
* `ros2_control_node` - default node - currently is using `TestRobotHardware` to initialize something until `ResourceManager` is compleated