### PR TITLE
Remove empty argument on INSTANTIATE_TEST_CASE_P for Rolling

### DIFF
--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(
     // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
     // https://github.com/google/googletest/issues/1419
     // cppcheck-suppress syntaxError
-    SimpleTransmission(-10.0, -1.0)), );
+    SimpleTransmission(-10.0, -1.0)));
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};


### PR DESCRIPTION
This does not compile with the errors @tylerjw mentioned in #389, since INSTANTIATE_TEST_CASE_P no longer accepts empty arguments. This PR remove empty argument on INSTANTIATE_TEST_CASE_P to compile ros2_control on rolling