### PR TITLE
rename command/state handles to command/state interfaces

### DIFF
--- a/hardware_interface/include/hardware_interface/components/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/components/actuator.hpp
@@ -45,10 +45,10 @@ public:
   return_type configure(const HardwareInfo & actuator_info);
 
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<StateHandle> export_state_handles();
+  std::vector<StateInterface> export_state_interfaces();
 
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<CommandHandle> export_command_handles();
+  std::vector<CommandInterface> export_command_interfaces();
 
   HARDWARE_INTERFACE_PUBLIC
   return_type start();

--- a/hardware_interface/include/hardware_interface/components/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/components/actuator_interface.hpp
@@ -50,29 +50,29 @@ public:
   virtual
   return_type configure(const HardwareInfo & actuator_info) = 0;
 
-  /// Exports all state handles for this actuator.
+  /// Exports all state interfaces for this actuator.
   /**
-   * The state handles have to be created and transfered according
+   * The state interfaces have to be created and transfered according
    * to the actuator info passed in for the configuration.
    *
-   * Note the ownership over the state handles must be released.
+   * Note the ownership over the state interfaces is transfered to the caller.
    *
-   * \return vector of state handles
+   * \return vector of state interfaces
    */
   virtual
-  std::vector<StateHandle> export_state_handles() = 0;
+  std::vector<StateInterface> export_state_interfaces() = 0;
 
-  /// Exports all command handles for this actuator.
+  /// Exports all command interfaces for this actuator.
   /**
-   * The command handles have to be created and transfered according
+   * The command interfaces have to be created and transfered according
    * to the actuator info passed in for the configuration.
    *
-   * Note the ownership over the command handles must be released.
+   * Note the ownership over the state interfaces is transfered to the caller.
    *
-   * \return vector of command handles
+   * \return vector of command interfaces
    */
   virtual
-  std::vector<CommandHandle> export_command_handles() = 0;
+  std::vector<CommandInterface> export_command_interfaces() = 0;
 
   /**
    * \brief Start exchange data with the hardware.
@@ -101,8 +101,8 @@ public:
   /// Read the current state values from the actuator.
   /**
    * The data readings from the physical hardware has to be updated
-   * and reflected accordingly in the exported state handles.
-   * That is, the data pointed by the handles shall be updated.
+   * and reflected accordingly in the exported state interfaces.
+   * That is, the data pointed by the interfaces shall be updated.
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
@@ -112,7 +112,7 @@ public:
   /// Write the current command values to the actuator.
   /**
    * The physical hardware shall be updated with the latest value from
-   * the exported command handles.
+   * the exported command interfaces.
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */

--- a/hardware_interface/include/hardware_interface/components/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/components/sensor.hpp
@@ -47,7 +47,7 @@ public:
   return_type configure(const HardwareInfo & sensor_info);
 
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<StateHandle> export_state_handles();
+  std::vector<StateInterface> export_state_interfaces();
 
   HARDWARE_INTERFACE_PUBLIC
   return_type start();

--- a/hardware_interface/include/hardware_interface/components/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/components/sensor_interface.hpp
@@ -50,17 +50,17 @@ public:
   virtual
   return_type configure(const HardwareInfo & sensor_info) = 0;
 
-  /// Exports all state handles for this sensor.
+  /// Exports all state interfaces for this sensor.
   /**
-   * The state handles have to be created and transfered according
+   * The state interfaces have to be created and transfered according
    * to the sensor info passed in for the configuration.
    *
-   * Note the ownership over the state handles must be released.
+   * Note the ownership over the state interfaces is transfered to the caller.
    *
-   * \return vector of state handles
+   * \return vector of state interfaces
    */
   virtual
-  std::vector<StateHandle> export_state_handles() = 0;
+  std::vector<StateInterface> export_state_interfaces() = 0;
 
   /**
    * \brief Start exchange data with the hardware.
@@ -89,8 +89,8 @@ public:
   /// Read the current state values from the sensor.
   /**
    * The data readings from the physical hardware has to be updated
-   * and reflected accordingly in the exported state handles.
-   * That is, the data pointed by the handles shall be updated.
+   * and reflected accordingly in the exported state interfaces.
+   * That is, the data pointed by the interfaces shall be updated.
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */

