### PR TITLE
List controller claimed interfaces

### DIFF
--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -18,8 +18,10 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "controller_interface/controller_interface.hpp"
@@ -144,10 +146,56 @@ public:
     cm_ = std::make_shared<controller_manager::ControllerManager>(
       std::make_unique<hardware_interface::ResourceManager>(controller_manager_test::urdf),
       executor_, "test_controller_manager");
+    run_updater_ = false;
+  }
+
+  void TearDown()
+  {
+    stopCmUpdater();
+  }
+
+  void startCmUpdater()
+  {
+    run_updater_ = true;
+    updater_ = std::thread(
+      [&](void) -> void {
+        while (run_updater_) {
+          cm_->update();
+          std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+      });
+  }
+
+  void stopCmUpdater()
+  {
+    if (run_updater_) {
+      run_updater_ = false;
+      updater_.join();
+    }
   }
 
   std::shared_ptr<rclcpp::Executor> executor_;
   std::shared_ptr<controller_manager::ControllerManager> cm_;
+
+  std::thread updater_;
+  bool run_updater_;
+};
+
+class ControllerManagerRunner
+{
+public:
+  explicit ControllerManagerRunner(ControllerManagerFixture * cmf)
+  : cmf_(cmf)
+  {
+    cmf_->startCmUpdater();
+  }
+
+  ~ControllerManagerRunner()
+  {
+    cmf_->stopCmUpdater();
+  }
+
+  ControllerManagerFixture * cmf_;
 };
 
 class ControllerMock : public controller_interface::ControllerInterface

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -23,7 +23,8 @@ namespace test_controller
 {
 
 TestController::TestController()
-: controller_interface::ControllerInterface()
+: controller_interface::ControllerInterface(),
+  cmd_iface_cfg_{controller_interface::interface_configuration_type::NONE}
 {}
 
 controller_interface::return_type
@@ -51,6 +52,12 @@ TestController::on_cleanup(
     (*cleanup_calls)++;
   }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+void TestController::set_command_interface_configuration(
+  const controller_interface::InterfaceConfiguration & cfg)
+{
+  cmd_iface_cfg_ = cfg;
 }
 
 }  // namespace test_controller

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -41,8 +41,7 @@ public:
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
-    return controller_interface::InterfaceConfiguration{
-      controller_interface::interface_configuration_type::NONE};
+    return cmd_iface_cfg_;
   }
 
   controller_interface::InterfaceConfiguration state_interface_configuration() const override
@@ -63,11 +62,15 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
 
+  void set_command_interface_configuration(
+    const controller_interface::InterfaceConfiguration & cfg);
+
   size_t internal_counter = 0;
   bool simulate_cleanup_failure = false;
   // Variable where we store when cleanup was called, pointer because the controller
   // is usually destroyed after cleanup
   size_t * cleanup_calls = nullptr;
+  controller_interface::InterfaceConfiguration cmd_iface_cfg_;
 };
 
 }  // namespace test_controller

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -149,7 +149,7 @@ TEST_F(TestLoadController, configure_controller)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -181,7 +181,7 @@ TEST_F(TestLoadController, configure_controller)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -381,11 +381,13 @@ TEST_F(TestLoadController, switch_controller)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    {
+      ControllerManagerRunner cm_runner(this);
+      EXPECT_EQ(
+        controller_interface::return_type::OK,
+        switch_future.get()
+      );
+    }
 
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
@@ -403,12 +405,13 @@ TEST_F(TestLoadController, switch_controller)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
-
+    {
+      ControllerManagerRunner cm_runner(this);
+      EXPECT_EQ(
+        controller_interface::return_type::OK,
+        switch_future.get()
+      );
+    }
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -430,7 +433,7 @@ TEST_F(TestLoadController, switch_controller)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -484,7 +487,7 @@ TEST_F(TestLoadController, switch_multiple_controllers)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -515,7 +518,7 @@ TEST_F(TestLoadController, switch_multiple_controllers)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -548,7 +551,7 @@ TEST_F(TestLoadController, switch_multiple_controllers)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -578,7 +581,7 @@ TEST_F(TestLoadController, switch_multiple_controllers)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -608,7 +611,7 @@ TEST_F(TestLoadController, switch_multiple_controllers)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()

--- a/controller_manager/test/test_release_interfaces.cpp
+++ b/controller_manager/test/test_release_interfaces.cpp
@@ -76,7 +76,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -105,7 +105,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -133,7 +133,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -161,7 +161,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -190,7 +190,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
     //   std::future_status::timeout,
     //   switch_future.wait_for(std::chrono::milliseconds(100))) <<
     //   "switch_controller should be blocking until next update cycle";
-    // cm_->update();
+    // ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::ERROR,
       switch_future.get()
@@ -218,7 +218,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()
@@ -246,7 +246,7 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       std::future_status::timeout,
       switch_future.wait_for(std::chrono::milliseconds(100))) <<
       "switch_controller should be blocking until next update cycle";
-    cm_->update();
+    ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(
       controller_interface::return_type::OK,
       switch_future.get()

--- a/controller_manager_msgs/msg/ControllerState.msg
+++ b/controller_manager_msgs/msg/ControllerState.msg
@@ -1,5 +1,4 @@
 string name
 string state
 string type
-# To be implemented
-# controller_manager_msgs/HardwareInterfaceResources[] claimed_resources
+string[] claimed_interfaces

--- a/hardware_interface/include/hardware_interface/controller_info.hpp
+++ b/hardware_interface/include/hardware_interface/controller_info.hpp
@@ -16,9 +16,7 @@
 #define HARDWARE_INTERFACE__CONTROLLER_INFO_HPP_
 
 #include <string>
-// TODO(v-lopez)
-// #include <vector>
-// #include <hardware_interface/interface_resources.h>
+#include <vector>
 
 namespace hardware_interface
 {
@@ -35,9 +33,8 @@ struct ControllerInfo
   /// Controller type.
   std::string type;
 
-  // TODO(v-lopez)
-  /** Claimed resources, grouped by the hardware interface they belong to. */
-//   std::map<std::string, std::vector<std::string>> resources;
+  /// List of claimed interfaces by the controller.
+  std::vector<std::string> claimed_interfaces;
 };
 
 }  // namespace hardware_interface


### PR DESCRIPTION
With this PR the controller manager `list_controllers` service now also informs about the claimed interfaces by each controller akin to what was done in the ROS1 version of the service.

```
ros2 service call /controller_manager/list_controllers controller_manager_msgs/srv/ListControllers
requester: making request: controller_manager_msgs.srv.ListControllers_Request()

response:
controller_manager_msgs.srv.ListControllers_Response(controller=[controller_manager_msgs.msg.ControllerState(name='joint_trajectory_controller', state='active', type='joint_trajectory_controller/JointTrajectoryController', claimed_interfaces=['joint1/position', 'joint2/position']), controller_manager_msgs.msg.ControllerState(name='joint_state_broadcaster', state='active', type='joint_state_broadcaster/JointStateBroadcaster', claimed_interfaces=[])])
```
