### PR TITLE
Automatically fetch latest patch of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - run: sudo apt-get update -qq && sudo apt-get upgrade
       - uses: actions/checkout@v1
-      - uses: 'ros-industrial/industrial_ci@master'
+      - uses: ros-industrial/industrial_ci@master
         env: ${{matrix.env}}
 
   ci_source:
@@ -29,10 +29,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: ros-tooling/setup-ros@0.0.26
+      - uses: ros-tooling/setup-ros@v0.1
         with:
           required-ros-distributions: foxy
-      - uses: ros-tooling/action-ros-ci@0.1.0
+      - uses: ros-tooling/action-ros-ci@v0.1
         with:
           target-ros2-distro: foxy
           # build all packages listed in the meta package
@@ -48,7 +48,7 @@ jobs:
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v1.0.14
+      - uses: codecov/codecov-action@v1
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.26
+    - uses: ros-tooling/setup-ros@v0.1
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: copyright
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.26
+    - uses: ros-tooling/setup-ros@v0.1
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: xmllint
@@ -48,7 +48,7 @@ jobs:
           linter: [cppcheck, cpplint, uncrustify]
     steps:
     - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@0.0.26
+    - uses: ros-tooling/setup-ros@v0.1
     - uses: ros-tooling/action-ros-lint@0.0.6
       with:
         linter: ${{ matrix.linter }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.1
-    - uses: ros-tooling/action-ros-lint@0.0.6
+    - uses: ros-tooling/action-ros-lint@v0.1
       with:
         linter: copyright
         package-name:
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.1
-    - uses: ros-tooling/action-ros-lint@0.0.6
+    - uses: ros-tooling/action-ros-lint@v0.1
       with:
         linter: xmllint
         package-name:
@@ -49,7 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.1
-    - uses: ros-tooling/action-ros-lint@0.0.6
+    - uses: ros-tooling/action-ros-lint@v0.1
       with:
         linter: ${{ matrix.linter }}
         package-name:


### PR DESCRIPTION
Use the new, more generic tags so that we grab the latest `vMAJOR.MINOR.*` without having to manually update the CI. See https://github.com/ros-controls/ros2_control/pull/253.

~Waiting for https://github.com/ros-tooling/action-ros-lint/issues/218 so I can also update `action-ros-lint`. Once that's done, will mark this PR as ready for review.~ Now ready :)