--- a/hardware_interface/include/hardware_interface/components/system.hpp
+++ b/hardware_interface/include/hardware_interface/components/system.hpp
@@ -45,10 +45,10 @@ public:
   return_type configure(const HardwareInfo & system_info);
 
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<StateHandle> export_state_handles();
+  std::vector<StateInterface> export_state_interfaces();
 
   HARDWARE_INTERFACE_PUBLIC
-  std::vector<CommandHandle> export_command_handles();
+  std::vector<CommandInterface> export_command_interfaces();
 
   HARDWARE_INTERFACE_PUBLIC
   return_type start();

--- a/hardware_interface/include/hardware_interface/components/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/components/system_interface.hpp
@@ -51,29 +51,30 @@ public:
   virtual
   return_type configure(const HardwareInfo & system_info) = 0;
 
-  /// Exports all state handles for this system.
+  /// Exports all state interfaces for this system.
   /**
-   * The state handles have to be created and transfered according
+   * The state interfaces have to be created and transfered according
    * to the system info passed in for the configuration.
    *
-   * Note the ownership over the state handles must be released.
+   * Note the ownership over the state interfaces is transfered to the caller.
    *
-   * \return vector of state handles
+   *
+   * \return vector of state interfaces
    */
   virtual
-  std::vector<StateHandle> export_state_handles() = 0;
+  std::vector<StateInterface> export_state_interfaces() = 0;
 
-  /// Exports all command handles for this system.
+  /// Exports all command interfaces for this system.
   /**
-   * The command handles have to be created and transfered according
+   * The command interfaces have to be created and transfered according
    * to the system info passed in for the configuration.
    *
-   * Note the ownership over the command handles must be released.
+   * Note the ownership over the state interfaces is transfered to the caller.
    *
-   * \return vector of command handles
+   * \return vector of command interfaces
    */
   virtual
