### PR TITLE
Add test assets package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             controller_manager_msgs
             hardware_interface
             ros2_control
+            ros2_control_test_assets
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
           colcon-mixin-name: coverage-gcc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,5 @@ jobs:
           controller_manager_msgs
           hardware_interface
           ros2_control
+          ros2_control_test_assets
           transmission_interface

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -59,6 +59,7 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+   find_package(ros2_control_test_assets REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
@@ -106,6 +107,7 @@ if(BUILD_TESTING)
   )
 
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
+  ament_target_dependencies(test_resource_manager ros2_control_test_assets)
   target_link_libraries(test_resource_manager hardware_interface)
 endif()
 

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -59,10 +59,10 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-   find_package(ros2_control_test_assets REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)
+  find_package(ros2_control_test_assets REQUIRED)
 
   ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -20,6 +20,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/hardware_interface/test/test_resource_manager.cpp
+++ b/hardware_interface/test/test_resource_manager.cpp
@@ -74,11 +74,9 @@ TEST_F(TestResourceManager, initialization_with_urdf_manual_validation) {
 }
 
 TEST_F(TestResourceManager, initialization_with_wrong_urdf) {
-  auto urdf = ros2_control_test_assets::urdf_head +
-    ros2_control_test_assets::hardware_resources_missing_keys +
-    ros2_control_test_assets::urdf_tail;
   try {
-    hardware_interface::ResourceManager rm(urdf);
+    hardware_interface::ResourceManager rm(
+      ros2_control_test_assets::minimal_robot_missing_keys_urdf);
     FAIL();
   } catch (const std::exception & e) {
     std::cout << e.what() << std::endl;

--- a/hardware_interface/test/test_resource_manager.cpp
+++ b/hardware_interface/test/test_resource_manager.cpp
@@ -22,6 +22,7 @@
 
 #include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/resource_manager.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
 
 class TestResourceManager : public ::testing::Test
 {
@@ -32,153 +33,7 @@ public:
 
   void SetUp()
   {
-    urdf_head_ =
-      R"(
-<?xml version="1.0" encoding="utf-8"?>
-<robot name="MinimalRobot">
-  <joint name="base_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0 0"/>
-    <parent link="world"/>
-    <child link="base_link"/>
-  </joint>
-  <link name="base_link">
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="0.1"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name="joint1" type="revolute">
-    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
-    <parent link="base_link"/>
-    <child link="link1"/>
-    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
-  </joint>
-  <link name="link1">
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="0.1"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name="joint2" type="revolute">
-    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
-    <parent link="link1"/>
-    <child link="link2"/>
-    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
-  </joint>
-  <link name="link2">
-    <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
-      <geometry>
-        <cylinder length="1" radius="0.1"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name="tool_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0 0 1"/>
-    <parent link="link2"/>
-    <child link="tool_link"/>
-  </joint>
-)";
-
-    urdf_tail_ =
-      R"(
-</robot>
-)";
-
-    hardware_resources_for_test_ =
-      R"(
-  <ros2_control name="TestActuatorHardware" type="actuator">
-    <hardware>
-      <plugin>test_actuator</plugin>
-    </hardware>
-    <joint name="joint1">
-      <command_interface name="position"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-    </joint>
-  </ros2_control>
-  <ros2_control name="TestSensorHardware" type="sensor">
-    <hardware>
-      <plugin>test_sensor</plugin>
-      <param name="example_param_write_for_sec">2</param>
-      <param name="example_param_read_for_sec">2</param>
-    </hardware>
-    <sensor name="sensor1">
-      <state_interface name="velocity"/>
-    </sensor>
-  </ros2_control>
-  <ros2_control name="TestSystemHardware" type="system">
-    <hardware>
-      <plugin>test_system</plugin>
-      <param name="example_param_write_for_sec">2</param>
-      <param name="example_param_read_for_sec">2</param>
-    </hardware>
-    <joint name="joint2">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-    </joint>
-    <joint name="joint3">
-      <command_interface name="velocity"/>
-      <state_interface name="position"/>
-    </joint>
-  </ros2_control>
-)";
-
-    hardware_resources_for_test_missing_keys_ =
-      R"(
-  <ros2_control name="TestActuatorHardware" type="actuator">
-    <hardware>
-      <plugin>test_actuator</plugin>
-    </hardware>
-    <joint name="joint1">
-      <command_interface name="position"/>
-      <command_interface name="does_not_exist"/>
-      <state_interface name="position"/>
-      <state_interface name="velocity"/>
-      <state_interface name="does_not_exist"/>
-    </joint>
-  </ros2_control>
-  <ros2_control name="TestSensorHardware" type="sensor">
-    <hardware>
-      <plugin>test_sensor</plugin>
-      <param name="example_param_write_for_sec">2</param>
-      <param name="example_param_read_for_sec">2</param>
-    </hardware>
-    <sensor name="sensor1">
-      <state_interface name="velocity"/>
-      <state_interface name="does_not_exist"/>
-    </sensor>
-  </ros2_control>
-  <ros2_control name="TestSystemHardware" type="system">
-    <hardware>
-      <plugin>test_system</plugin>
-      <param name="example_param_write_for_sec">2</param>
-      <param name="example_param_read_for_sec">2</param>
-    </hardware>
-    <joint name="joint2">
-      <command_interface name="velocity"/>
-      <command_interface name="does_not_exist"/>
-      <state_interface name="position"/>
-      <state_interface name="does_not_exist"/>
-    </joint>
-    <joint name="joint3">
-      <command_interface name="velocity"/>
-      <command_interface name="does_not_exist"/>
-      <state_interface name="position"/>
-      <state_interface name="does_not_exist"/>
-    </joint>
-  </ros2_control>
-)";
   }
