### PR TITLE
fix osx

### DIFF
--- a/controller_interface/include/semantic_components/semantic_component_interface.hpp
+++ b/controller_interface/include/semantic_components/semantic_component_interface.hpp
@@ -96,7 +96,7 @@ public:
   /**
    * \return false by default
    */
-  bool get_values_as_message(MessageReturnType & message)
+  bool get_values_as_message(MessageReturnType & /* message */)
   {
     return false;
   }

--- a/controller_interface/test/test_force_torque_sensor.cpp
+++ b/controller_interface/test/test_force_torque_sensor.cpp
@@ -18,6 +18,7 @@
 
 #include "test_force_torque_sensor.hpp"
 
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_interface/test/test_force_torque_sensor.hpp
+++ b/controller_interface/test/test_force_torque_sensor.hpp
@@ -49,6 +49,8 @@ public:
       interface_force_x, interface_force_y, interface_force_z,
       interface_torque_x, interface_torque_y, interface_torque_z)
   {}
+
+  virtual ~TestableForceTorqueSensor() = default;
 };
 
 class ForceTorqueSensorTest : public ::testing::Test

--- a/controller_interface/test/test_semantic_component_interface.hpp
+++ b/controller_interface/test/test_semantic_component_interface.hpp
@@ -50,6 +50,8 @@ public:
     }
   }
 
+  virtual ~TestableSemanticComponentInterface() = default;
+
   std::string test_name_ = "TestSemanticComponent";
 };
 


### PR DESCRIPTION
osx reported a bunch of error, mainly about not finding `isnan`. Then there were warnings about non-virtual destructors and unused variables.