-  std::vector<CommandHandle> export_command_handles() = 0;
+  std::vector<CommandInterface> export_command_interfaces() = 0;
 
   /**
    * \brief Start exchange data with the hardware.
@@ -102,8 +103,8 @@ public:
   /// Read the current state values from the actuators and sensors within the system.
   /**
    * The data readings from the physical hardware has to be updated
-   * and reflected accordingly in the exported state handles.
-   * That is, the data pointed by the handles shall be updated.
+   * and reflected accordingly in the exported state interfaces.
+   * That is, the data pointed by the interfaces shall be updated.
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
@@ -113,7 +114,7 @@ public:
   /// Write the current command values to the actuator within the system.
   /**
    * The physical hardware shall be updated with the latest value from
-   * the exported command handles.
+   * the exported command interfaces.
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -136,24 +136,24 @@ public:
   }
 };
 
-class StateHandle : public ReadOnlyHandle<StateHandle>
+class StateInterface : public ReadOnlyHandle<StateInterface>
 {
 public:
-  StateHandle(const StateHandle & other) = delete;
+  StateInterface(const StateInterface & other) = delete;
 
-  StateHandle(StateHandle && other) = default;
+  StateInterface(StateInterface && other) = default;
 
-  using ReadOnlyHandle<StateHandle>::ReadOnlyHandle;
+  using ReadOnlyHandle<StateInterface>::ReadOnlyHandle;
 };
 
-class CommandHandle : public ReadWriteHandle<CommandHandle>
+class CommandInterface : public ReadWriteHandle<CommandInterface>
 {
 public:
-  CommandHandle(const CommandHandle & other) = delete;
+  CommandInterface(const CommandInterface & other) = delete;
 
-  CommandHandle(CommandHandle && other) = default;
+  CommandInterface(CommandInterface && other) = default;
 
-  using ReadWriteHandle<CommandHandle>::ReadWriteHandle;
+  using ReadWriteHandle<CommandInterface>::ReadWriteHandle;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/components/actuator.cpp
+++ b/hardware_interface/src/components/actuator.cpp
@@ -40,16 +40,16 @@ return_type Actuator::configure(const HardwareInfo & actuator_info)
   return impl_->configure(actuator_info);
 }
 
-std::vector<StateHandle> Actuator::export_state_handles()
+std::vector<StateInterface> Actuator::export_state_interfaces()
 {
   // TODO(karsten1987): Might be worth to do some brief sanity check here
-  return impl_->export_state_handles();
+  return impl_->export_state_interfaces();
 }
 
-std::vector<CommandHandle> Actuator::export_command_handles()
+std::vector<CommandInterface> Actuator::export_command_interfaces()
 {
   // TODO(karsten1987): Might be worth to do some brief sanity check here
-  return impl_->export_command_handles();
+  return impl_->export_command_interfaces();
 }
 
 return_type Actuator::start()

--- a/hardware_interface/src/components/sensor.cpp
+++ b/hardware_interface/src/components/sensor.cpp
@@ -39,9 +39,9 @@ return_type Sensor::configure(const HardwareInfo & sensor_info)
   return impl_->configure(sensor_info);
 }
 
-std::vector<StateHandle> Sensor::export_state_handles()
+std::vector<StateInterface> Sensor::export_state_interfaces()
 {
-  return impl_->export_state_handles();
+  return impl_->export_state_interfaces();
 }
 
 return_type Sensor::start()

--- a/hardware_interface/src/components/system.cpp
+++ b/hardware_interface/src/components/system.cpp
@@ -39,14 +39,14 @@ return_type System::configure(const HardwareInfo & system_info)
   return impl_->configure(system_info);
 }
 
-std::vector<StateHandle> System::export_state_handles()
+std::vector<StateInterface> System::export_state_interfaces()
 {
-  return impl_->export_state_handles();
+  return impl_->export_state_interfaces();
 }
 
-std::vector<CommandHandle> System::export_command_handles()
+std::vector<CommandInterface> System::export_command_interfaces()
 {
-  return impl_->export_command_handles();
+  return impl_->export_command_interfaces();
 }
 
 return_type System::start()

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -45,26 +45,26 @@ class DummyActuator : public hardware_interface::components::ActuatorInterface
     return hardware_interface::return_type::OK;
   }
 
-  std::vector<hardware_interface::StateHandle> export_state_handles() override
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     // We can read a position and a velocity
-    std::vector<hardware_interface::StateHandle> state_handles;
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint1", "position", &position_state_));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint1", "velocity", &velocity_state_));
+    std::vector<hardware_interface::StateInterface> state_interfaces;
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint1", "position", &position_state_));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint1", "velocity", &velocity_state_));
 
-    return state_handles;
+    return state_interfaces;
   }
 
-  std::vector<hardware_interface::CommandHandle> export_command_handles() override
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     // We can command in velocity
-    std::vector<hardware_interface::CommandHandle> command_handles;
-    command_handles.emplace_back(
-      hardware_interface::CommandHandle("joint1", "velocity", &velocity_command_));
+    std::vector<hardware_interface::CommandInterface> command_interfaces;
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface("joint1", "velocity", &velocity_command_));
 
-    return command_handles;
+    return command_interfaces;
   }
 
   hardware_interface::return_type start() override
@@ -111,14 +111,14 @@ class DummySensor : public hardware_interface::components::SensorInterface
     return hardware_interface::return_type::OK;
   }
 
-  std::vector<hardware_interface::StateHandle> export_state_handles() override
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     // We can read some voltage level
-    std::vector<hardware_interface::StateHandle> state_handles;
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint1", "voltage", &voltage_level_));
+    std::vector<hardware_interface::StateInterface> state_interfaces;
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint1", "voltage", &voltage_level_));
 
-    return state_handles;
+    return state_interfaces;
   }
 
   hardware_interface::return_type start() override
@@ -155,38 +155,38 @@ class DummySystem : public hardware_interface::components::SystemInterface
     return hardware_interface::return_type::OK;
   }
 
-  std::vector<hardware_interface::StateHandle> export_state_handles() override
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     // We can read a position and a velocity
-    std::vector<hardware_interface::StateHandle> state_handles;
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint1", "position", &position_state_[0]));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint1", "velocity", &velocity_state_[0]));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint2", "position", &position_state_[1]));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint2", "velocity", &velocity_state_[1]));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint3", "position", &position_state_[2]));
-    state_handles.emplace_back(
-      hardware_interface::StateHandle("joint3", "velocity", &velocity_state_[2]));
+    std::vector<hardware_interface::StateInterface> state_interfaces;
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint1", "position", &position_state_[0]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint1", "velocity", &velocity_state_[0]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint2", "position", &position_state_[1]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint2", "velocity", &velocity_state_[1]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint3", "position", &position_state_[2]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface("joint3", "velocity", &velocity_state_[2]));
 
-    return state_handles;
+    return state_interfaces;
   }
 
-  std::vector<hardware_interface::CommandHandle> export_command_handles() override
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     // We can command in velocity
-    std::vector<hardware_interface::CommandHandle> command_handles;
-    command_handles.emplace_back(
-      hardware_interface::CommandHandle("joint1", "velocity", &velocity_command_[0]));
-    command_handles.emplace_back(
-      hardware_interface::CommandHandle("joint2", "velocity", &velocity_command_[1]));
-    command_handles.emplace_back(
-      hardware_interface::CommandHandle("joint3", "velocity", &velocity_command_[2]));
+    std::vector<hardware_interface::CommandInterface> command_interfaces;
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface("joint1", "velocity", &velocity_command_[0]));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface("joint2", "velocity", &velocity_command_[1]));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface("joint3", "velocity", &velocity_command_[2]));
 
-    return command_handles;
+    return command_interfaces;
   }
 
   hardware_interface::return_type start() override
@@ -235,26 +235,26 @@ TEST(TestComponentInterfaces, dummy_actuator)
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, actuator_hw.configure(mock_hw_info));
 
-  auto state_handles = actuator_hw.export_state_handles();
-  ASSERT_EQ(2u, state_handles.size());
-  EXPECT_EQ("joint1", state_handles[0].get_name());
-  EXPECT_EQ("position", state_handles[0].get_interface_name());
-  EXPECT_EQ("joint1", state_handles[1].get_name());
-  EXPECT_EQ("velocity", state_handles[1].get_interface_name());
+  auto state_interfaces = actuator_hw.export_state_interfaces();
+  ASSERT_EQ(2u, state_interfaces.size());
+  EXPECT_EQ("joint1", state_interfaces[0].get_name());
+  EXPECT_EQ("position", state_interfaces[0].get_interface_name());
+  EXPECT_EQ("joint1", state_interfaces[1].get_name());
+  EXPECT_EQ("velocity", state_interfaces[1].get_interface_name());
 
-  auto command_handles = actuator_hw.export_command_handles();
-  ASSERT_EQ(1u, command_handles.size());
-  EXPECT_EQ("joint1", command_handles[0].get_name());
-  EXPECT_EQ("velocity", command_handles[0].get_interface_name());
+  auto command_interfaces = actuator_hw.export_command_interfaces();
+  ASSERT_EQ(1u, command_interfaces.size());
+  EXPECT_EQ("joint1", command_interfaces[0].get_name());
+  EXPECT_EQ("velocity", command_interfaces[0].get_interface_name());
 
-  command_handles[0].set_value(1.0);  // velocity
+  command_interfaces[0].set_value(1.0);  // velocity
   ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.write());
 
   for (auto step = 1u; step <= 10; ++step) {
     ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.read());
 
-    ASSERT_EQ(step, state_handles[0].get_value());  // position value
-    ASSERT_EQ(1u, state_handles[1].get_value());  // velocity
+    ASSERT_EQ(step, state_interfaces[0].get_value());  // position value
+    ASSERT_EQ(1u, state_interfaces[1].get_value());  // velocity
 
     ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.write());
   }
@@ -268,11 +268,11 @@ TEST(TestComponentInterfaces, dummy_sensor)
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, sensor_hw.configure(mock_hw_info));
 
-  auto state_handles = sensor_hw.export_state_handles();
-  ASSERT_EQ(1u, state_handles.size());
-  EXPECT_EQ("joint1", state_handles[0].get_name());
-  EXPECT_EQ("voltage", state_handles[0].get_interface_name());
-  EXPECT_EQ(0x666, state_handles[0].get_value());
+  auto state_interfaces = sensor_hw.export_state_interfaces();
+  ASSERT_EQ(1u, state_interfaces.size());
+  EXPECT_EQ("joint1", state_interfaces[0].get_name());
+  EXPECT_EQ("voltage", state_interfaces[0].get_interface_name());
+  EXPECT_EQ(0x666, state_interfaces[0].get_value());
 }
 
 TEST(TestComponentInterfaces, dummy_system)
@@ -283,44 +283,44 @@ TEST(TestComponentInterfaces, dummy_system)
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, system_hw.configure(mock_hw_info));
 
-  auto state_handles = system_hw.export_state_handles();
-  ASSERT_EQ(6u, state_handles.size());
-  EXPECT_EQ("joint1", state_handles[0].get_name());
-  EXPECT_EQ("position", state_handles[0].get_interface_name());
-  EXPECT_EQ("joint1", state_handles[1].get_name());
-  EXPECT_EQ("velocity", state_handles[1].get_interface_name());
-  EXPECT_EQ("joint2", state_handles[2].get_name());
-  EXPECT_EQ("position", state_handles[2].get_interface_name());
-  EXPECT_EQ("joint2", state_handles[3].get_name());
-  EXPECT_EQ("velocity", state_handles[3].get_interface_name());
-  EXPECT_EQ("joint3", state_handles[4].get_name());
-  EXPECT_EQ("position", state_handles[4].get_interface_name());
-  EXPECT_EQ("joint3", state_handles[5].get_name());
-  EXPECT_EQ("velocity", state_handles[5].get_interface_name());
+  auto state_interfaces = system_hw.export_state_interfaces();
+  ASSERT_EQ(6u, state_interfaces.size());
+  EXPECT_EQ("joint1", state_interfaces[0].get_name());
+  EXPECT_EQ("position", state_interfaces[0].get_interface_name());
+  EXPECT_EQ("joint1", state_interfaces[1].get_name());
+  EXPECT_EQ("velocity", state_interfaces[1].get_interface_name());
+  EXPECT_EQ("joint2", state_interfaces[2].get_name());
+  EXPECT_EQ("position", state_interfaces[2].get_interface_name());
+  EXPECT_EQ("joint2", state_interfaces[3].get_name());
+  EXPECT_EQ("velocity", state_interfaces[3].get_interface_name());
+  EXPECT_EQ("joint3", state_interfaces[4].get_name());
+  EXPECT_EQ("position", state_interfaces[4].get_interface_name());
+  EXPECT_EQ("joint3", state_interfaces[5].get_name());
+  EXPECT_EQ("velocity", state_interfaces[5].get_interface_name());
 
-  auto command_handles = system_hw.export_command_handles();
-  ASSERT_EQ(3u, command_handles.size());
-  EXPECT_EQ("joint1", command_handles[0].get_name());
-  EXPECT_EQ("velocity", command_handles[0].get_interface_name());
-  EXPECT_EQ("joint2", command_handles[1].get_name());
-  EXPECT_EQ("velocity", command_handles[1].get_interface_name());
-  EXPECT_EQ("joint3", command_handles[2].get_name());
-  EXPECT_EQ("velocity", command_handles[2].get_interface_name());
+  auto command_interfaces = system_hw.export_command_interfaces();
+  ASSERT_EQ(3u, command_interfaces.size());
+  EXPECT_EQ("joint1", command_interfaces[0].get_name());
+  EXPECT_EQ("velocity", command_interfaces[0].get_interface_name());
+  EXPECT_EQ("joint2", command_interfaces[1].get_name());
+  EXPECT_EQ("velocity", command_interfaces[1].get_interface_name());
+  EXPECT_EQ("joint3", command_interfaces[2].get_name());
+  EXPECT_EQ("velocity", command_interfaces[2].get_interface_name());
 
-  command_handles[0].set_value(1.0);  // velocity
-  command_handles[1].set_value(1.0);  // velocity
-  command_handles[2].set_value(1.0);  // velocity
+  command_interfaces[0].set_value(1.0);  // velocity
+  command_interfaces[1].set_value(1.0);  // velocity
+  command_interfaces[2].set_value(1.0);  // velocity
   ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write());
 
   for (auto step = 1u; step <= 10; ++step) {
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read());
 
-    ASSERT_EQ(step, state_handles[0].get_value());  // position value
-    ASSERT_EQ(1u, state_handles[1].get_value());  // velocity
-    ASSERT_EQ(step, state_handles[2].get_value());  // position value
-    ASSERT_EQ(1u, state_handles[3].get_value());  // velocity
-    ASSERT_EQ(step, state_handles[4].get_value());  // position value
-    ASSERT_EQ(1u, state_handles[5].get_value());  // velocity
+    ASSERT_EQ(step, state_interfaces[0].get_value());  // position value
+    ASSERT_EQ(1u, state_interfaces[1].get_value());  // velocity
+    ASSERT_EQ(step, state_interfaces[2].get_value());  // position value
+    ASSERT_EQ(1u, state_interfaces[3].get_value());  // velocity
+    ASSERT_EQ(step, state_interfaces[4].get_value());  // position value
+    ASSERT_EQ(1u, state_interfaces[5].get_value());  // velocity
 
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write());
   }

--- a/hardware_interface/test/test_joint_handle.cpp
+++ b/hardware_interface/test/test_joint_handle.cpp
@@ -16,8 +16,8 @@
 #include "hardware_interface/joint_handle.hpp"
 
 using hardware_interface::JointHandle;
-using hardware_interface::CommandHandle;
-using hardware_interface::StateHandle;
+using hardware_interface::CommandInterface;
+using hardware_interface::StateInterface;
 
 namespace
 {
@@ -25,21 +25,21 @@ constexpr auto JOINT_NAME = "joint_1";
 constexpr auto FOO_INTERFACE = "FooInterface";
 }  // namespace
 
-TEST(TestJointHandle, command_handle)
+TEST(TestJointHandle, command_interface)
 {
   double value = 1.337;
-  CommandHandle handle{JOINT_NAME, FOO_INTERFACE, &value};
-  EXPECT_DOUBLE_EQ(handle.get_value(), value);
-  EXPECT_NO_THROW(handle.set_value(0.0));
-  EXPECT_DOUBLE_EQ(handle.get_value(), 0.0);
+  CommandInterface interface{JOINT_NAME, FOO_INTERFACE, &value};
+  EXPECT_DOUBLE_EQ(interface.get_value(), value);
+  EXPECT_NO_THROW(interface.set_value(0.0));
+  EXPECT_DOUBLE_EQ(interface.get_value(), 0.0);
 }
 
-TEST(TestJointHandle, state_handle)
+TEST(TestJointHandle, state_interface)
 {
   double value = 1.337;
-  StateHandle handle{JOINT_NAME, FOO_INTERFACE, &value};
-  EXPECT_DOUBLE_EQ(handle.get_value(), value);
-  // handle.set_value(5);  compiler error, no set_value function
+  StateInterface interface{JOINT_NAME, FOO_INTERFACE, &value};
+  EXPECT_DOUBLE_EQ(interface.get_value(), value);
+  // interface.set_value(5);  compiler error, no set_value function
 }
 
 TEST(TestJointHandle, name_getters_work)


### PR DESCRIPTION
fixes #201 

as per title, the command and state handles are renamed to match the nomenclature of the URDF.