-
-  std::string urdf_head_;
-  std::string hardware_resources_for_test_;
-  std::string hardware_resources_for_test_missing_keys_;
-  std::string urdf_tail_;
 };
 
 TEST_F(TestResourceManager, initialization_empty) {
@@ -186,20 +41,18 @@ TEST_F(TestResourceManager, initialization_empty) {
 }
 
 TEST_F(TestResourceManager, initialization_with_urdf) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
-  ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf));
+  ASSERT_NO_THROW(
+    hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf));
 }
 
 TEST_F(TestResourceManager, post_initialization_with_urdf) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
   hardware_interface::ResourceManager rm;
-  ASSERT_NO_THROW(rm.load_urdf(urdf));
+  ASSERT_NO_THROW(rm.load_urdf(ros2_control_test_assets::minimal_robot_urdf));
 }
 
 TEST_F(TestResourceManager, initialization_with_urdf_manual_validation) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
   // we validate the results manually
-  hardware_interface::ResourceManager rm(urdf, false);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf, false);
 
   EXPECT_EQ(1u, rm.actuator_components_size());
   EXPECT_EQ(1u, rm.sensor_components_size());
@@ -221,7 +74,9 @@ TEST_F(TestResourceManager, initialization_with_urdf_manual_validation) {
 }
 
 TEST_F(TestResourceManager, initialization_with_wrong_urdf) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_missing_keys_ + urdf_tail_;
