### PR TITLE
Fix building on macOS with clang

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,54 +3,19 @@ on:
   pull_request:
 
 jobs:
-  ament_copyright:
-    name: ament_copyright
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@v0.1
-    - uses: ros-tooling/action-ros-lint@v0.1
-      with:
-        linter: copyright
-        package-name:
-          controller_interface
-          controller_manager
-          controller_manager_msgs
-          hardware_interface
-          ros2_control
-          test_robot_hardware
-          transmission_interface
-
-  ament_xmllint:
-    name: ament_xmllint
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v1
-    - uses: ros-tooling/setup-ros@v0.1
-    - uses: ros-tooling/action-ros-lint@v0.1
-      with:
-        linter: xmllint
-        package-name:
-          controller_interface
-          controller_manager
-          controller_manager_msgs
-          hardware_interface
-          ros2_control
-          test_robot_hardware
-          transmission_interface
-
-  ament_lint_cpp:
+  ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-          linter: [cppcheck, cpplint, uncrustify]
+          linter: [copyright, cppcheck, cpplint, flake8, pep257, uncrustify, xmllint]
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.1
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
+        distribution: foxy
         linter: ${{ matrix.linter }}
         package-name:
           controller_interface

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "controller_manager/controller_manager.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -48,9 +49,7 @@ int main(int argc, char ** argv)
         cm->read();
         cm->update();
         cm->write();
-        struct timespec duration{};
-        duration.tv_nsec = 1000000000 / update_rate;
-        clock_nanosleep(CLOCK_MONOTONIC, 0, &duration, NULL);
+        std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / update_rate));
       }
     });
 

--- a/transmission_interface/src/transmission_parser.cpp
+++ b/transmission_interface/src/transmission_parser.cpp
@@ -20,8 +20,6 @@
 
 namespace
 {
-constexpr const auto kTransmissionParserLoggerName = "transmission_parser";
-
 constexpr const auto kTransmissionTag = "transmission";
 constexpr const auto kNameTag = "name";
 constexpr const auto kJointTag = "joint";

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -174,6 +174,8 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(10.0, 1.0),
     SimpleTransmission(10.0, -1.0),
     SimpleTransmission(-10.0, 1.0),
+    // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
+    // https://github.com/google/googletest/issues/1419
     // cppcheck-suppress syntaxError
     SimpleTransmission(-10.0, -1.0)), );
 

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -174,7 +174,8 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(10.0, 1.0),
     SimpleTransmission(10.0, -1.0),
     SimpleTransmission(-10.0, 1.0),
-    SimpleTransmission(-10.0, -1.0)));
+    // cppcheck-suppress syntaxError
+    SimpleTransmission(-10.0, -1.0)), );
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};


### PR DESCRIPTION
as mentioned in https://github.com/ros-controls/ros2_control/pull/275#issuecomment-759131671, the use of Linux posix API doesn't work on OSX.
Why not using standard C++ for this?

this pr also addresses some warnings in the transmission_interface package.