### PR TITLE
Remove lifecycle node

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -25,7 +25,7 @@
 #include "hardware_interface/loaned_state_interface.hpp"
 
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
 namespace controller_interface
 {
@@ -93,13 +93,41 @@ public:
   update() = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode>
-  get_lifecycle_node();
+  std::shared_ptr<rclcpp::Node>
+  get_node();
+
+  /**
+   * The methods below are a substitute to the LifecycleNode methods with the same name.
+   * We cannot use a LifecycleNode because it would expose the possiblity of changing the state
+   * the rest of the ROS system by exposing the change state service.
+   * Changing state of a controller means having been assigned interfaces by the ResourceManager,
+   * and only the ControllerManager should have the possibility of doing it.
+   *
+   * Hopefully in the future we can use a LifecycleNode where we disable modifications from the outside.
+   */
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & configure();
+
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & cleanup();
+
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & deactivate();
+
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & activate();
+
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & shutdown();
+
+  CONTROLLER_INTERFACE_PUBLIC
+  const rclcpp_lifecycle::State & get_current_state() const;
 
 protected:
   std::vector<hardware_interface::LoanedCommandInterface> command_interfaces_;
   std::vector<hardware_interface::LoanedStateInterface> state_interfaces_;
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> lifecycle_node_;
+  std::shared_ptr<rclcpp::Node> node_;
+  rclcpp_lifecycle::State lifecycle_state_;
 };
 
 using ControllerInterfaceSharedPtr = std::shared_ptr<ControllerInterface>;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -98,10 +98,9 @@ public:
 
   /**
    * The methods below are a substitute to the LifecycleNode methods with the same name.
-   * We cannot use a LifecycleNode because it would expose the possiblity of changing the state
-   * the rest of the ROS system by exposing the change state service.
-   * Changing state of a controller means having been assigned interfaces by the ResourceManager,
-   * and only the ControllerManager should have the possibility of doing it.
+   * We cannot use a LifecycleNode because it would expose change
+   * state services to the rest of the ROS system.
+   * Only the Controller Manager should have possibility to change state of s controller.
    *
    * Hopefully in the future we can use a LifecycleNode where we disable modifications from the outside.
    */

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -23,6 +23,7 @@
 
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -33,57 +33,96 @@ ControllerInterface::init(const std::string & controller_name)
   return return_type::SUCCESS;
 }
 
