### PR TITLE
Replace controller_interface::return_type SUCCESS by OK and mark SUCCESS as deprecated

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -33,8 +33,9 @@ namespace controller_interface
 
 enum class return_type : std::uint8_t
 {
-  SUCCESS = 0,
+  OK = 0,
   ERROR = 1,
+  SUCCESS [[deprecated("Use controller_interface::return_type::OK instead.")]] = OK
 };
 
 /// Indicating which interfaces are to be claimed.

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -31,7 +31,7 @@ ControllerInterface::init(const std::string & controller_name)
     rclcpp::NodeOptions().allow_undeclared_parameters(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
-  return return_type::SUCCESS;
+  return return_type::OK;
 }
 
 const rclcpp_lifecycle::State & ControllerInterface::configure()


### PR DESCRIPTION
As per the title.

Fix #151 