### PR TITLE
Add ros2 components package

### DIFF
--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -17,13 +17,9 @@
 
 namespace hardware_interface
 {
-/// Constant defining position interface
 constexpr const auto HW_IF_POSITION = "position";
-/// Constant defining velocity interface
 constexpr const auto HW_IF_VELOCITY = "velocity";
-/// Constant defining effort interface
 constexpr const auto HW_IF_EFFORT = "effort";
-
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -17,9 +17,13 @@
 
 namespace hardware_interface
 {
+/// Constant defining position interface
 constexpr const auto HW_IF_POSITION = "position";
+/// Constant defining velocity interface
 constexpr const auto HW_IF_VELOCITY = "velocity";
+/// Constant defining effort interface
 constexpr const auto HW_IF_EFFORT = "effort";
+
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_

--- a/ros2_control/package.xml
+++ b/ros2_control/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>controller_interface</exec_depend>
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>ros2_control_components</exec_depend>
   <exec_depend>transmission_interface</exec_depend>
   <exec_depend>joint_limits_interface</exec_depend>
 

--- a/ros2_control_components/CMakeLists.txt
+++ b/ros2_control_components/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_control_components)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(hardware_interface REQUIRED)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(
+  include
+)
+ament_export_dependencies(
+  hardware_interface
+)
+ament_package()

--- a/ros2_control_components/include/ros2_control_components/base_interface.hpp
+++ b/ros2_control_components/include/ros2_control_components/base_interface.hpp
@@ -15,6 +15,8 @@
 #ifndef ROS2_CONTROL_COMPONENTS__BASE_INTERFACE_HPP_
 #define ROS2_CONTROL_COMPONENTS__BASE_INTERFACE_HPP_
 
+#include <string>
+
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_status_values.hpp"
 

--- a/ros2_control_components/include/ros2_control_components/base_interface.hpp
+++ b/ros2_control_components/include/ros2_control_components/base_interface.hpp
@@ -1,0 +1,52 @@
+// Copyright 2020 ROS2-Control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_CONTROL_COMPONENTS__BASE_INTERFACE_HPP_
+#define ROS2_CONTROL_COMPONENTS__BASE_INTERFACE_HPP_
+
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+
+namespace ros2_control_components
+{
+
+template<class InterfaceType>
+class BaseInterface : public InterfaceType
+{
+public:
+  hardware_interface::return_type configure(const hardware_interface::HardwareInfo & info) override
+  {
+    info_ = info;
+    status_ = hardware_interface::status::CONFIGURED;
+    return hardware_interface::return_type::OK;
+  }
+
+  std::string get_name() const
+  {
+    return info_.name;
+  }
+
+  hardware_interface::status get_status() const final
+  {
+    return status_;
+  }
+
+protected:
+  hardware_interface::HardwareInfo info_;
+  hardware_interface::status status_;
+};
+
+}  // namespace ros2_control_components
+
+#endif  // ROS2_CONTROL_COMPONENTS__BASE_INTERFACE_HPP_

--- a/ros2_control_components/package.xml
+++ b/ros2_control_components/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_control_components</name>
+  <version>0.0.1</version>
+  <description>The package implements control components, i.e., joints and sensors, the logical building blocks of ros2_control system.
+  </description>
+  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
+  <license>Apache License 2.0</license>
+
+  <depend>hardware_interface</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
The package adds default functionality for components introducing an additional layer.

This should replace #180 using new components design from #207.

It creates package mentioned in #219.