### PR TITLE
Bump `wait_for_service` timeout to 10 seconds

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -25,7 +25,7 @@ def service_caller(node, service_name, service_type, request):
     if not cli.service_is_ready():
         node.get_logger().debug('waiting for service {} to become available...'
                                 .format(service_name))
-        if not cli.wait_for_service(2.0):
+        if not cli.wait_for_service(10.0):
             raise RuntimeError('Could not contact service {}'.format(service_name))
 
     node.get_logger().debug('requester: making request: %r\n' % request)


### PR DESCRIPTION
The controller manager might need a few seconds to boot all their hardware resources before the actual `spin` is triggered and its services are available.
The spawner.py script might be called simultaneously within the same launch file and should thus be able to wait for a bit longer in order for the CM services to be available.