### PR TITLE
Fix update rate issues by working around MutliThreadedExecutor

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -126,6 +126,8 @@ public:
    * Deterministic (real-time safe) callback group for the update function. Default behavior
    * is read hardware, update controller and finally write new values to the hardware.
    */
+  // TODO(anyone): Due to issues with the MutliThreadedExecutor, this control loop does not rely on
+  // the executor (see issue #260).
   // rclcpp::CallbackGroup::SharedPtr deterministic_callback_group_;
 
 protected:

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -126,7 +126,7 @@ public:
    * Deterministic (real-time safe) callback group for the update function. Default behavior
    * is read hardware, update controller and finally write new values to the hardware.
    */
-  rclcpp::CallbackGroup::SharedPtr deterministic_callback_group_;
+  // rclcpp::CallbackGroup::SharedPtr deterministic_callback_group_;
 
 protected:
   CONTROLLER_MANAGER_PUBLIC

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -92,8 +92,8 @@ ControllerManager::ControllerManager(
 
 void ControllerManager::init_services()
 {
-  deterministic_callback_group_ = create_callback_group(
-    rclcpp::CallbackGroupType::MutuallyExclusive);
+// deterministic_callback_group_ = create_callback_group(
+//   rclcpp::CallbackGroupType::MutuallyExclusive);
   best_effort_callback_group_ = create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -92,8 +92,10 @@ ControllerManager::ControllerManager(
 
 void ControllerManager::init_services()
 {
-// deterministic_callback_group_ = create_callback_group(
-//   rclcpp::CallbackGroupType::MutuallyExclusive);
+  // TODO(anyone): Due to issues with the MutliThreadedExecutor, this control loop does not rely on
+  // the executor (see issue #260).
+  // deterministic_callback_group_ = create_callback_group(
+  //   rclcpp::CallbackGroupType::MutuallyExclusive);
   best_effort_callback_group_ = create_callback_group(
     rclcpp::CallbackGroupType::MutuallyExclusive);
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -32,8 +32,10 @@ int main(int argc, char ** argv)
     executor,
     manager_node_name);
 
-  // TODO: Due to issues with the MutliThreadedExecutor, this control loop does not rely on the executor. When the
-  // MutliThreadedExecutor issues are fixes, this loop should be converted back to a timer.
+  // TODO(anyone): Due to issues with the MutliThreadedExecutor, this control loop does not rely on
+  // the executor (see issue #260).
+  // When the MutliThreadedExecutor issues are fixed (ros2/rclcpp#1168), this loop should be
+  // converted back to a timer.
   std::thread cm_thread([cm]() {
       // load controller_manager update time parameter
       int update_rate = 100;


### PR DESCRIPTION
Currently the MutliThreadedExecutor performance is very bad. This leads to controllers not meeting their update rate. This PR is a temporary workaround for these issues.

The current approach uses a `rclcpp` timer to execute the control loop. When used in combination with the `MutliThreadedExecutor`, the timers are not execute at their target frequency. I've converted the control loop to a while loop on a separate thread that uses `nanosleep` to execute the correct update rate. This means that `rclcpp` is not involved in the execution and leads to much better performance.

I've done some simple performance benchmarking. Using https://github.com/ros-controls/ros2_control_demos
with `update_rate` set to 500 Hz.

fix/update-rate-issues branch

```
$ ros2 topic hz /joint_states -w 500
average rate: 444.370
	min: 0.002s max: 0.003s std dev: 0.00016s window: 500
average rate: 443.508
	min: 0.002s max: 0.003s std dev: 0.00016s window: 500
average rate: 442.099
	min: 0.002s max: 0.003s std dev: 0.00016s window: 500
average rate: 445.781
	min: 0.002s max: 0.003s std dev: 0.00014s window: 500
average rate: 445.271
	min: 0.002s max: 0.003s std dev: 0.00016s window: 500
average rate: 443.078
	min: 0.002s max: 0.003s std dev: 0.00017s window: 500
average rate: 443.917
	min: 0.002s max: 0.003s std dev: 0.00015s window: 500
```

master branch
```
$ ros2 topic hz /joint_states -w 10
average rate: 4.811
	min: 0.067s max: 0.388s std dev: 0.12711s window: 7
average rate: 4.768
	min: 0.023s max: 0.388s std dev: 0.14797s window: 10
average rate: 11.099
	min: 0.002s max: 0.279s std dev: 0.08028s window: 10
average rate: 9.588
	min: 0.009s max: 0.277s std dev: 0.07749s window: 10
average rate: 7.070
	min: 0.009s max: 0.488s std dev: 0.13346s window: 10
average rate: 4.990
	min: 0.017s max: 0.712s std dev: 0.19685s window: 10
average rate: 4.472
	min: 0.002s max: 0.712s std dev: 0.23221s window: 10
```

I'm curious what you guys think about this workaround. Without this patch, I'm unable to run a control loop at 50Hz.
