### PR TITLE
Revert "run apt update && upgrade"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
     steps:
-      - run: sudo apt-get update -qq && sudo apt-get upgrade
       - uses: actions/checkout@v1
       - uses: ros-industrial/industrial_ci@master
         env: ${{matrix.env}}


### PR DESCRIPTION
Reverts ros-controls/ros2_control#158

This line is not needed (Docker..), prolongs the build by 4 min and apparently breaks it now.
As reported in https://github.com/ros-industrial/industrial_ci/issues/607.