### PR TITLE
Use constants instead of strings in tests

### DIFF
--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -22,7 +22,7 @@ constexpr const auto HW_IF_POSITION = "position";
 /// Constant defining velocity interface
 constexpr const auto HW_IF_VELOCITY = "velocity";
 /// Constant defining acceleration interface
-constexpr const auto HW_IF_EFFORT = "acceleration";
+constexpr const auto HW_IF_ACCELERATION = "acceleration";
 /// Constant defining effort interface
 constexpr const auto HW_IF_EFFORT = "effort";
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -17,8 +17,13 @@
 
 namespace hardware_interface
 {
+/// Constant defining position interface
 constexpr const auto HW_IF_POSITION = "position";
+/// Constant defining velocity interface
 constexpr const auto HW_IF_VELOCITY = "velocity";
+/// Constant defining acceleration interface
+constexpr const auto HW_IF_EFFORT = "acceleration";
+/// Constant defining effort interface
 constexpr const auto HW_IF_EFFORT = "effort";
 }  // namespace hardware_interface
 

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -50,9 +50,11 @@ class DummyActuator : public hardware_interface::components::ActuatorInterface
     // We can read a position and a velocity
     std::vector<hardware_interface::StateInterface> state_interfaces;
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint1", "position", &position_state_));
+      hardware_interface::StateInterface(
+        "joint1", hardware_interface::HW_IF_POSITION, &position_state_));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint1", "velocity", &velocity_state_));
+      hardware_interface::StateInterface(
+        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_));
 
     return state_interfaces;
   }
@@ -62,7 +64,8 @@ class DummyActuator : public hardware_interface::components::ActuatorInterface
     // We can command in velocity
     std::vector<hardware_interface::CommandInterface> command_interfaces;
     command_interfaces.emplace_back(
-      hardware_interface::CommandInterface("joint1", "velocity", &velocity_command_));
+      hardware_interface::CommandInterface(
+        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_));
 
     return command_interfaces;
   }
@@ -160,17 +163,23 @@ class DummySystem : public hardware_interface::components::SystemInterface
     // We can read a position and a velocity
     std::vector<hardware_interface::StateInterface> state_interfaces;
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint1", "position", &position_state_[0]));
+      hardware_interface::StateInterface(
+        "joint1", hardware_interface::HW_IF_POSITION, &position_state_[0]));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint1", "velocity", &velocity_state_[0]));
+      hardware_interface::StateInterface(
+        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_[0]));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint2", "position", &position_state_[1]));
+      hardware_interface::StateInterface(
+        "joint2", hardware_interface::HW_IF_POSITION, &position_state_[1]));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint2", "velocity", &velocity_state_[1]));
+      hardware_interface::StateInterface(
+        "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_state_[1]));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint3", "position", &position_state_[2]));
+      hardware_interface::StateInterface(
+        "joint3", hardware_interface::HW_IF_POSITION, &position_state_[2]));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface("joint3", "velocity", &velocity_state_[2]));
+      hardware_interface::StateInterface(
+        "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_state_[2]));
 
     return state_interfaces;
   }
@@ -180,11 +189,14 @@ class DummySystem : public hardware_interface::components::SystemInterface
     // We can command in velocity
     std::vector<hardware_interface::CommandInterface> command_interfaces;
     command_interfaces.emplace_back(
-      hardware_interface::CommandInterface("joint1", "velocity", &velocity_command_[0]));
+      hardware_interface::CommandInterface(
+        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_[0]));
     command_interfaces.emplace_back(
-      hardware_interface::CommandInterface("joint2", "velocity", &velocity_command_[1]));
+      hardware_interface::CommandInterface(
+        "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_command_[1]));
     command_interfaces.emplace_back(
-      hardware_interface::CommandInterface("joint3", "velocity", &velocity_command_[2]));
+      hardware_interface::CommandInterface(
+        "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_command_[2]));
 
     return command_interfaces;
   }
@@ -238,14 +250,14 @@ TEST(TestComponentInterfaces, dummy_actuator)
   auto state_interfaces = actuator_hw.export_state_interfaces();
   ASSERT_EQ(2u, state_interfaces.size());
   EXPECT_EQ("joint1", state_interfaces[0].get_name());
-  EXPECT_EQ("position", state_interfaces[0].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_POSITION, state_interfaces[0].get_interface_name());
   EXPECT_EQ("joint1", state_interfaces[1].get_name());
-  EXPECT_EQ("velocity", state_interfaces[1].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, state_interfaces[1].get_interface_name());
 
   auto command_interfaces = actuator_hw.export_command_interfaces();
   ASSERT_EQ(1u, command_interfaces.size());
   EXPECT_EQ("joint1", command_interfaces[0].get_name());
-  EXPECT_EQ("velocity", command_interfaces[0].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, command_interfaces[0].get_interface_name());
 
   command_interfaces[0].set_value(1.0);  // velocity
   ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.write());
