### PR TITLE
Make Foxy source job actually build everything from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: ros-tooling/setup-ros@v0.1
-        with:
-          required-ros-distributions: foxy
       - uses: ros-tooling/action-ros-ci@v0.1
         with:
           target-ros2-distro: foxy
@@ -44,6 +42,7 @@ jobs:
             ros2_control
             ros2_control_test_assets
           vcs-repo-file-url: |
+            https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml


### PR DESCRIPTION
Avoids downloading `ros-foxy-desktop` and makes `action-ros-ci` build dependencies from source.

Follow-up to https://github.com/ros-controls/ros2_control/pull/372. See discussion under that PR.