### PR TITLE
guard around pragmas

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -32,15 +32,19 @@ namespace controller_interface
 {
 
 // TODO(karsten1987): Remove clang pragma within Galactic
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++17-extensions"
+#endif
 enum class return_type : std::uint8_t
 {
   OK = 0,
   ERROR = 1,
   SUCCESS [[deprecated("Use controller_interface::return_type::OK instead.")]] = OK
 };
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 /// Indicating which interfaces are to be claimed.
 /**


### PR DESCRIPTION
follow up to #393, the pragmas obviously only work on a clang compiler.
The buildfarm is not really happy when using gcc: https://build.ros2.org/job/Fdev__ros2_control__ubuntu_focal_amd64/60/display/redirect?page=changes

@bmagyar fyi
