### PR TITLE
correct return values in CLI

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/configure_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/configure_controller.py
@@ -35,4 +35,6 @@ class ConfigureControllerVerb(VerbExtension):
             response = configure_controller(node, args.controller_manager, args.controller_name)
             if not response.ok:
                 'Error configuring controller, check controller_manager logs'
-            return f'Successfully configured controller {args.controller_name}'
+
+            print(f'Successfully configured controller {args.controller_name}')
+            return 0

--- a/ros2controlcli/ros2controlcli/verb/configure_start_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/configure_start_controller.py
@@ -36,4 +36,6 @@ class ConfigureStartControllerVerb(VerbExtension):
         response = configure_start_controller(args.controller_manager, args.controller_name)
         if not response.ok:
             return 'Error configuring and starting controller, check controller_manager logs'
-        return f'Successfully configured and started controller {args.controller_name}'
+
+        print(f'Successfully configured and started controller {args.controller_name}')
+        return 0

--- a/ros2controlcli/ros2controlcli/verb/list.py
+++ b/ros2controlcli/ros2controlcli/verb/list.py
@@ -33,4 +33,5 @@ class ListVerb(VerbExtension):
             controllers = list_controllers(node, args.controller_manager).controller
             for c in controllers:
                 print(f'{c.name:20s}[{c.type:20s}] {c.state:10s}')
+            
             return 0

--- a/ros2controlcli/ros2controlcli/verb/list.py
+++ b/ros2controlcli/ros2controlcli/verb/list.py
@@ -33,5 +33,5 @@ class ListVerb(VerbExtension):
             controllers = list_controllers(node, args.controller_manager).controller
             for c in controllers:
                 print(f'{c.name:20s}[{c.type:20s}] {c.state:10s}')
-            
+
             return 0

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
@@ -48,4 +48,5 @@ class ListHardwareInterfacesVerb(VerbExtension):
             print('state interfaces')
             for state_interface in state_interfaces:
                 print('\t', state_interface.name)
+
             return 0

--- a/ros2controlcli/ros2controlcli/verb/list_types.py
+++ b/ros2controlcli/ros2controlcli/verb/list_types.py
@@ -34,5 +34,5 @@ class ListTypesVerb(VerbExtension):
             types_and_classes = zip(response.types, response.base_classes)
             for c in types_and_classes:
                 print(f'{c[0]:70s} {c[1]}')
-            
+
             return 0

--- a/ros2controlcli/ros2controlcli/verb/list_types.py
+++ b/ros2controlcli/ros2controlcli/verb/list_types.py
@@ -34,4 +34,5 @@ class ListTypesVerb(VerbExtension):
             types_and_classes = zip(response.types, response.base_classes)
             for c in types_and_classes:
                 print(f'{c[0]:70s} {c[1]}')
+            
             return 0

--- a/ros2controlcli/ros2controlcli/verb/load.py
+++ b/ros2controlcli/ros2controlcli/verb/load.py
@@ -57,6 +57,6 @@ class LoadVerb(VerbExtension):
                 if not response.ok:
                     return 'Error starting controller, check controller_manager logs'
 
