### PR TITLE
move deprecation note before function definition instead of inside

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -59,9 +59,9 @@ public:
   /// Returns true if handle references a value.
   inline operator bool() const {return value_ptr_ != nullptr;}
 
+  [[deprecated("with_value_ptr is deprecated and will be removed in the next release")]]
   HandleType with_value_ptr(double * value_ptr)
   {
-    [[deprecated("with_value_ptr is deprecated and will be removed in the next release")]]
     return HandleType(name_, interface_name_, value_ptr);
   }
 


### PR DESCRIPTION
Following #378, the [[deprecated]] has been moved to at function definition. Otherwise it throws the following warnings which are not the one we expect:
`attributes at the beginning of statement are ignored [-Wattributes] 64 ...`