### PR TITLE
Increase service call timeout, often services take longer than 0.2s

### DIFF
--- a/ros2controlcli/ros2controlcli/api/__init__.py
+++ b/ros2controlcli/ros2controlcli/api/__init__.py
@@ -37,7 +37,7 @@ def service_caller(service_name, service_type, request):
         if not cli.service_is_ready():
             node.get_logger().debug('waiting for service {} to become available...'
                                     .format(service_name))
-            if not cli.wait_for_service(0.2):
+            if not cli.wait_for_service(2.0):
                 raise RuntimeError('Could not contact service {}'.format(service_name))
 
         node.get_logger().debug('requester: making request: %r\n' % request)


### PR DESCRIPTION
I noticed testing the spawner that every now and then one of the service calls would fail.

After testing a bit more and comparing with `ros2 service call` which never failed, I noticed we had this timeout, whereas `ros2 service call` has none.

Increasing to 2.0 solved the issue for me, it's an arbitrary number though.