@@ -286,26 +298,26 @@ TEST(TestComponentInterfaces, dummy_system)
   auto state_interfaces = system_hw.export_state_interfaces();
   ASSERT_EQ(6u, state_interfaces.size());
   EXPECT_EQ("joint1", state_interfaces[0].get_name());
-  EXPECT_EQ("position", state_interfaces[0].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_POSITION, state_interfaces[0].get_interface_name());
   EXPECT_EQ("joint1", state_interfaces[1].get_name());
-  EXPECT_EQ("velocity", state_interfaces[1].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, state_interfaces[1].get_interface_name());
   EXPECT_EQ("joint2", state_interfaces[2].get_name());
-  EXPECT_EQ("position", state_interfaces[2].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_POSITION, state_interfaces[2].get_interface_name());
   EXPECT_EQ("joint2", state_interfaces[3].get_name());
-  EXPECT_EQ("velocity", state_interfaces[3].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, state_interfaces[3].get_interface_name());
   EXPECT_EQ("joint3", state_interfaces[4].get_name());
-  EXPECT_EQ("position", state_interfaces[4].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_POSITION, state_interfaces[4].get_interface_name());
   EXPECT_EQ("joint3", state_interfaces[5].get_name());
-  EXPECT_EQ("velocity", state_interfaces[5].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, state_interfaces[5].get_interface_name());
 
   auto command_interfaces = system_hw.export_command_interfaces();
   ASSERT_EQ(3u, command_interfaces.size());
   EXPECT_EQ("joint1", command_interfaces[0].get_name());
-  EXPECT_EQ("velocity", command_interfaces[0].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, command_interfaces[0].get_interface_name());
   EXPECT_EQ("joint2", command_interfaces[1].get_name());
-  EXPECT_EQ("velocity", command_interfaces[1].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, command_interfaces[1].get_interface_name());
   EXPECT_EQ("joint3", command_interfaces[2].get_name());
-  EXPECT_EQ("velocity", command_interfaces[2].get_interface_name());
+  EXPECT_EQ(hardware_interface::HW_IF_VELOCITY, command_interfaces[2].get_interface_name());
 
   command_interfaces[0].set_value(1.0);  // velocity
   command_interfaces[1].set_value(1.0);  // velocity

--- a/hardware_interface/test/test_components/test_system.cpp
+++ b/hardware_interface/test/test_components/test_system.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <vector>
 
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "hardware_interface/components/system_interface.hpp"
 
 using hardware_interface::status;
@@ -37,13 +38,14 @@ class TestSystem : public hardware_interface::components::SystemInterface
     for (auto i = 0u; i < system_info_.joints.size(); ++i) {
       state_interfaces.emplace_back(
         hardware_interface::StateInterface(
-          system_info_.joints[i].name, "position", &position_state_[i]));
+          system_info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
       state_interfaces.emplace_back(
         hardware_interface::StateInterface(
-          system_info_.joints[i].name, "velocity", &velocity_state_[i]));
+          system_info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
       state_interfaces.emplace_back(
         hardware_interface::StateInterface(
-          system_info_.joints[i].name, "acceleration", &acceleration_state_[i]));
+          system_info_.joints[i].name,
+          hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
     }
 
     return state_interfaces;
@@ -55,7 +57,7 @@ class TestSystem : public hardware_interface::components::SystemInterface
     for (auto i = 0u; i < system_info_.joints.size(); ++i) {
       command_interfaces.emplace_back(
         hardware_interface::CommandInterface(
-          system_info_.joints[i].name, "velocity", &velocity_command_[i]));
+          system_info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
     }
 
     return command_interfaces;


### PR DESCRIPTION
For the "standard" interfaces we should provide constants and use them, so that people also see that and use them also.
This can hopefully reduce typos in used strings.