### PR TITLE
Replace standard interfaces' hard-coded strings by constants

### DIFF
--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"
 
@@ -30,6 +31,9 @@ protected:
 };
 
 using hardware_interface::parse_control_resources_from_urdf;
+using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_VELOCITY;
+using hardware_interface::HW_IF_EFFORT;
 
 TEST_F(TestComponentParser, empty_string_throws_error)
 {
@@ -127,20 +131,20 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_one_interface)
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].min, "-1");
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].max, "1");
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
 
   EXPECT_EQ(hardware_info.joints[1].name, "joint2");
   EXPECT_EQ(hardware_info.joints[1].type, "joint");
   ASSERT_THAT(hardware_info.joints[1].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].name, HW_IF_POSITION);
   EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].min, "-1");
   EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].max, "1");
   ASSERT_THAT(hardware_info.joints[1].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].name, HW_IF_POSITION);
 }
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_interface)
@@ -167,15 +171,15 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_interface
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(3));
-  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(3));
-  EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].name, "velocity");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].name, HW_IF_VELOCITY);
 
   EXPECT_EQ(hardware_info.joints[1].name, "joint2");
   EXPECT_EQ(hardware_info.joints[1].type, "joint");
   ASSERT_THAT(hardware_info.joints[1].command_interfaces, SizeIs(1));
   ASSERT_THAT(hardware_info.joints[1].state_interfaces, SizeIs(3));
-  EXPECT_EQ(hardware_info.joints[1].state_interfaces[2].name, "effort");
+  EXPECT_EQ(hardware_info.joints[1].state_interfaces[2].name, HW_IF_EFFORT);
 }
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_sensor)
@@ -323,7 +327,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, "velocity");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_VELOCITY);
 
   ASSERT_THAT(hardware_info.transmissions, SizeIs(1));
   EXPECT_EQ(hardware_info.transmissions[0].name, "transmission1");
@@ -346,7 +350,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.joints[0].name, "joint2");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, "velocity");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_VELOCITY);
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].min, "-1");
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].max, "1");
 
@@ -366,7 +370,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, IsEmpty());
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
 
 
   hardware_info = control_hardware.at(3);
@@ -383,7 +387,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, IsEmpty());
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, "position");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
 }
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_transmission)
@@ -477,11 +481,11 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_only)
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, "velocity");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_VELOCITY);
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].min, "-1");
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].max, "1");
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, "velocity");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_VELOCITY);
 
 
   ASSERT_THAT(hardware_info.transmissions, SizeIs(1));

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -18,6 +18,7 @@
 #define JOINT_LIMITS_INTERFACE__JOINT_LIMITS_INTERFACE_HPP_
 
 #include <hardware_interface/joint_handle.hpp>
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
 
 #include <rclcpp/duration.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -48,8 +49,8 @@ public:
   JointLimitHandle()
   : prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0),
-    jposh_("position"),
-    jvelh_("velocity"),
+    jposh_(hardware_interface::HW_IF_POSITION),
+    jvelh_(hardware_interface::HW_IF_VELOCITY),
     jcmdh_("position_command")
   {}
 
@@ -58,7 +59,7 @@ public:
     const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
   : jposh_(jposh),
-    jvelh_("velocity"),
+    jvelh_(hardware_interface::HW_IF_VELOCITY),
     jcmdh_(jcmdh),
     limits_(limits),
     prev_pos_(std::numeric_limits<double>::quiet_NaN()),
@@ -358,7 +359,8 @@ public:
     const hardware_interface::JointHandle & jposh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : EffortJointSaturationHandle(jposh, hardware_interface::JointHandle("velocity"), jcmdh, limits)
+  : EffortJointSaturationHandle(jposh,
+      hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits)
   {
   }
 
@@ -427,7 +429,8 @@ public:
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
   : EffortJointSoftLimitsHandle(jposh,
-      hardware_interface::JointHandle("velocity"), jcmdh, limits, soft_limits)
+      hardware_interface::JointHandle(
+        hardware_interface::HW_IF_VELOCITY), jcmdh, limits, soft_limits)
   {
   }
 
