### PR TITLE
Fix failing test on rolling

### DIFF
--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -179,7 +179,11 @@ INSTANTIATE_TEST_CASE_P(
     // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
     // https://github.com/google/googletest/issues/1419
     // cppcheck-suppress syntaxError
+  #ifdef __APPLE__
     SimpleTransmission(-10.0, -1.0)), );
+  #else
+    SimpleTransmission(-10.0, -1.0)));
+#endif
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -168,6 +168,11 @@ TEST_P(BlackBoxTest, IdentityMap)
 }
 
 #ifdef __APPLE__
+#define INSTANTIATE_TEST_CASE_P_COMPAT ,
+#else
+#define INSTANTIATE_TEST_CASE_P_COMPAT
+#endif
+
 INSTANTIATE_TEST_CASE_P(
   IdentityMap,
   BlackBoxTest,
@@ -177,25 +182,9 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(10.0, 1.0),
     SimpleTransmission(10.0, -1.0),
     SimpleTransmission(-10.0, 1.0),
-    // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
-    // https://github.com/google/googletest/issues/1419
+    SimpleTransmission(-10.0, -1.0))
     // cppcheck-suppress syntaxError
-    SimpleTransmission(-10.0, -1.0)), );
-#else
-  INSTANTIATE_TEST_CASE_P(
-    IdentityMap,
-    BlackBoxTest,
-    ::testing::Values(
-      SimpleTransmission(10.0),
-      SimpleTransmission(-10.0),
-      SimpleTransmission(10.0, 1.0),
-      SimpleTransmission(10.0, -1.0),
-      SimpleTransmission(-10.0, 1.0),
-      // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
-      // https://github.com/google/googletest/issues/1419
-      // cppcheck-suppress syntaxError
-      SimpleTransmission(-10.0, -1.0)));
-#endif
+    INSTANTIATE_TEST_CASE_P_COMPAT);
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -167,6 +167,7 @@ TEST_P(BlackBoxTest, IdentityMap)
   testIdentityMap(trans, HW_IF_EFFORT, -1.0);
 }
 
+#ifdef __APPLE__
 INSTANTIATE_TEST_CASE_P(
   IdentityMap,
   BlackBoxTest,
@@ -179,10 +180,21 @@ INSTANTIATE_TEST_CASE_P(
     // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
     // https://github.com/google/googletest/issues/1419
     // cppcheck-suppress syntaxError
-  #ifdef __APPLE__
     SimpleTransmission(-10.0, -1.0)), );
-  #else
-    SimpleTransmission(-10.0, -1.0)));
+#else
+  INSTANTIATE_TEST_CASE_P(
+    IdentityMap,
+    BlackBoxTest,
+    ::testing::Values(
+      SimpleTransmission(10.0),
+      SimpleTransmission(-10.0),
+      SimpleTransmission(10.0, 1.0),
+      SimpleTransmission(10.0, -1.0),
+      SimpleTransmission(-10.0, 1.0),
+      // remove once INSTANTIATE_TEST_SUITE_P is available to use in gtest
+      // https://github.com/google/googletest/issues/1419
+      // cppcheck-suppress syntaxError
+      SimpleTransmission(-10.0, -1.0)));
 #endif
 
 class WhiteBoxTest : public TransmissionSetup,

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -183,8 +183,8 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(10.0, -1.0),
     SimpleTransmission(-10.0, 1.0),
     SimpleTransmission(-10.0, -1.0))
-    // cppcheck-suppress syntaxError
-    INSTANTIATE_TEST_CASE_P_COMPAT);
+  // cppcheck-suppress syntaxError
+  INSTANTIATE_TEST_CASE_P_COMPAT);
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};


### PR DESCRIPTION
Fixes the failin rolling test with a specfic macro for MacOS devices. See #406 and #390 .

This will allow ros2_control to compile on rolling