### PR TITLE
Make hardware interface types as const char array rather than a pointer to const char 

### DIFF
--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -18,13 +18,13 @@
 namespace hardware_interface
 {
 /// Constant defining position interface
-constexpr const auto HW_IF_POSITION = "position";
+constexpr char HW_IF_POSITION[] = "position";
 /// Constant defining velocity interface
-constexpr const auto HW_IF_VELOCITY = "velocity";
+constexpr char HW_IF_VELOCITY[] = "velocity";
 /// Constant defining acceleration interface
-constexpr const auto HW_IF_ACCELERATION = "acceleration";
+constexpr char HW_IF_ACCELERATION[] = "acceleration";
 /// Constant defining effort interface
-constexpr const auto HW_IF_EFFORT = "effort";
+constexpr char HW_IF_EFFORT[] = "effort";
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_


### PR DESCRIPTION
This's needed for https://github.com/ros-controls/ros2_controllers/pull/162

Using `auto` will cause the type of the variable to decay (a pointer to const char for the variables here) which prevent it from being used as a template parameter