@@ -496,7 +499,8 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle(hardware_interface::JointHandle("position"), jvelh, jcmdh, limits)
+  : JointLimitHandle(hardware_interface::JointHandle(
+        hardware_interface::HW_IF_POSITION), jvelh, jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(
@@ -508,8 +512,8 @@ public:
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle(hardware_interface::JointHandle("position"),
-      hardware_interface::JointHandle("velocity"), jcmdh, limits)
+  : JointLimitHandle(hardware_interface::JointHandle(hardware_interface::HW_IF_POSITION),
+      hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits)
   {
     if (!limits.has_velocity_limits) {
       throw joint_limits_interface::JointLimitsInterfaceException(

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <hardware_interface/types/hardware_interface_type_values.hpp>
 #include <joint_limits_interface/joint_limits_interface.hpp>
 
 #include <rclcpp/logging.hpp>
@@ -64,9 +65,9 @@ public:
     name("joint_name"),
     period(0, 100000000),
     cmd_handle(hardware_interface::JointHandle(name, "position_command", &cmd)),
-    pos_handle(hardware_interface::JointHandle(name, "position", &pos)),
-    vel_handle(hardware_interface::JointHandle(name, "velocity", &vel)),
-    eff_handle(hardware_interface::JointHandle(name, "effort", &eff))
+    pos_handle(hardware_interface::JointHandle(name, hardware_interface::HW_IF_POSITION, &pos)),
+    vel_handle(hardware_interface::JointHandle(name, hardware_interface::HW_IF_VELOCITY, &vel)),
+    eff_handle(hardware_interface::JointHandle(name, hardware_interface::HW_IF_EFFORT, &eff))
   {
     limits.has_position_limits = true;
     limits.min_position = -1.0;
@@ -491,9 +492,15 @@ public:
     cmd2_handle(std::make_shared<hardware_interface::JointHandle>(
         name2, "position_command",
         &cmd2)),
-    pos2_handle(std::make_shared<hardware_interface::JointHandle>(name2, "position", &pos2)),
-    vel2_handle(std::make_shared<hardware_interface::JointHandle>(name2, "velocity", &vel2)),
-    eff2_handle(std::make_shared<hardware_interface::JointHandle>(name2, "effort", &eff2))
+    pos2_handle(std::make_shared<hardware_interface::JointHandle>(
+        name2,
+        hardware_interface::HW_IF_POSITION, &pos2)),
+    vel2_handle(std::make_shared<hardware_interface::JointHandle>(
+        name2,
+        hardware_interface::HW_IF_VELOCITY, &vel2)),
+    eff2_handle(std::make_shared<hardware_interface::JointHandle>(
+        name2,
+        hardware_interface::HW_IF_EFFORT, &eff2))
   {}
 
 protected:

--- a/transmission_interface/include/transmission_interface/simple_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/simple_transmission.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "transmission_interface/transmission.hpp"
 #include "transmission_interface/exception.hpp"
 
@@ -189,17 +190,17 @@ void SimpleTransmission::configure(
     throw Exception("Actuator names given to transmissions should be identical");
   }
 
-  joint_position_ = get_by_interface(joint_handles, "position");
-  joint_velocity_ = get_by_interface(joint_handles, "velocity");
-  joint_effort_ = get_by_interface(joint_handles, "effort");
+  joint_position_ = get_by_interface(joint_handles, hardware_interface::HW_IF_POSITION);
+  joint_velocity_ = get_by_interface(joint_handles, hardware_interface::HW_IF_VELOCITY);
+  joint_effort_ = get_by_interface(joint_handles, hardware_interface::HW_IF_EFFORT);
 
   if (!joint_position_ && !joint_velocity_ && !joint_effort_) {
     throw Exception("None of the provided joint handles are valid or from the required interfaces");
   }
 
-  actuator_position_ = get_by_interface(actuator_handles, "position");
-  actuator_velocity_ = get_by_interface(actuator_handles, "velocity");
-  actuator_effort_ = get_by_interface(actuator_handles, "effort");
+  actuator_position_ = get_by_interface(actuator_handles, hardware_interface::HW_IF_POSITION);
+  actuator_velocity_ = get_by_interface(actuator_handles, hardware_interface::HW_IF_VELOCITY);
+  actuator_effort_ = get_by_interface(actuator_handles, hardware_interface::HW_IF_EFFORT);
 
   if (!actuator_position_ && !actuator_velocity_ && !actuator_effort_) {
     throw Exception("None of the provided joint handles are valid or from the required interfaces");


### PR DESCRIPTION
Replace the standard interfaces hard-coded strings "position", "velocity", "effort", and "acceleration" by the constants defined in [hardware_interface/types/hardware_interface_type_values.hpp](https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp).

Fix #250