+  auto urdf = ros2_control_test_assets::urdf_head +
+    ros2_control_test_assets::hardware_resources_missing_keys +
+    ros2_control_test_assets::urdf_tail;
   try {
     hardware_interface::ResourceManager rm(urdf);
     FAIL();
@@ -232,9 +87,8 @@ TEST_F(TestResourceManager, initialization_with_wrong_urdf) {
 }
 
 TEST_F(TestResourceManager, initialization_with_urdf_unclaimed) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
   // we validate the results manually
-  hardware_interface::ResourceManager rm(urdf);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   auto command_interface_keys = rm.command_interface_keys();
   for (const auto & key : command_interface_keys) {
@@ -249,8 +103,7 @@ TEST_F(TestResourceManager, initialization_with_urdf_unclaimed) {
 }
 
 TEST_F(TestResourceManager, resource_status) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
-  hardware_interface::ResourceManager rm(urdf);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   std::unordered_map<std::string, hardware_interface::status> status_map;
 
@@ -261,8 +114,7 @@ TEST_F(TestResourceManager, resource_status) {
 }
 
 TEST_F(TestResourceManager, starting_and_stopping_resources) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
-  hardware_interface::ResourceManager rm(urdf);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   std::unordered_map<std::string, hardware_interface::status> status_map;
 
@@ -280,8 +132,7 @@ TEST_F(TestResourceManager, starting_and_stopping_resources) {
 }
 
 TEST_F(TestResourceManager, resource_claiming) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
-  hardware_interface::ResourceManager rm(urdf);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   const auto key = "joint1/position";
   EXPECT_FALSE(rm.command_interface_is_claimed(key));
@@ -396,9 +247,8 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
 };
 
 TEST_F(TestResourceManager, post_initialization_add_components) {
-  auto urdf = urdf_head_ + hardware_resources_for_test_ + urdf_tail_;
   // we validate the results manually
-  hardware_interface::ResourceManager rm(urdf, false);
+  hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf, false);
 
   EXPECT_EQ(1u, rm.actuator_components_size());
   EXPECT_EQ(1u, rm.sensor_components_size());

--- a/ros2_control/package.xml
+++ b/ros2_control/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>hardware_interface</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
+  <exec_depend>ros2_control_test_assets</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-find_package(hardware_interface REQUIRED)
 
 install(
   DIRECTORY include/
@@ -22,8 +21,5 @@ endif()
 
 ament_export_include_directories(
   include
-)
-ament_export_dependencies(
-  hardware_interface
 )
 ament_package()

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_control_test_assets)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(hardware_interface REQUIRED)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(
+  include
+)
+ament_export_dependencies(
+  hardware_interface
+)
+ament_package()

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -169,6 +169,9 @@ const auto hardware_resources_missing_keys =
 const auto minimal_robot_urdf = std::string(urdf_head) + std::string(hardware_resources) +
   std::string(urdf_tail);
 
+const auto minimal_robot_missing_keys_urdf = std::string(urdf_head) +
+  std::string(hardware_resources_missing_keys) + std::string(urdf_tail);
+
 }  // namespace ros2_control_test_assets
 
 #endif  // ROS2_CONTROL_TEST_ASSETS__DESCRIPTIONS_HPP_

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -1,0 +1,174 @@
+// Copyright 2020 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_CONTROL_TEST_ASSETS__DESCRIPTIONS_HPP_
+#define ROS2_CONTROL_TEST_ASSETS__DESCRIPTIONS_HPP_
+
+#include <string>
+
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+
+namespace ros2_control_test_assets
+{
+
+const auto urdf_head =
+  R"(
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="MinimalRobot">
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+  <link name="base_link">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint1" type="revolute">
+    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link1">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link2">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="tool_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="link2"/>
+    <child link="tool_link"/>
+  </joint>
+)";
+
+const auto urdf_tail =
+  R"(
+</robot>
+)";
+
+const auto hardware_resources =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+    </joint>
+  </ros2_control>
+)";
+
+const auto hardware_resources_missing_keys =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+      <state_interface name="does_not_exist"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="position"/>
+      <state_interface name="does_not_exist"/>
+    </joint>
+  </ros2_control>
+)";
+
+
+const auto minimal_robot_urdf = std::string(urdf_head) + std::string(hardware_resources) +
+  std::string(urdf_tail);
+
+}  // namespace ros2_control_test_assets
+
+#endif  // ROS2_CONTROL_TEST_ASSETS__DESCRIPTIONS_HPP_

--- a/ros2_control_test_assets/package.xml
+++ b/ros2_control_test_assets/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_control_test_assets</name>
+  <version>0.0.1</version>
+  <description>The package provides shared test resources for ros2_control stack
+  </description>
+  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
+  <license>Apache License 2.0</license>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ros2_control_test_assets/package.xml
+++ b/ros2_control_test_assets/package.xml
@@ -2,9 +2,10 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_control_test_assets</name>
-  <version>0.0.1</version>
+  <version>0.0.0</version>
   <description>The package provides shared test resources for ros2_control stack
   </description>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
   <license>Apache License 2.0</license>
 

--- a/ros2_control_test_assets/package.xml
+++ b/ros2_control_test_assets/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_control_test_assets</name>
-  <version>0.0.0</version>
+  <version>0.1.3</version>
   <description>The package provides shared test resources for ros2_control stack
   </description>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>


### PR DESCRIPTION
sits on #288  (Sorry I didn't do a clean diff, but we need first anyway #288)...

the second part of #208 

Changes:
- add `ros2_control_test_assets` package
- shared `description.hpp` for RM setup
- test RM upon this description