### PR TITLE
Add missing dependency on controller_manager_msgs

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_controller_manager_srvs PRIVATE include)
   target_link_libraries(test_controller_manager_srvs controller_manager test_controller)
-  ament_target_dependencies (
+  ament_target_dependencies(
     test_controller_manager_srvs
     controller_manager_msgs
   )

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -123,6 +123,10 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_controller_manager_srvs PRIVATE include)
   target_link_libraries(test_controller_manager_srvs controller_manager test_controller)
+    ament_target_dependencies (
+    test_controller_manager_srvs
+    controller_manager_msgs
+  )
 
   add_library(test_controller_with_interfaces SHARED test/test_controller_with_interfaces/test_controller_with_interfaces.cpp)
   target_include_directories(test_controller_with_interfaces PRIVATE include)

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_controller_manager_srvs PRIVATE include)
   target_link_libraries(test_controller_manager_srvs controller_manager test_controller)
-    ament_target_dependencies (
+  ament_target_dependencies (
     test_controller_manager_srvs
     controller_manager_msgs
   )


### PR DESCRIPTION
Even after clearing the workspace and doing a clean build I had issues with missing dependency/fields when compiling this test.
It is obvious that the dependency is missing.