### PR TITLE
Add missing urdf dependency to urdf test

### DIFF
--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
   target_include_directories(joint_limits_urdf_test PUBLIC include)
-  ament_target_dependencies(joint_limits_urdf_test rclcpp)
+  ament_target_dependencies(joint_limits_urdf_test rclcpp urdf)
 endif()
 
 # Install headers


### PR DESCRIPTION
Added `urdf` dependency to `joint_limits_urdf_test` build.

This addresses the issue reported in #232 which leads to the `joint_limits_interface` package build failing.