### PR TITLE
Add NodeOptions parameter to init function of controller_interface

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -38,8 +38,14 @@ install(TARGETS controller_interface
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gmock(test_controller_with_options test/test_controller_with_options.cpp)
+  target_link_libraries(test_controller_with_options controller_interface)
+  target_include_directories(test_controller_with_options PRIVATE include)
 endif()
 
 ament_export_dependencies(

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -39,7 +39,6 @@ install(TARGETS controller_interface
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
-  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -100,6 +100,11 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual
   return_type
+  init(const std::string & controller_name, rclcpp::NodeOptions & node_options);
+
+  CONTROLLER_INTERFACE_PUBLIC
+  virtual
+  return_type
   update() = 0;
 
   CONTROLLER_INTERFACE_PUBLIC

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -4,6 +4,7 @@
   <name>controller_interface</name>
   <version>0.4.0</version>
   <description>Description of controller_interface</description>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>
 
@@ -15,7 +16,7 @@
   <exec_depend>hardware_interface</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -34,6 +34,17 @@ ControllerInterface::init(const std::string & controller_name)
   return return_type::OK;
 }
 
+return_type
+ControllerInterface::init(const std::string & controller_name, rclcpp::NodeOptions & node_options)
+{
+  node_ = std::make_shared<rclcpp::Node>(
+    controller_name,
+    node_options.allow_undeclared_parameters(true));
+  lifecycle_state_ = rclcpp_lifecycle::State(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+  return return_type::OK;
+}
+
 const rclcpp_lifecycle::State & ControllerInterface::configure()
 {
   if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2021 ros2_control development team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -17,42 +17,6 @@
 #include "test_controller_with_options.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-namespace controller_with_options
-{
-controller_interface::return_type ControllerWithOptions::init(
-  const std::string & controller_name)
-{
-  rclcpp::NodeOptions options;
-  options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
-  auto result = ControllerInterface::init(controller_name, options);
-  if (result == controller_interface::return_type::ERROR) {
-    return result;
-  }
-  if (node_->get_parameters("parameter_list", params)) {
-    RCLCPP_INFO_STREAM(node_->get_logger(), "I found " << params.size() << " parameters.");
-    return controller_interface::return_type::OK;
-  } else {
-    return controller_interface::return_type::ERROR;
-  }
-}
-controller_interface::InterfaceConfiguration
-ControllerWithOptions::command_interface_configuration() const
-{
-  return controller_interface::InterfaceConfiguration{
-    controller_interface::interface_configuration_type::NONE};
-}
-controller_interface::InterfaceConfiguration
-ControllerWithOptions::state_interface_configuration() const
-{
-  return controller_interface::InterfaceConfiguration{
-    controller_interface::interface_configuration_type::NONE};
-}
-controller_interface::return_type ControllerWithOptions::update()
-{
-  return controller_interface::return_type::OK;
-}
-}  // namespace controller_with_options
-
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions
 {
   FRIEND_TEST(ControllerWithOption, init_with_overrides);

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -1,0 +1,98 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include "test_controller_with_options.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace controller_with_options
+{
+controller_interface::return_type ControllerWithOptions::init(
+  const std::string & controller_name)
+{
+  rclcpp::NodeOptions options;
+  options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
+  auto result = ControllerInterface::init(controller_name, options);
+  if (result == controller_interface::return_type::ERROR) {
+    return result;
+  }
+  if (node_->get_parameters("parameter_list", params)) {
+    RCLCPP_INFO_STREAM(node_->get_logger(), "I found " << params.size() << " parameters.");
+    return controller_interface::return_type::OK;
+  } else {
+    return controller_interface::return_type::ERROR;
+  }
+}
+controller_interface::InterfaceConfiguration
+ControllerWithOptions::command_interface_configuration() const
+{
+  return controller_interface::InterfaceConfiguration{
+    controller_interface::interface_configuration_type::NONE};
+}
+controller_interface::InterfaceConfiguration
+ControllerWithOptions::state_interface_configuration() const
+{
+  return controller_interface::InterfaceConfiguration{
+    controller_interface::interface_configuration_type::NONE};
+}
+controller_interface::return_type ControllerWithOptions::update()
+{
+  return controller_interface::return_type::OK;
+}
+}  // namespace controller_with_options
+
+class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions
+{
+  FRIEND_TEST(ControllerWithOption, init_with_overrides);
+  FRIEND_TEST(ControllerWithOption, init_without_overrides);
+};
+
+TEST(ControllerWithOption, init_with_overrides) {
+  // mocks the declaration of overrides parameters in a yaml file
+  int argc = 8;
+  char const * const argv[8] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
+    "parameter_list.parameter2:=2.", "-p", "parameter_list.parameter3:=3."};
+  rclcpp::init(argc, argv);
+  // creates the controller
+  FriendControllerWithOptions controller;
+  EXPECT_EQ(controller.init("controller_name"), controller_interface::return_type::OK);
+  // checks that the node options have been updated
+  const auto & node_options = controller.node_->get_node_options();
+  EXPECT_TRUE(node_options.allow_undeclared_parameters());
+  EXPECT_TRUE(node_options.automatically_declare_parameters_from_overrides());
+  // checks that the parameters have been correctly processed
+  EXPECT_EQ(controller.params.size(), 3u);
+  EXPECT_EQ(controller.params["parameter1"], 1.);
+  EXPECT_EQ(controller.params["parameter2"], 2.);
+  EXPECT_EQ(controller.params["parameter3"], 3.);
+  rclcpp::shutdown();
+}
+
+TEST(ControllerWithOption, init_without_overrides) {
+  // mocks the declaration of overrides parameters in a yaml file
+  int argc = 1;
+  char const * const argv[8] = {""};
+  rclcpp::init(argc, argv);
+  // creates the controller
+  FriendControllerWithOptions controller;
+  EXPECT_EQ(controller.init("controller_name"), controller_interface::return_type::ERROR);
+  // checks that the node options have been updated
+  const auto & node_options = controller.node_->get_node_options();
+  EXPECT_TRUE(node_options.allow_undeclared_parameters());
+  EXPECT_TRUE(node_options.automatically_declare_parameters_from_overrides());
+  // checks that no parameter has been declared from overrides
+  EXPECT_EQ(controller.params.size(), 0u);
+  rclcpp::shutdown();
+}

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -62,7 +62,7 @@ class FriendControllerWithOptions : public controller_with_options::ControllerWi
 TEST(ControllerWithOption, init_with_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
   int argc = 8;
-  char const * const argv[8] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
+  char const * const argv[argc] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
     "parameter_list.parameter2:=2.", "-p", "parameter_list.parameter3:=3."};
   rclcpp::init(argc, argv);
   // creates the controller
@@ -83,7 +83,7 @@ TEST(ControllerWithOption, init_with_overrides) {
 TEST(ControllerWithOption, init_without_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
   int argc = 1;
-  char const * const argv[8] = {""};
+  char const * const argv[argc] = {""};
   rclcpp::init(argc, argv);
   // creates the controller
   FriendControllerWithOptions controller;

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2021 ros2_control development team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -31,11 +31,42 @@ class ControllerWithOptions : public controller_interface::ControllerInterface
 {
 public:
   ControllerWithOptions() = default;
-  controller_interface::return_type init(const std::string & controller_name) override;
-  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
-  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
-  controller_interface::return_type update() override;
+  controller_interface::return_type init(const std::string & controller_name) override
+  {
+    rclcpp::NodeOptions options;
+    options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
+    auto result = ControllerInterface::init(controller_name, options);
+    if (result == controller_interface::return_type::ERROR) {
+      return result;
+    }
+    if (node_->get_parameters("parameter_list", params)) {
+      RCLCPP_INFO_STREAM(node_->get_logger(), "I found " << params.size() << " parameters.");
+      return controller_interface::return_type::OK;
+    } else {
+      return controller_interface::return_type::ERROR;
+    }
+  }
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override
+  {
+    return controller_interface::InterfaceConfiguration{
+      controller_interface::interface_configuration_type::NONE};
+  }
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override
+  {
+    return controller_interface::InterfaceConfiguration{
+      controller_interface::interface_configuration_type::NONE};
+  }
+
+  controller_interface::return_type update() override
+  {
+    return controller_interface::return_type::OK;
+  }
+
   std::map<std::string, double> params;
 };
 }  // namespace controller_with_options
+
+
 #endif  // TEST_CONTROLLER_WITH_OPTIONS_HPP_

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -1,0 +1,41 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_CONTROLLER_WITH_OPTIONS_HPP_
+#define TEST_CONTROLLER_WITH_OPTIONS_HPP_
+
+#include <controller_interface/controller_interface.hpp>
+#include <string>
+#include <map>
+
+namespace controller_with_options
+{
+/**
+ * Example of Controller using the ControllerInterface::init(const std::string &,
+ * rclcpp::NodeOptions &) function. In this example, we set the node options so that parameters
+ * are automatically declared by overrides. This is a rare use case, but it can be useful in some
+ * situations.
+ */
+class ControllerWithOptions : public controller_interface::ControllerInterface
+{
+public:
+  ControllerWithOptions() = default;
+  controller_interface::return_type init(const std::string & controller_name) override;
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+  controller_interface::return_type update() override;
+  std::map<std::string, double> params;
+};
+}  // namespace controller_with_options
+#endif  // TEST_CONTROLLER_WITH_OPTIONS_HPP_


### PR DESCRIPTION
This allows for finer tuning of the NodeOptions of the controller_interface object.
For example, this allows to declare parameters from YAML files directly with the options `allow_undeclared_parameters` and `automatically_declare_parameters_from_overrides`