-
 const rclcpp_lifecycle::State & ControllerInterface::configure()
 {
-  if (on_configure(lifecycle_state_) == LifecycleNodeInterface::CallbackReturn::SUCCESS) {
-    lifecycle_state_ = rclcpp_lifecycle::State(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      "inactive");
+  switch (on_configure(lifecycle_state_)) {
+    case LifecycleNodeInterface::CallbackReturn::SUCCESS:
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+        "inactive");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::ERROR:
+      on_error(lifecycle_state_);
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::FAILURE:
+      break;
   }
   return lifecycle_state_;
 }
 
 const rclcpp_lifecycle::State & ControllerInterface::cleanup()
 {
-  if (on_cleanup(lifecycle_state_) == LifecycleNodeInterface::CallbackReturn::SUCCESS) {
-    lifecycle_state_ = rclcpp_lifecycle::State(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+  switch (on_cleanup(lifecycle_state_)) {
+    case LifecycleNodeInterface::CallbackReturn::SUCCESS:
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::ERROR:
+      on_error(lifecycle_state_);
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::FAILURE:
+      break;
   }
   return lifecycle_state_;
 }
-
 const rclcpp_lifecycle::State & ControllerInterface::deactivate()
 {
-  if (on_deactivate(lifecycle_state_) == LifecycleNodeInterface::CallbackReturn::SUCCESS) {
-    lifecycle_state_ = rclcpp_lifecycle::State(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      "inactive");
+  switch (on_deactivate(lifecycle_state_)) {
+    case LifecycleNodeInterface::CallbackReturn::SUCCESS:
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, "inactive");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::ERROR:
+      on_error(lifecycle_state_);
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::FAILURE:
+      break;
   }
   return lifecycle_state_;
 }
-
 const rclcpp_lifecycle::State & ControllerInterface::activate()
 {
-  if (on_activate(lifecycle_state_) == LifecycleNodeInterface::CallbackReturn::SUCCESS) {
-    lifecycle_state_ = rclcpp_lifecycle::State(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      "active");
+  switch (on_activate(lifecycle_state_)) {
+    case LifecycleNodeInterface::CallbackReturn::SUCCESS:
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::ERROR:
+      on_error(lifecycle_state_);
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::FAILURE:
+      break;
   }
   return lifecycle_state_;
 }
 
 const rclcpp_lifecycle::State & ControllerInterface::shutdown()
 {
-  if (on_shutdown(lifecycle_state_) == LifecycleNodeInterface::CallbackReturn::SUCCESS) {
-    lifecycle_state_ = rclcpp_lifecycle::State(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
-      "finalized");
+  switch (on_activate(lifecycle_state_)) {
+    case LifecycleNodeInterface::CallbackReturn::SUCCESS:
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::ERROR:
+      on_error(lifecycle_state_);
+      lifecycle_state_ = rclcpp_lifecycle::State(
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+      break;
+    case LifecycleNodeInterface::CallbackReturn::FAILURE:
+      break;
   }
   return lifecycle_state_;
 }
 
-const rclcpp_lifecycle::State &ControllerInterface::get_current_state() const
+const rclcpp_lifecycle::State & ControllerInterface::get_current_state() const
 {
   return lifecycle_state_;
 }

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -40,6 +40,17 @@ TestController::on_configure(const rclcpp_lifecycle::State & previous_state)
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestController::on_cleanup(
+  const rclcpp_lifecycle::State & previous_state)
+{
+  (void) previous_state;
+  if (cleanup_calls) {
+    (*cleanup_calls)++;
+  }
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
 }  // namespace test_controller
 
 #include "pluginlib/class_list_macros.hpp"

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -34,17 +34,15 @@ TestController::update()
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-TestController::on_configure(const rclcpp_lifecycle::State & previous_state)
+TestController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  (void) previous_state;
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 TestController::on_cleanup(
-  const rclcpp_lifecycle::State & previous_state)
+  const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  (void) previous_state;
   if (cleanup_calls) {
     (*cleanup_calls)++;
   }

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -59,7 +59,14 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State & previous_state) override;
 
+  CONTROLLER_MANAGER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
+
   size_t internal_counter = 0;
+  // Variable where we store when cleanup was called, pointer because the controller
+  // is usually destroyed after cleanup
+  size_t * cleanup_calls = nullptr;
 };
 
 }  // namespace test_controller

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -45,7 +45,7 @@ TEST_F(TestControllerManager, controller_lifecycle) {
 
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
 
   EXPECT_EQ(controller_interface::return_type::SUCCESS, cm_->update());
   EXPECT_EQ(0u, test_controller->internal_counter) << "Controller is not started";
@@ -72,7 +72,7 @@ TEST_F(TestControllerManager, controller_lifecycle) {
   );
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
 
   EXPECT_EQ(controller_interface::return_type::SUCCESS, cm_->update());
   EXPECT_EQ(1u, test_controller->internal_counter);
@@ -103,7 +103,7 @@ TEST_F(TestControllerManager, controller_lifecycle) {
 
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
   auto unload_future = std::async(
     std::launch::async,
     &controller_manager::ControllerManager::unload_controller, cm_,
@@ -121,6 +121,6 @@ TEST_F(TestControllerManager, controller_lifecycle) {
 
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
   EXPECT_EQ(1, test_controller.use_count());
 }

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -189,25 +189,17 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   auto request =
     std::make_shared<controller_manager_msgs::srv::ReloadControllerLibraries::Request>();
 
-  // Create a lambda to store the cleanup state change
-  bool cleanup_called = false;
-  auto set_cleanup_called =
-    [&](
-    const rclcpp_lifecycle::State &)
-    {
-      cleanup_called = true;
-      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-    };
-
   // Reload with no controllers running
   request->force_kill = false;
   auto result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
 
   // Add a controller, but stopped
-  auto test_controller = cm_->load_controller(
-    test_controller::TEST_CONTROLLER_NAME,
-    test_controller::TEST_CONTROLLER_CLASS_NAME);
+  std::shared_ptr<test_controller::TestController> test_controller =
+    std::dynamic_pointer_cast<test_controller::TestController>(
+    cm_->load_controller(
+      test_controller::TEST_CONTROLLER_NAME,
+      test_controller::TEST_CONTROLLER_CLASS_NAME));
 
   // weak_ptr so the only controller shared_ptr instance is owned by the controller_manager and
   // can be completely destroyed before reloading the library
@@ -215,27 +207,29 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
 
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
   ASSERT_GT(
     test_controller.use_count(),
     1) << "Controller manager should have have a copy of this shared ptr";
 
-  cleanup_called = false;
-  test_controller->get_lifecycle_node()->register_on_cleanup(set_cleanup_called);
+  size_t cleanup_calls = 0;
+  test_controller->cleanup_calls = &cleanup_calls;
   test_controller.reset();  // destroy our copy of the controller
 
   request->force_kill = false;
   result = call_service_and_wait(*client, request, srv_executor, true);
   ASSERT_TRUE(result->ok);
-  ASSERT_TRUE(cleanup_called);
+  ASSERT_EQ(cleanup_calls, 1u);
   ASSERT_EQ(
     test_controller.use_count(),
     0) << "No more references to the controller after reloading.";
   test_controller.reset();
 
-  test_controller = cm_->load_controller(
-    test_controller::TEST_CONTROLLER_NAME,
-    test_controller::TEST_CONTROLLER_CLASS_NAME);
+  test_controller =
+    std::dynamic_pointer_cast<test_controller::TestController>(
+    cm_->load_controller(
+      test_controller::TEST_CONTROLLER_NAME,
+      test_controller::TEST_CONTROLLER_CLASS_NAME));
   test_controller_weak = test_controller;
   // Start Controller
   cm_->switch_controller(
@@ -244,7 +238,7 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
     rclcpp::Duration(0, 0));
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
 
   // Failed reload due to active controller
   request->force_kill = false;
@@ -252,15 +246,15 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   ASSERT_FALSE(result->ok) << "Cannot reload if controllers are running";
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_lifecycle_node()->get_current_state().id());
+    test_controller->get_current_state().id());
   ASSERT_GT(
     test_controller.use_count(),
     1) <<
     "Controller manager should still have have a copy of "
     "this shared ptr, no unloading was performed";
 
-  cleanup_called = false;
-  test_controller->get_lifecycle_node()->register_on_cleanup(set_cleanup_called);
+  cleanup_calls = 0;
+  test_controller->cleanup_calls = &cleanup_calls;
   test_controller.reset();  // destroy our copy of the controller
 
   // Force stop active controller
@@ -271,7 +265,7 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   ASSERT_EQ(
     test_controller_weak.use_count(),
     0) << "No more references to the controller after reloading.";
-  ASSERT_TRUE(cleanup_called) <<
+  ASSERT_EQ(cleanup_calls, 1u) <<
     "Controller should have been stopped and cleaned up with force_kill = true";
 }
 

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -51,10 +51,10 @@ TEST_F(TestLoadController, load1_known_controller)
   controller_manager::ControllerSpec abstract_test_controller =
     cm_->get_loaded_controllers()[0];
 
-  auto lifecycle_node = abstract_test_controller.c->get_lifecycle_node();
+  auto node = abstract_test_controller.c->get_node();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller.c->get_current_state().id());
 }
 
 TEST_F(TestLoadController, load2_known_controller)
