### PR TITLE
avoid deprecations warnings (on OSX)

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -31,12 +31,16 @@
 namespace controller_interface
 {
 
+// TODO(karsten1987): Remove clang pragma within Galactic
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++17-extensions"
 enum class return_type : std::uint8_t
 {
   OK = 0,
   ERROR = 1,
   SUCCESS [[deprecated("Use controller_interface::return_type::OK instead.")]] = OK
 };
+#pragma clang diagnostic pop
 
 /// Indicating which interfaces are to be claimed.
 /**

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
@@ -27,7 +27,7 @@ TestControllerFailedInit::TestControllerFailedInit()
 {}
 
 controller_interface::return_type
-TestControllerFailedInit::init(const std::string & controller_name)
+TestControllerFailedInit::init(const std::string & /* controller_name */)
 {
   return controller_interface::return_type::ERROR;
 }

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -63,12 +63,3 @@ TEST(TestHandle, value_methods_work_on_non_nullptr)
   EXPECT_NO_THROW(handle.set_value(0.0));
   EXPECT_DOUBLE_EQ(handle.get_value(), 0.0);
 }
-
-TEST(TestHandle, with_value_ptr_initializes_new_handle_correctly)
-{
-  double value = 1.337;
-  StateInterface handle{JOINT_NAME, FOO_INTERFACE};
-  auto new_handle = handle.with_value_ptr(&value);
-  EXPECT_ANY_THROW(handle.get_value());
-  EXPECT_DOUBLE_EQ(new_handle.get_value(), value);
-}


### PR DESCRIPTION
Clang complaint about a few warnings, mentioned in https://github.com/ros-controls/ros2_control/pull/374#issuecomment-825996131 and https://github.com/ros-controls/ros2_control/pull/381#issuecomment-825994127