### PR TITLE
[ros2_control_test_assets] Fix typo

### DIFF
--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -417,6 +417,8 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_tr
   //   hardware_info.transmissions[0].class_type,
   //   "transmission_interface/SomeComplex_2x2_Transmission");
   ASSERT_THAT(hardware_info.transmissions[0].parameters, SizeIs(6));
+  EXPECT_EQ(hardware_info.transmissions[0].parameters.at("joints"), "{joint1, joint2}");
+  EXPECT_EQ(hardware_info.transmissions[0].parameters.at("output"), "{output1, output2}");
   EXPECT_EQ(hardware_info.transmissions[0].parameters.at("joint1_output1"), "1.5");
   EXPECT_EQ(hardware_info.transmissions[0].parameters.at("joint1_output2"), "3.2");
   EXPECT_EQ(hardware_info.transmissions[0].parameters.at("joint2_output1"), "3.1");

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -390,7 +390,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_tr
 {
   std::string urdf_to_test =
     std::string(ros2_control_test_assets::urdf_head) +
-    ros2_control_test_assets::valid_urdf_ros2_control_system_muti_joints_transmission +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_multi_joints_transmission +
     ros2_control_test_assets::urdf_tail;
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
   ASSERT_THAT(control_hardware, SizeIs(1));

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -281,7 +281,7 @@ const auto valid_urdf_ros2_control_system_muti_joints_transmission =
     <transmission name="transmission1">
       <plugin>transmission_interface/SomeComplex2by2Transmission</plugin>
       <param name="joints">{joint1, joint2}</param>
-      <param name="output">{output2, output2}</param>
+      <param name="output">{output1, output2}</param>
       <param name="joint1_output1">1.5</param>
       <param name="joint1_output2">3.2</param>
       <param name="joint2_output1">3.1</param>

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -256,7 +256,7 @@ const auto valid_urdf_ros2_control_actuator_modular_robot_sensors =
 
 // 7. Modular Robots with separate communication to each "actuator" with multi joints
 // Example for complex transmission (multi-joint/multi-actuator) - (system component is used)
-const auto valid_urdf_ros2_control_system_muti_joints_transmission =
+const auto valid_urdf_ros2_control_system_multi_joints_transmission =
   R"(
   <ros2_control name="RRBotModularWrist" type="system">
     <hardware>


### PR DESCRIPTION
I found typo in `ros2_control_test_assets`. This PR fixed them.