-            print(f'Sucessfully loaded controller {args.controller_name} into ' \
+            print(f'Sucessfully loaded controller {args.controller_name} into '
                   f'state { "inactive" if args.state == "configure" else "active" }')
             return 0

--- a/ros2controlcli/ros2controlcli/verb/load.py
+++ b/ros2controlcli/ros2controlcli/verb/load.py
@@ -42,7 +42,8 @@ class LoadVerb(VerbExtension):
                 return 'Error loading controller, check controller_manager logs'
 
             if not args.state:
-                return f'Successfully loaded controller {args.controller_name}'
+                print(f'Successfully loaded controller {args.controller_name}')
+                return 0
 
             # we in any case configure the controller
             response = configure_controller(node, args.controller_manager, args.controller_name)
@@ -56,5 +57,6 @@ class LoadVerb(VerbExtension):
                 if not response.ok:
                     return 'Error starting controller, check controller_manager logs'
 
-            return f'Sucessfully loaded controller {args.controller_name} into ' \
-                   f'state { "inactive" if args.state == "configure" else "active" }'
+            print(f'Sucessfully loaded controller {args.controller_name} into ' \
+                  f'state { "inactive" if args.state == "configure" else "active" }')
+            return 0

--- a/ros2controlcli/ros2controlcli/verb/load_configure_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_configure_controller.py
@@ -36,4 +36,6 @@ class LoadConfigureControllerVerb(VerbExtension):
         response = load_configure_controller(args.controller_manager, args.controller_name)
         if not response.ok:
             return 'Error loading and configuring controller, check controller_manager logs'
-        return f'Successfully loaded and configured controller {args.controller_name}'
+
+        print(f'Successfully loaded and configured controller {args.controller_name}')
+        return 0

--- a/ros2controlcli/ros2controlcli/verb/load_start_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_start_controller.py
@@ -36,6 +36,6 @@ class LoadStartControllerVerb(VerbExtension):
         response = load_start_controller(args.controller_manager, args.controller_name)
         if not response.ok:
             return 'Error loading and starting controller, check controller_manager logs'
-        
+
         print(f'Successfully loaded and started controller {args.controller_name}')
         return 0

--- a/ros2controlcli/ros2controlcli/verb/load_start_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_start_controller.py
@@ -36,4 +36,6 @@ class LoadStartControllerVerb(VerbExtension):
         response = load_start_controller(args.controller_manager, args.controller_name)
         if not response.ok:
             return 'Error loading and starting controller, check controller_manager logs'
-        return f'Successfully loaded and started controller {args.controller_name}'
+        
+        print(f'Successfully loaded and started controller {args.controller_name}')
+        return 0

--- a/ros2controlcli/ros2controlcli/verb/reload_libraries.py
+++ b/ros2controlcli/ros2controlcli/verb/reload_libraries.py
@@ -36,6 +36,8 @@ class ReloadLibrariesVerb(VerbExtension):
             response = reload_controller_libraries(
                 node, args.controller_manager, force_kill=args.force_kill
             )
-            if response.ok:
-                return 'Reload successful'
-            return 'Error reloading libraries, check controller_manager logs'
+            if not response.ok:
+                return 'Error reloading libraries, check controller_manager logs'
+
+            print('Reload successful')
+            return 0

--- a/ros2controlcli/ros2controlcli/verb/set_controller_state.py
+++ b/ros2controlcli/ros2controlcli/verb/set_controller_state.py
@@ -54,7 +54,9 @@ class SetControllerStateVerb(VerbExtension):
                 )
                 if not response.ok:
                     return 'Error configuring controller, check controller_manager logs'
-                return f'successfully configured {args.controller_name}'
+
+                print(f'successfully configured {args.controller_name}')
+                return 0
 
             if args.state == 'start':
                 if matched_controller.state != 'inactive':
@@ -65,7 +67,9 @@ class SetControllerStateVerb(VerbExtension):
                 )
                 if not response.ok:
                     return 'Error starting controller, check controller_manager logs'
-                return f'successfully started {args.controller_name}'
+
+                print(f'successfully started {args.controller_name}')
+                return 0
 
             if args.state == 'stop':
                 if matched_controller.state != 'active':
@@ -77,4 +81,6 @@ class SetControllerStateVerb(VerbExtension):
                 )
                 if not response.ok:
                     return 'Error stopping controller, check controller_manager logs'
-                return f'successfully stopped {args.controller_name}'
+
+                print(f'successfully stopped {args.controller_name}')
+                return 0

--- a/ros2controlcli/ros2controlcli/verb/switch.py
+++ b/ros2controlcli/ros2controlcli/verb/switch.py
@@ -64,4 +64,6 @@ class SwitchVerb(VerbExtension):
             )
             if not response.ok:
                 return 'Error switching controllers, check controller_manager logs'
-            return 'Successfully switched controllers'
+
+            print('Successfully switched controllers')
+            return 0

--- a/ros2controlcli/ros2controlcli/verb/unload.py
+++ b/ros2controlcli/ros2controlcli/verb/unload.py
@@ -35,4 +35,6 @@ class UnloadVerb(VerbExtension):
             response = unload_controller(node, args.controller_manager, args.controller_name)
             if not response.ok:
                 return 'Error unloading controllers, check controller_manager logs'
-            return f'Successfully unloaded controller {args.controller_name}'
+
+            print(f'Successfully unloaded controller {args.controller_name}')
+            return 0


### PR DESCRIPTION
fixes #396 

returning a string counts as a non-zero return code. This PR simply changes the return code to a `print` and returns 0 instead.

@Teusner fyi