### PR TITLE
Update arg reference to set_state since the argument name has been changed

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/load_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_controller.py
@@ -41,7 +41,7 @@ class LoadControllerVerb(VerbExtension):
             if not response.ok:
                 return 'Error loading controller, check controller_manager logs'
 
-            if not args.state:
+            if not args.set_state:
                 print(f'Successfully loaded controller {args.controller_name}')
                 return 0
 
@@ -50,7 +50,7 @@ class LoadControllerVerb(VerbExtension):
             if not response.ok:
                 return 'Error configuring controller'
 
-            if args.state == 'start':
+            if args.set_state == 'start':
                 response = switch_controllers(
                     node, args.controller_manager, [], [args.controller_name], True, True, 5.0
                 )
@@ -58,5 +58,5 @@ class LoadControllerVerb(VerbExtension):
                     return 'Error starting controller, check controller_manager logs'
 
             print(f'Sucessfully loaded controller {args.controller_name} into '
-                  f'state { "inactive" if args.state == "configure" else "active" }')
+                  f'state { "inactive" if args.set_state == "configure" else "active" }')
             return 0


### PR DESCRIPTION
In ros2controlcli load_controller.py the argument state was renamed to set-state. This was not reflected in the references to that argument later on in the file, resulting in an attribute error when trying to use set-state.