### PR TITLE
Added labels for controller states.

### DIFF
--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -22,7 +22,7 @@ namespace controller_interface
 
 namespace state_names
 {
-/// Constant defining state labels
+/// Constants defining string labels corresponding to lifecycle states
 const std::string UNCONFIGURED = "unconfigured";
 const std::stringr INACTIVE = "inactive";
 const std::string ACTIVE = "active";

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021, Stogl Robotics Consulting UG (haftungsbeschränkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/// \author: Denis Stogl
+
+#ifndef CONTROLLER_INTERFACE__CONTROLLER_STATE_NAMES_HPP_
+#define CONTROLLER_INTERFACE__CONTROLLER_STATE_NAMES_HPP_
+
+namespace controller_interface
+{
+
+namespace state_names
+{
+/// Constant defining state labels
+constexpr char UNCONFIGURED[] = "unconfigured";
+constexpr char INACTIVE[] = "inactive";
+constexpr char ACTIVE[] = "active";
+constexpr char FINALIZED[] = "finalized";
+}  // namespace state_names
+
+}  // namespace controller_interface
+
+#endif  // CONTROLLER_INTERFACE__CONTROLLER_STATE_NAMES_HPP_

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -25,10 +25,10 @@ namespace controller_interface
 namespace state_names
 {
 /// Constants defining string labels corresponding to lifecycle states
-const std::string UNCONFIGURED = "unconfigured";
-const std::string INACTIVE = "inactive";
-const std::string ACTIVE = "active";
-const std::string FINALIZED = "finalized";
+const auto UNCONFIGURED = "unconfigured";
+const auto INACTIVE = "inactive";
+const auto ACTIVE = "active";
+const auto FINALIZED = "finalized";
 }  // namespace state_names
 
 }  // namespace controller_interface

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -25,10 +25,10 @@ namespace controller_interface
 namespace state_names
 {
 /// Constants defining string labels corresponding to lifecycle states
-const auto UNCONFIGURED = "unconfigured";
-const auto INACTIVE = "inactive";
-const auto ACTIVE = "active";
-const auto FINALIZED = "finalized";
+constexpr char UNCONFIGURED[] = "unconfigured";
+constexpr char INACTIVE[] = "inactive";
+constexpr char ACTIVE[] = "active";
+constexpr char FINALIZED[] = "finalized";
 }  // namespace state_names
 
 }  // namespace controller_interface

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -23,10 +23,10 @@ namespace controller_interface
 namespace state_names
 {
 /// Constant defining state labels
-constexpr char UNCONFIGURED[] = "unconfigured";
-constexpr char INACTIVE[] = "inactive";
-constexpr char ACTIVE[] = "active";
-constexpr char FINALIZED[] = "finalized";
+const std::string UNCONFIGURED = "unconfigured";
+const std::stringr INACTIVE = "inactive";
+const std::string ACTIVE = "active";
+const std::string FINALIZED = "finalized";
 }  // namespace state_names
 
 }  // namespace controller_interface

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -17,6 +17,8 @@
 #ifndef CONTROLLER_INTERFACE__CONTROLLER_STATE_NAMES_HPP_
 #define CONTROLLER_INTERFACE__CONTROLLER_STATE_NAMES_HPP_
 
+#include <string>
+
 namespace controller_interface
 {
 
@@ -24,7 +26,7 @@ namespace state_names
 {
 /// Constants defining string labels corresponding to lifecycle states
 const std::string UNCONFIGURED = "unconfigured";
-const std::stringr INACTIVE = "inactive";
+const std::string INACTIVE = "inactive";
 const std::string ACTIVE = "active";
 const std::string FINALIZED = "finalized";
 }  // namespace state_names

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 #include "controller_interface/controller_interface.hpp"
-#include <lifecycle_msgs/msg/state.hpp>
 
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "controller_interface/controller_state_names.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
 
 namespace controller_interface
 {
@@ -30,7 +32,7 @@ ControllerInterface::init(const std::string & controller_name)
     controller_name,
     rclcpp::NodeOptions().allow_undeclared_parameters(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;
 }
 
@@ -52,12 +54,12 @@ const rclcpp_lifecycle::State & ControllerInterface::configure()
       case LifecycleNodeInterface::CallbackReturn::SUCCESS:
         lifecycle_state_ = rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-          "inactive");
+          state_names::INACTIVE);
         break;
       case LifecycleNodeInterface::CallbackReturn::ERROR:
         on_error(lifecycle_state_);
         lifecycle_state_ = rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+          lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
         break;
       case LifecycleNodeInterface::CallbackReturn::FAILURE:
         break;
@@ -71,12 +73,12 @@ const rclcpp_lifecycle::State & ControllerInterface::cleanup()
   switch (on_cleanup(lifecycle_state_)) {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
       break;
     case LifecycleNodeInterface::CallbackReturn::ERROR:
       on_error(lifecycle_state_);
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
       break;
     case LifecycleNodeInterface::CallbackReturn::FAILURE:
       break;
@@ -88,12 +90,12 @@ const rclcpp_lifecycle::State & ControllerInterface::deactivate()
   switch (on_deactivate(lifecycle_state_)) {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, "inactive");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, state_names::INACTIVE);
       break;
     case LifecycleNodeInterface::CallbackReturn::ERROR:
       on_error(lifecycle_state_);
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
       break;
     case LifecycleNodeInterface::CallbackReturn::FAILURE:
       break;
@@ -106,12 +108,12 @@ const rclcpp_lifecycle::State & ControllerInterface::activate()
     switch (on_activate(lifecycle_state_)) {
       case LifecycleNodeInterface::CallbackReturn::SUCCESS:
         lifecycle_state_ = rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active");
+          lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state_names::ACTIVE);
         break;
       case LifecycleNodeInterface::CallbackReturn::ERROR:
         on_error(lifecycle_state_);
         lifecycle_state_ = rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+          lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
         break;
       case LifecycleNodeInterface::CallbackReturn::FAILURE:
         break;
@@ -125,12 +127,12 @@ const rclcpp_lifecycle::State & ControllerInterface::shutdown()
   switch (on_activate(lifecycle_state_)) {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
       break;
     case LifecycleNodeInterface::CallbackReturn::ERROR:
       on_error(lifecycle_state_);
       lifecycle_state_ = rclcpp_lifecycle::State(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, "finalized");
+        lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
       break;
     case LifecycleNodeInterface::CallbackReturn::FAILURE:
       break;


### PR DESCRIPTION
Add controllers' state labels as constants to a separate file. This is useful when checking controllers' status from another node using "list_controller" service call.

This is a workaround to not break user-interface, i.e., service.

IMO the proper solution would be to exted the service response to include ID of the controller state defined in lifecycle_msg::msg::State.
This should be done in [here in the CM﻿](
https://github.com/ros-controls/ros2_control/blob/master/controller_manager/src/controller_manager.cpp#L792).
Then only ints would be compared and not strings.
