### PR TITLE
Debug fake system when testing with real-world example

### DIFF
--- a/hardware_interface/include/fake_components/generic_system.hpp
+++ b/hardware_interface/include/fake_components/generic_system.hpp
@@ -106,7 +106,7 @@ private:
     std::vector<std::vector<double>> & states,
     const std::vector<std::string> & interfaces);
 
-  bool fake_sensor_command_interfaces;
+  bool fake_sensor_command_interfaces_;
 };
 
 typedef GenericSystem GenericRobot;

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -37,6 +37,7 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
   // check if to create fake command interface for sensor
   auto it = info_.hardware_parameters.find("fake_sensor_commands");
   if (it != info_.hardware_parameters.end()) {
+    TODO(anyone): change this when there is parse_bool() function implemented (see ros2_control#339)
     fake_sensor_command_interfaces_ = it->second == "true" || it->second == "True";
   } else {
     fake_sensor_command_interfaces_ = false;

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -37,9 +37,9 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
   // check if to create fake command interface for sensor
   auto it = info_.hardware_parameters.find("fake_sensor_commands");
   if (it != info_.hardware_parameters.end()) {
-    fake_sensor_command_interfaces = it->second == "true";
+    fake_sensor_command_interfaces_ = it->second == "true" || it->second == "True";
   } else {
-    fake_sensor_command_interfaces = false;
+    fake_sensor_command_interfaces_ = false;
   }
 
   // Initialize storage for standard interfaces
@@ -151,7 +151,7 @@ std::vector<hardware_interface::CommandInterface> GenericSystem::export_command_
   }
 
   // Fake sensor command interfaces
-  if (fake_sensor_command_interfaces) {
+  if (fake_sensor_command_interfaces_) {
     for (uint i = 0; i < info_.sensors.size(); i++) {
       const auto & sensor = info_.sensors[i];
       for (const auto & interface : sensor.state_interfaces) {
@@ -172,10 +172,10 @@ std::vector<hardware_interface::CommandInterface> GenericSystem::export_command_
 
 return_type GenericSystem::read()
 {
-  // only do loopback
+  // do loopback
   joint_states_ = joint_commands_;
   other_states_ = other_commands_;
-  if (fake_sensor_command_interfaces) {
+  if (fake_sensor_command_interfaces_) {
     sensor_states_ = sensor_fake_commands_;
   }
   return return_type::OK;

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -37,7 +37,7 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
   // check if to create fake command interface for sensor
   auto it = info_.hardware_parameters.find("fake_sensor_commands");
   if (it != info_.hardware_parameters.end()) {
-    TODO(anyone): change this when there is parse_bool() function implemented (see ros2_control#339)
+    //  TODO(anyone): change this when there is parse_bool() function implemented (see ros2_control#339)
     fake_sensor_command_interfaces_ = it->second == "true" || it->second == "True";
   } else {
     fake_sensor_command_interfaces_ = false;

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -37,7 +37,7 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
   // check if to create fake command interface for sensor
   auto it = info_.hardware_parameters.find("fake_sensor_commands");
   if (it != info_.hardware_parameters.end()) {
-    //  TODO(anyone): change this when there is parse_bool() function implemented (see ros2_control#339)
+    // TODO(anyone): change this to parse_bool() (see ros2_control#339)
     fake_sensor_command_interfaces_ = it->second == "true" || it->second == "True";
   } else {
     fake_sensor_command_interfaces_ = false;

--- a/hardware_interface/test/fake_components/test_generic_system.cpp
+++ b/hardware_interface/test/fake_components/test_generic_system.cpp
@@ -177,6 +177,35 @@ protected:
     </sensor>
   </ros2_control>
 )";
+
+    hardware_system_2dof_with_sensor_fake_command_True_ =
+      R"(
+  <ros2_control name="GenericSystem2dof" type="system">
+    <hardware>
+      <plugin>fake_components/GenericSystem</plugin>
+      <param name="fake_sensor_commands">True</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="position"/>
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <sensor name="tcp_force_sensor">
+      <state_interface name="fx"/>
+      <state_interface name="fy"/>
+      <state_interface name="tx"/>
+      <state_interface name="ty"/>
+      <param name="frame_id">kuka_tcp</param>
+    </sensor>
+  </ros2_control>
+)";
   }
 
   std::string hardware_robot_2dof_;
@@ -186,6 +215,7 @@ protected:
   std::string hardware_system_2dof_with_other_interface_;
   std::string hardware_system_2dof_with_sensor_;
   std::string hardware_system_2dof_with_sensor_fake_command_;
+  std::string hardware_system_2dof_with_sensor_fake_command_True_;
 };
 
 TEST_F(TestGenericSystem, load_generic_system_2dof) {
@@ -548,11 +578,8 @@ TEST_F(TestGenericSystem, generic_system_2dof_sensor) {
   ASSERT_EQ(0.33, j2p_c.get_value());
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_sensor_fake_command_ +
-    ros2_control_test_assets::urdf_tail;
+void test_generic_system_with_fake_sensor_commands(std::string urdf)
+{
   hardware_interface::ResourceManager rm(urdf);
 
   // Check interfaces
@@ -669,4 +696,22 @@ TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command) {
   ASSERT_EQ(2.22, sfy_c.get_value());
   ASSERT_EQ(3.33, stx_c.get_value());
   ASSERT_EQ(4.44, sty_c.get_value());
+}
+
+TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command) {
+  auto urdf =
+    ros2_control_test_assets::urdf_head +
+    hardware_system_2dof_with_sensor_fake_command_ +
+    ros2_control_test_assets::urdf_tail;
+
+  test_generic_system_with_fake_sensor_commands(urdf);
+}
+
+TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command_True) {
+  auto urdf =
+    ros2_control_test_assets::urdf_head +
+    hardware_system_2dof_with_sensor_fake_command_True_ +
+    ros2_control_test_assets::urdf_tail;
+
+  test_generic_system_with_fake_sensor_commands(urdf);
 }


### PR DESCRIPTION
I found out that xacro if generating URDF with "True" keyword.

Also, a member name was missing "_" suffix.