### PR TITLE
Upgrade action-ros-ci to v0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ros-tooling/setup-ros@v0.1
         with:
           required-ros-distributions: foxy
-      - uses: ros-tooling/action-ros-ci@v0.1
+      - uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: foxy
           # build all packages listed in the meta package
@@ -45,8 +45,13 @@ jobs:
             ros2_control_test_assets
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
       - uses: codecov/codecov-action@v1
         with:
           file: ros_ws/lcov/total_coverage.info


### PR DESCRIPTION
This bumps `action-ros-ci` to v0.2 and updates the config.

It fixes the CI issue reported in https://github.com/ros-tooling/action-ros-ci/issues/615. It's an alternative to relying on the upcoming `setup-ros` fix, so you can either wait for that or just merge this.

Also, I just wanted to point out that you're currently only building the `ros2_control`-related repos in the "Foxy source job" and relying on the Foxy binaries for the dependencies (e.g. ament and all).