### PR TITLE
Use correct names after changing arguments

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/switch_controllers.py
+++ b/ros2controlcli/ros2controlcli/verb/switch_controllers.py
@@ -56,8 +56,8 @@ class SwitchControllersVerb(VerbExtension):
             response = switch_controllers(
                 node,
                 args.controller_manager,
-                args.stop_controllers,
-                args.start_controllers,
+                args.stop,
+                args.start,
                 args.strict,
                 args.start_asap,
                 args.switch_timeout,


### PR DESCRIPTION
In #412 we forgot to update the argument after changing flags.