### PR TITLE
Remove the with_value_ptr and class templatization for ReadOnlyHandle

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -24,7 +24,6 @@
 namespace hardware_interface
 {
 /// A handle used to get and set a value on a given interface.
-template<class HandleType>
 class ReadOnlyHandle
 {
 public:
@@ -59,12 +58,6 @@ public:
   /// Returns true if handle references a value.
   inline operator bool() const {return value_ptr_ != nullptr;}
 
-  [[deprecated("with_value_ptr is deprecated and will be removed in the next release")]]
-  HandleType with_value_ptr(double * value_ptr)
-  {
-    return HandleType(name_, interface_name_, value_ptr);
-  }
-
   const std::string & get_name() const
   {
     return name_;
@@ -87,23 +80,22 @@ protected:
   double * value_ptr_;
 };
 
-template<class HandleType>
-class ReadWriteHandle : public ReadOnlyHandle<HandleType>
+class ReadWriteHandle : public ReadOnlyHandle
 {
 public:
   ReadWriteHandle(
     const std::string & name,
     const std::string & interface_name,
     double * value_ptr = nullptr)
-  : ReadOnlyHandle<HandleType>(name, interface_name, value_ptr)
+  : ReadOnlyHandle(name, interface_name, value_ptr)
   {}
 
   explicit ReadWriteHandle(const std::string & interface_name)
-  : ReadOnlyHandle<HandleType>(interface_name)
+  : ReadOnlyHandle(interface_name)
   {}
 
   explicit ReadWriteHandle(const char * interface_name)
-  : ReadOnlyHandle<HandleType>(interface_name)
+  : ReadOnlyHandle(interface_name)
   {}
 
   ReadWriteHandle(const ReadWriteHandle & other) = default;
@@ -123,17 +115,17 @@ public:
   }
 };
 
-class StateInterface : public ReadOnlyHandle<StateInterface>
+class StateInterface : public ReadOnlyHandle
 {
 public:
   StateInterface(const StateInterface & other) = default;
 
   StateInterface(StateInterface && other) = default;
 
-  using ReadOnlyHandle<StateInterface>::ReadOnlyHandle;
+  using ReadOnlyHandle::ReadOnlyHandle;
 };
 
-class CommandInterface : public ReadWriteHandle<CommandInterface>
+class CommandInterface : public ReadWriteHandle
 {
 public:
   /// CommandInterface copy constructor is actively deleted.
@@ -146,7 +138,7 @@ public:
 
   CommandInterface(CommandInterface && other) = default;
 
-  using ReadWriteHandle<CommandInterface>::ReadWriteHandle;
+  using ReadWriteHandle::ReadWriteHandle;
 };
 
 }  // namespace hardware_interface

--- a/transmission_interface/include/transmission_interface/handle.hpp
+++ b/transmission_interface/include/transmission_interface/handle.hpp
@@ -22,17 +22,17 @@
 namespace transmission_interface
 {
 /** A handle used to get and set a value on a given actuator interface. */
-class ActuatorHandle : public hardware_interface::ReadWriteHandle<ActuatorHandle>
+class ActuatorHandle : public hardware_interface::ReadWriteHandle
 {
 public:
-  using hardware_interface::ReadWriteHandle<ActuatorHandle>::ReadWriteHandle;
+  using hardware_interface::ReadWriteHandle::ReadWriteHandle;
 };
 
 /** A handle used to get and set a value on a given joint interface. */
-class JointHandle : public hardware_interface::ReadWriteHandle<JointHandle>
+class JointHandle : public hardware_interface::ReadWriteHandle
 {
 public:
-  using hardware_interface::ReadWriteHandle<JointHandle>::ReadWriteHandle;
+  using hardware_interface::ReadWriteHandle::ReadWriteHandle;
 };
 
 }  // namespace transmission_interface


### PR DESCRIPTION
`with_value_ptr` method is going to be removed (see #378) , and with it goes away the need for class templatization for `ReadOnlyHandle` and all children classes (`ReadWriteHandle`, `StateInterface`, `CommandInterface`).
This PR removes those class templatization.
However this breaks ABI and API....