### PR TITLE
Fix transmission interface test on OSX

### DIFF
--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(-10.0, 1.0),
     SimpleTransmission(-10.0, -1.0))
   // cppcheck-suppress syntaxError
-  ,);
+  , );
 #else
 INSTANTIATE_TEST_CASE_P(
   IdentityMap,

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -168,11 +168,6 @@ TEST_P(BlackBoxTest, IdentityMap)
 }
 
 #ifdef __APPLE__
-#define INSTANTIATE_TEST_CASE_P_COMPAT ,
-#else
-#define INSTANTIATE_TEST_CASE_P_COMPAT
-#endif
-
 INSTANTIATE_TEST_CASE_P(
   IdentityMap,
   BlackBoxTest,
@@ -184,7 +179,20 @@ INSTANTIATE_TEST_CASE_P(
     SimpleTransmission(-10.0, 1.0),
     SimpleTransmission(-10.0, -1.0))
   // cppcheck-suppress syntaxError
-  INSTANTIATE_TEST_CASE_P_COMPAT);
+  ,);
+#else
+INSTANTIATE_TEST_CASE_P(
+  IdentityMap,
+  BlackBoxTest,
+  ::testing::Values(
+    SimpleTransmission(10.0),
+    SimpleTransmission(-10.0),
+    SimpleTransmission(10.0, 1.0),
+    SimpleTransmission(10.0, -1.0),
+    SimpleTransmission(-10.0, 1.0),
+    SimpleTransmission(-10.0, -1.0)));
+#endif
+
 
 class WhiteBoxTest : public TransmissionSetup,
   public ::testing::Test {};


### PR DESCRIPTION
This PR restores a functional compilation on OSX for foxy. As mentioned in https://github.com/ros-controls/ros2_control/pull/416#issuecomment-846094212 `if/else`ing between OS's might not be the right approach. We'd rather should separate between distros as this is the original intention to release for Foxy, Galactic and Rolling from the same branch.

I think there must be a better way to this wo/ code duplication, but expanding a macro in a macro didn't seem to work OOTB.