### PR TITLE
Don't use FileType for param-file

### DIFF
--- a/controller_manager/scripts/spawner.py
+++ b/controller_manager/scripts/spawner.py
@@ -48,7 +48,7 @@ def main(args=None):
         '-c', '--controller-manager', help='Name of the controller manager ROS node',
         default='/controller_manager', required=False)
     parser.add_argument(
-        '-p', '--param-file', type=argparse.FileType('r'),
+        '-p', '--param-file',
         help='Controller param file to be loaded into controller node before configure',
         required=False)
     parser.add_argument(

--- a/controller_manager/scripts/spawner.py
+++ b/controller_manager/scripts/spawner.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import argparse
+import errno
+import os
 import subprocess
 import sys
 import time
@@ -62,6 +64,10 @@ def main(args=None):
     controller_manager_name = args.controller_manager
     param_file = args.param_file
     controller_type = args.controller_type
+
+    if param_file and not os.path.isfile(param_file):
+        raise FileNotFoundError(
+            errno.ENOENT, os.strerror(errno.ENOENT), param_file)
 
     node = Node('spawner_' + controller_name)
     try:


### PR DESCRIPTION
As it is, the `spawner.py` crashes when reading the `param_file` argument since it is of type `FileType` instead of string. 

See the following traceback:

```
Traceback (most recent call last):
  File "/home/user/exchange/tiago_ws/install/controller_manager/lib/controller_manager/spawner.py", line 141, in <module>
    sys.exit(main())
  File "/home/user/exchange/tiago_ws/install/controller_manager/lib/controller_manager/spawner.py", line 101, in main
    ret = subprocess.run(['ros2', 'param', 'load', controller_name,
  File "/usr/lib/python3.8/subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1637, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not _io.TextIOWrapper
```



`FileType` is used for opening the selected file and returns a handle to it. The caller is also responsible for closing the handle later.

This is not the intention of the `spawner.py` script since we only wish to pass the specified file path to the `ros2 param load` command.