@@ -68,10 +68,10 @@ TEST_F(TestLoadController, load2_known_controller)
   controller_manager::ControllerSpec abstract_test_controller1 =
     cm_->get_loaded_controllers()[0];
   EXPECT_STREQ(
-    controller_name1.c_str(), abstract_test_controller1.c->get_lifecycle_node()->get_name());
+    controller_name1.c_str(), abstract_test_controller1.c->get_node()->get_name());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller1.c->get_current_state().id());
 
   // load the same controller again with a different name
   std::string controller_name2 = "test_controller2";
@@ -80,12 +80,12 @@ TEST_F(TestLoadController, load2_known_controller)
   controller_manager::ControllerSpec abstract_test_controller2 =
     cm_->get_loaded_controllers()[1];
   EXPECT_STREQ(
-    controller_name2.c_str(), abstract_test_controller2.c->get_lifecycle_node()->get_name());
+    controller_name2.c_str(), abstract_test_controller2.c->get_node()->get_name());
   EXPECT_STREQ(
     controller_name2.c_str(), abstract_test_controller2.info.name.c_str());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller2.c->get_current_state().id());
 }
 
 TEST_F(TestLoadController, update)
@@ -98,10 +98,10 @@ TEST_F(TestLoadController, update)
   controller_manager::ControllerSpec abstract_test_controller =
     cm_->get_loaded_controllers()[0];
 
-  auto lifecycle_node = abstract_test_controller.c->get_lifecycle_node();
+  auto node = abstract_test_controller.c->get_node();
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller.c->get_current_state().id());
 }
 
 TEST_F(TestLoadController, switch_controller_empty)
@@ -209,7 +209,7 @@ TEST_F(TestLoadController, switch_controller)
 
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller1.c->get_current_state().id());
 
   {  //  Test stopping an stopped controller
     std::vector<std::string> start_controllers = {};
@@ -275,7 +275,7 @@ TEST_F(TestLoadController, switch_controller)
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller1.c->get_current_state().id());
 
     // Stop controller
     start_controllers = {};
@@ -301,7 +301,7 @@ TEST_F(TestLoadController, switch_controller)
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller1.c->get_current_state().id());
   }
 }
 
@@ -322,10 +322,10 @@ TEST_F(TestLoadController, switch_multiple_controllers)
 
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller1.c->get_current_state().id());
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
+    abstract_test_controller2.c->get_current_state().id());
 
   // Only testing with STRICT now for simplicity
   { //  Test starting an stopped controller, and stopping afterwards
@@ -352,10 +352,10 @@ TEST_F(TestLoadController, switch_multiple_controllers)
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller1.c->get_current_state().id());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller2.c->get_current_state().id());
 
     // Stop controller 1, start controller 2
     start_controllers = {controller_name2};
@@ -381,10 +381,10 @@ TEST_F(TestLoadController, switch_multiple_controllers)
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      abstract_test_controller1.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller1.c->get_current_state().id());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller2.c->get_current_state().id());
 
     start_controllers = {};
     stop_controllers = {controller_name2};
@@ -409,6 +409,6 @@ TEST_F(TestLoadController, switch_multiple_controllers)
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      abstract_test_controller2.c->get_lifecycle_node()->get_current_state().id());
+      abstract_test_controller2.c->get_current_state().id());
   }
 }


### PR DESCRIPTION
Summary of changes:

- Change `ControllerInterface::get_lifecycle_node` to `get_node`
- Add `activate`, `configure` and similar methods to `ControllerInterface` to emulate the API that `LifecycleNode` provided
- The controllers are a bit more affected, check: https://github.com/ros-controls/ros2_controllers/pull/124