### PR TITLE
Sleep accurate duration on ros2_control_node

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
@@ -46,10 +47,14 @@ int main(int argc, char ** argv)
       RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);
 
       while (rclcpp::ok()) {
+        std::chrono::system_clock::time_point begin = std::chrono::system_clock::now();
         cm->read();
         cm->update();
         cm->write();
-        std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / update_rate));
+        std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
+        auto duration = end - begin;
+        std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / update_rate) -
+                                    std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
       }
     });
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -53,8 +54,10 @@ int main(int argc, char ** argv)
         cm->write();
         std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
         std::this_thread::sleep_for(
-          std::chrono::nanoseconds(1000000000 / update_rate) -
-          std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin));
+          std::max(
+            std::chrono::nanoseconds(0),
+            std::chrono::nanoseconds(1000000000 / update_rate) -
+            std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)));
       }
     });
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -52,10 +52,9 @@ int main(int argc, char ** argv)
         cm->update();
         cm->write();
         std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-        auto duration = end - begin;
         std::this_thread::sleep_for(
           std::chrono::nanoseconds(1000000000 / update_rate) -
-          std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
+          std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin));
       }
     });
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -53,8 +53,9 @@ int main(int argc, char ** argv)
         cm->write();
         std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
         auto duration = end - begin;
-        std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / update_rate) -
-                                    std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
+        std::this_thread::sleep_for(
+          std::chrono::nanoseconds(1000000000 / update_rate) -
+          std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
       }
     });
 


### PR DESCRIPTION
Current main loop of the `ros2_control_node` doesn't cycle under correct `update_rate` because it ignores the computation time of `read`, `update`, and `write` methods.
This PR fixed the problem.

I know we won't need this PR if #260 would be solved but I need it now.