### PR TITLE
Use namespace in controller_manager

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -56,12 +56,14 @@ public:
   ControllerManager(
     std::unique_ptr<hardware_interface::ResourceManager> resource_manager,
     std::shared_ptr<rclcpp::Executor> executor,
-    const std::string & manager_node_name = "controller_manager");
+    const std::string & manager_node_name = "controller_manager",
+    const std::string & namespace_ = "");
 
   CONTROLLER_MANAGER_PUBLIC
   ControllerManager(
     std::shared_ptr<rclcpp::Executor> executor,
-    const std::string & manager_node_name = "controller_manager");
+    const std::string & manager_node_name = "controller_manager",
+    const std::string & namespace_ = "");
 
   CONTROLLER_MANAGER_PUBLIC
   virtual

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -52,8 +52,9 @@ rclcpp::NodeOptions get_cm_node_options()
 
 ControllerManager::ControllerManager(
   std::shared_ptr<rclcpp::Executor> executor,
-  const std::string & manager_node_name)
-: rclcpp::Node(manager_node_name, get_cm_node_options()),
+  const std::string & manager_node_name,
+  const std::string & namespace_)
+: rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::make_unique<hardware_interface::ResourceManager>()),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(
@@ -76,8 +77,9 @@ ControllerManager::ControllerManager(
 ControllerManager::ControllerManager(
   std::unique_ptr<hardware_interface::ResourceManager> resource_manager,
   std::shared_ptr<rclcpp::Executor> executor,
-  const std::string & manager_node_name)
-: rclcpp::Node(manager_node_name, get_cm_node_options()),
+  const std::string & manager_node_name,
+  const std::string & namespace_)
+: rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::move(resource_manager)),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(


### PR DESCRIPTION
Add missing namespace parameter to allow controller_manager to be namespaced