### PR TITLE
add deprecation note for with_value_ptr

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -61,6 +61,7 @@ public:
 
   HandleType with_value_ptr(double * value_ptr)
   {
+    [[deprecated("with_value_ptr is deprecated and will be removed in the next release")]]
     return HandleType(name_, interface_name_, value_ptr);
   }
 


### PR DESCRIPTION
As discussed, the method `with_value_ptr` is only used in unit tests, and will be removed in the next release.
This PR add in the deprecation note. This will throw a bunch of warnings at compilation time.