### PR TITLE
Remove set_value(value, name) from ReadWriteHandle

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -120,20 +120,6 @@ public:
     THROW_ON_NULLPTR(this->value_ptr_);
     *this->value_ptr_ = value;
   }
-
-  void set_value(const std::string & name, double value)
-  {
-    THROW_ON_NULLPTR(this->value_ptr_);
-    this->name_ = name;
-    *this->value_ptr_ = value;
-  }
-
-  void set_value(const char * name, double value)
-  {
-    THROW_ON_NULLPTR(this->value_ptr_);
-    this->name_ = name;
-    *this->value_ptr_ = value;
-  }
 };
 
 class StateInterface : public ReadOnlyHandle<StateInterface>


### PR DESCRIPTION
Resolves #222 

These were added for `joint_limits_interface` but are a little messy in this new API. We'll rework `joint_limits_interface` with it's own handles, similarly to transmissions where this API can be allowed.