### PR TITLE
Revert "Remove empty argument on INSTANTIATE_TEST_CASE_P for Rolling"

### DIFF
--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(
     // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
     // https://github.com/google/googletest/issues/1419
     // cppcheck-suppress syntaxError
-    SimpleTransmission(-10.0, -1.0)));
+    SimpleTransmission(-10.0, -1.0)), );
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};


### PR DESCRIPTION
Reverts ros-controls/ros2_control#390

as mentioned here: https://github.com/ros-controls/ros2_control/pull/390#issuecomment-825995367
If we need/want to support rolling, we have to branch off. As it stands today, the master branches only accept Foxy.