### PR TITLE
fix float conversion warning

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -129,8 +129,8 @@ public:
     const std::vector<std::string> & stop_controllers,
     int strictness,
     bool start_asap = kWaitForAllResources,
-    const rclcpp::Duration & timeout = rclcpp::Duration(kInfiniteTimeout));
-
+    const rclcpp::Duration & timeout =
+    rclcpp::Duration(static_cast<rcl_duration_value_t>(kInfiniteTimeout)));
 
   CONTROLLER_MANAGER_PUBLIC
   void read();


### PR DESCRIPTION
this came up during my review of the gazebo plugins.
clang's complaining about losing floating point precision without an explicit cast.