### PR TITLE
Make controller manager update rate optional

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -44,7 +44,7 @@ int main(int argc, char ** argv)
   std::thread cm_thread([cm]() {
       // load controller_manager update time parameter
       int update_rate = DEFAULT_UPDATE_RATE;
-      if(!cm->get_parameter("update_rate", update_rate)){
+      if (!cm->get_parameter("update_rate", update_rate)) {
         RCLCPP_WARN(cm->get_logger(), "'update_rate' parameter not set, using default value.");
       }
       RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -42,9 +42,7 @@ int main(int argc, char ** argv)
   std::thread cm_thread([cm]() {
       // load controller_manager update time parameter
       int update_rate = 100;
-      if (!cm->get_parameter("update_rate", update_rate)) {
-        throw std::runtime_error("update_rate parameter not existing or empty");
-      }
+      cm->get_parameter_or("update_rate", update_rate, update_rate);
       RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);
 
       while (rclcpp::ok()) {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -23,6 +23,8 @@
 
 using namespace std::chrono_literals;
 
+const int DEFAULT_UPDATE_RATE = 100;
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
@@ -41,8 +43,10 @@ int main(int argc, char ** argv)
   // converted back to a timer.
   std::thread cm_thread([cm]() {
       // load controller_manager update time parameter
-      int update_rate = 100;
-      cm->get_parameter_or("update_rate", update_rate, update_rate);
+      int update_rate = DEFAULT_UPDATE_RATE;
+      if(!cm->get_parameter("update_rate", update_rate)){
+        RCLCPP_WARN(cm->get_logger(), "'update_rate' parameter not set, using default value.");
+      }
       RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);
 
       while (rclcpp::ok()) {


### PR DESCRIPTION
I believe it's still good practice to declare a desired update rate, but we shouldn't necessarily require it and actually default it to 100 if not declared.
The current logic was flawed in a way that it would always raise the exception if the parameter wasn't set.