### PR TITLE
WIP: Configurable load_controller target_state

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -57,11 +57,19 @@ public:
   virtual
   ~ControllerManager() = default;
 
+  /**
+   * @brief load_controller Create a controller instance and change its lifecycle state
+   * @param controller_name
+   * @param controller_type pluginlib type of controller
+   * @param target_state target lifecycle state, only valid UNCONFIGURED, INACTIVE and ACTIVE
+   */
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceSharedPtr
   load_controller(
     const std::string & controller_name,
-    const std::string & controller_type);
+    const std::string & controller_type,
+    const lifecycle_msgs::msg::State & target_state = lifecycle_msgs::msg::State().set__id(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE));
 
   /**
    * @brief load_controller loads a controller by name, the type must be defined in the parameter server
@@ -69,7 +77,8 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceSharedPtr
   load_controller(
-    const std::string & controller_name);
+    const std::string & controller_name,
+    const lifecycle_msgs::msg::State & target_state);
 
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::return_type unload_controller(
@@ -85,13 +94,14 @@ public:
   controller_interface::ControllerInterfaceSharedPtr
   add_controller(
     std::shared_ptr<T> controller, const std::string & controller_name,
-    const std::string & controller_type)
+    const std::string & controller_type,
+    const lifecycle_msgs::msg::State & target_state)
   {
     ControllerSpec controller_spec;
     controller_spec.c = controller;
     controller_spec.info.name = controller_name;
     controller_spec.info.type = controller_type;
-    return add_controller_impl(controller_spec);
+    return add_controller_impl(controller_spec, target_state);
   }
 
   /**
@@ -114,7 +124,9 @@ public:
 protected:
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::ControllerInterfaceSharedPtr
-  add_controller_impl(const ControllerSpec & controller);
+  add_controller_impl(
+    const ControllerSpec & controller,
+    const lifecycle_msgs::msg::State & target_state);
 
   CONTROLLER_MANAGER_PUBLIC
   void manage_switch();

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -30,10 +30,12 @@ TEST_F(TestControllerManager, controller_lifecycle) {
     "test_controller_manager");
 
 
+  lifecycle_msgs::msg::State target_state;
+  target_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
   auto test_controller = std::make_shared<test_controller::TestController>();
   cm->add_controller(
     test_controller, test_controller::TEST_CONTROLLER_NAME,
-    test_controller::TEST_CONTROLLER_TYPE);
+    test_controller::TEST_CONTROLLER_TYPE, target_state);
   EXPECT_EQ(1u, cm->get_loaded_controllers().size());
   EXPECT_EQ(2, test_controller.use_count());
 

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -135,9 +135,11 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
     result->controller.size());
 
   auto test_controller = std::make_shared<test_controller::TestController>();
+  lifecycle_msgs::msg::State target_state;
+  target_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
   auto abstract_test_controller = cm_->add_controller(
     test_controller, test_controller::TEST_CONTROLLER_NAME,
-    test_controller::TEST_CONTROLLER_TYPE);
+    test_controller::TEST_CONTROLLER_TYPE, target_state);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(
@@ -285,6 +287,7 @@ TEST_F(TestControllerManagerSrvs, load_controller_srv) {
 
   auto request = std::make_shared<controller_manager_msgs::srv::LoadController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
+  request->target_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
   auto result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "There's no param specifying the type for " << request->name;
   rclcpp::Parameter joint_parameters(std::string(test_controller::TEST_CONTROLLER_NAME) + ".type",
@@ -308,9 +311,12 @@ TEST_F(TestControllerManagerSrvs, unload_controller_srv) {
   ASSERT_FALSE(result->ok) << "Controller not loaded: " << request->name;
 
   auto test_controller = std::make_shared<test_controller::TestController>();
+  lifecycle_msgs::msg::State target_state;
+  target_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
   auto abstract_test_controller = cm_->add_controller(
     test_controller, test_controller::TEST_CONTROLLER_NAME,
-    test_controller::TEST_CONTROLLER_TYPE);
+    test_controller::TEST_CONTROLLER_TYPE,
+    target_state);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
 
   result = call_service_and_wait(*client, request, srv_executor, true);

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -51,8 +51,6 @@ TEST_F(TestControllerManager, load1_known_controller)
   controller_manager::ControllerSpec abstract_test_controller =
     cm.get_loaded_controllers()[0];
 
-  auto lifecycle_node = abstract_test_controller.c->get_lifecycle_node();
-  lifecycle_node->configure();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     abstract_test_controller.c->get_lifecycle_node()->get_current_state().id());
@@ -71,7 +69,6 @@ TEST_F(TestControllerManager, load2_known_controller)
     cm.get_loaded_controllers()[0];
   EXPECT_STREQ(
     controller_name1.c_str(), abstract_test_controller1.c->get_lifecycle_node()->get_name());
-  abstract_test_controller1.c->get_lifecycle_node()->configure();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
@@ -86,7 +83,6 @@ TEST_F(TestControllerManager, load2_known_controller)
     controller_name2.c_str(), abstract_test_controller2.c->get_lifecycle_node()->get_name());
   EXPECT_STREQ(
     controller_name2.c_str(), abstract_test_controller2.info.name.c_str());
-  abstract_test_controller2.c->get_lifecycle_node()->configure();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
@@ -122,8 +118,6 @@ TEST_F(TestControllerManager, update)
   controller_manager::ControllerSpec abstract_test_controller =
     cm.get_loaded_controllers()[0];
 
-  auto lifecycle_node = abstract_test_controller.c->get_lifecycle_node();
-  lifecycle_node->configure();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     abstract_test_controller.c->get_lifecycle_node()->get_current_state().id());

--- a/controller_manager_msgs/CMakeLists.txt
+++ b/controller_manager_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 
 set(msg_files
   msg/ControllerState.msg
@@ -34,7 +35,7 @@ endif()
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces
+  DEPENDENCIES builtin_interfaces lifecycle_msgs
   ADD_LINTER_TESTS
 )
 ament_export_dependencies(rosidl_default_runtime)

--- a/controller_manager_msgs/package.xml
+++ b/controller_manager_msgs/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>builtin_interfaces</build_depend>
+  <build_depend>lifecycle_msgs</build_depend>
 
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/controller_manager_msgs/srv/LoadController.srv
+++ b/controller_manager_msgs/srv/LoadController.srv
@@ -5,6 +5,11 @@
 # The return value "ok" indicates if the controller was successfully
 # constructed and initialized or not.
 
+# target_state specify in which lifecycle state the controller should 
+# be left after loading
+# The only valid options are:
+# PRIMARY_STATE_UNCONFIGURED, PRIMARY_STATE_INACTIVE and PRIMARY_STATE_ACTIVE
 string name
+lifecycle_msgs/State target_state
 ---
 bool ok

--- a/ros2controlcli/package.xml
+++ b/ros2controlcli/package.xml
@@ -14,6 +14,7 @@
   <depend>ros2node</depend>
   <depend>ros2param</depend>
   <depend>controller_manager_msgs</depend>
+  <depend>lifecycle_msgs</depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ros2controlcli/ros2controlcli/api/__init__.py
+++ b/ros2controlcli/ros2controlcli/api/__init__.py
@@ -19,6 +19,7 @@ import rclpy
 from ros2cli.node.direct import DirectNode
 from ros2node.api import NodeNameCompleter
 from ros2param.api import call_list_parameters
+from lifecycle_msgs.msg import State
 
 
 def service_caller(service_name, service_type, request):
@@ -71,9 +72,15 @@ def reload_controller_libraries(controller_manager_name, force_kill):
         request)
 
 
-def load_controller(controller_manager_name, controller_name):
+def load_controller(controller_manager_name, controller_name, target_state):
     request = LoadController.Request()
     request.name = controller_name
+    if target_state == "unconfigured":
+        request.target_state = State(id=State.PRIMARY_STATE_UNCONFIGURED)
+    elif target_state == "inactive":
+        request.target_state = State(id=State.PRIMARY_STATE_INACTIVE)
+    elif target_state == "active":
+        request.target_state = State(id=State.PRIMARY_STATE_ACTIVE)
     return service_caller('{}/load_controller'.format(controller_manager_name),
                           LoadController, request)
 

--- a/ros2controlcli/ros2controlcli/verb/load.py
+++ b/ros2controlcli/ros2controlcli/verb/load.py
@@ -25,8 +25,12 @@ class LoadVerb(VerbExtension):
         arg = parser.add_argument(
             'controller_name', help='Name of the controller')
         arg.completer = ControllerNameCompleter()
+        arg = parser.add_argument(
+            '--target_state', help='Target state of the controller after loading',
+            choices=['unconfigured', 'inactive', 'active'], default='inactive', required=False)
         add_controller_mgr_parsers(parser)
 
     def main(self, *, args):
-        response = load_controller(args.controller_manager, args.controller_name)
+        response = load_controller(args.controller_manager, args.controller_name,
+                                   args.target_state)
         return response.ok


### PR DESCRIPTION
Added the option to specify the state of the controller after loading. 
Also added cli options.

For cli there are two implementations that I like.

The current one that can be used as:
`ros2 control load left_arm_controller --target_state inactive` 
As well as the default behavior:
`ros2 control load left_arm_controller` 

The second option is to make the target state argument mandatory:
`ros2 control load left_arm_controller inactive` 