### PR TITLE
prevent variable-sized object initialization

### DIFF
--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -23,11 +23,14 @@ class FriendControllerWithOptions : public controller_with_options::ControllerWi
   FRIEND_TEST(ControllerWithOption, init_without_overrides);
 };
 
+template<class T, size_t N>
+constexpr size_t arrlen(T (&)[N]) {return N;}
+
 TEST(ControllerWithOption, init_with_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
-  int argc = 8;
-  char const * const argv[8] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
+  char const * const argv[] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
     "parameter_list.parameter2:=2.", "-p", "parameter_list.parameter3:=3."};
+  int argc = arrlen(argv);
   rclcpp::init(argc, argv);
   // creates the controller
   FriendControllerWithOptions controller;
@@ -46,8 +49,8 @@ TEST(ControllerWithOption, init_with_overrides) {
 
 TEST(ControllerWithOption, init_without_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
-  int argc = 1;
-  char const * const argv[1] = {""};
+  char const * const argv[] = {""};
+  int argc = arrlen(argv);
   rclcpp::init(argc, argv);
   // creates the controller
   FriendControllerWithOptions controller;

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -26,7 +26,7 @@ class FriendControllerWithOptions : public controller_with_options::ControllerWi
 TEST(ControllerWithOption, init_with_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
   int argc = 8;
-  char const * const argv[argc] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
+  char const * const argv[8] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
     "parameter_list.parameter2:=2.", "-p", "parameter_list.parameter3:=3."};
   rclcpp::init(argc, argv);
   // creates the controller
@@ -47,7 +47,7 @@ TEST(ControllerWithOption, init_with_overrides) {
 TEST(ControllerWithOption, init_without_overrides) {
   // mocks the declaration of overrides parameters in a yaml file
   int argc = 1;
-  char const * const argv[argc] = {""};
+  char const * const argv[1] = {""};
   rclcpp::init(argc, argv);
   // creates the controller
   FriendControllerWithOptions controller;


### PR DESCRIPTION
Clang/OSX won't compile a variable-sized c-style array initialization.

```
[ 88%] Building CXX object CMakeFiles/test_controller_with_options.dir/test/test_controller_with_options.cpp.o
/Users/karsten/workspace/ros2/ros2_control_ws/src/ros-controls/ros2_control/controller_interface/test/test_controller_with_options.cpp:29:27: error: variable-sized object may not be initialized
  char const * const argv[argc] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
                          ^~~~
/Users/karsten/workspace/ros2/ros2_control_ws/src/ros-controls/ros2_control/controller_interface/test/test_controller_with_options.cpp:50:27: error: variable-sized object may not be initialized
  char const * const argv[argc] = {""};
                          ^~~~
2 errors generated.
```

Error was introduced in #382 