### PR TITLE
Added GPIO parsing and test

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -61,7 +61,7 @@ struct ComponentInfo
   std::vector<InterfaceInfo> command_interfaces;
   /**
    * Name of the state interfaces that can be read, e.g. "position", "velocity", etc.
-   * Used by Joints, Sensors and GPIOs.
+   * Used by joints, sensors and GPIOs.
    */
   std::vector<InterfaceInfo> state_interfaces;
   /// (Optional) Key-value pairs of component parameters, e.g. min/max values or serial number.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -38,6 +38,8 @@ struct InterfaceInfo
   std::string min;
   /// (Optional) Maximal allowed values of the interface.
   std::string max;
+  /// (Optional) The datatype of the interface, e.g. "bool", "int". Defaults to double.
+  std::string data_type;
 };
 
 /**

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -38,8 +38,10 @@ struct InterfaceInfo
   std::string min;
   /// (Optional) Maximal allowed values of the interface.
   std::string max;
-  /// (Optional) The datatype of the interface, e.g. "bool", "int". Defaults to double.
+  /// (Optional) The datatype of the interface, e.g. "bool", "int". Used by GPIOs.
   std::string data_type;
+  /// (Optional) If the handle is an array, the size of the array. Used by GPIOs.
+  int size;
 };
 
 /**

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -31,7 +31,7 @@ struct InterfaceInfo
 {
   /**
    * Name of the command interfaces that can be set, e.g. "position", "velocity", etc.
-   * Used by joints.
+   * Used by joints and GPIOs.
    */
   std::string name;
   /// (Optional) Minimal allowed values of the interface.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -52,12 +52,12 @@ struct ComponentInfo
   std::string type;
   /**
    * Name of the command interfaces that can be set, e.g. "position", "velocity", etc.
-   * Used by joints and GPIO.
+   * Used by joints and GPIOs.
    */
   std::vector<InterfaceInfo> command_interfaces;
   /**
    * Name of the state interfaces that can be read, e.g. "position", "velocity", etc.
-   * Used by Joints, Sensors and GPIO.
+   * Used by Joints, Sensors and GPIOs.
    */
   std::vector<InterfaceInfo> state_interfaces;
   /// (Optional) Key-value pairs of component parameters, e.g. min/max values or serial number.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -48,16 +48,16 @@ struct ComponentInfo
 {
   /// Name of the component.
   std::string name;
-  /// Type of the component: sensor or joint.
+  /// Type of the component: sensor, joint, or GPIO.
   std::string type;
   /**
    * Name of the command interfaces that can be set, e.g. "position", "velocity", etc.
-   * Used by joints.
+   * Used by joints and GPIO.
    */
   std::vector<InterfaceInfo> command_interfaces;
   /**
    * Name of the state interfaces that can be read, e.g. "position", "velocity", etc.
-   * Used by Joints and Sensors.
+   * Used by Joints, Sensors and GPIO.
    */
   std::vector<InterfaceInfo> state_interfaces;
   /// (Optional) Key-value pairs of component parameters, e.g. min/max values or serial number.
@@ -84,6 +84,11 @@ struct HardwareInfo
    * Required for Sensor and optional for System Hardware.
    */
   std::vector<ComponentInfo> sensors;
+  /**
+   * Map of GPIO provided by the hardware where the key is a descriptive name of the GPIO.
+   * Optional for any hardware components.
+   */
+  std::vector<ComponentInfo> gpios;
   /**
    * Map of transmissions to calcualte ration between joints and physical actuators.
    * Optional for Actuator and System Hardware.

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -30,6 +30,7 @@ constexpr const auto kClassTypeTag = "plugin";
 constexpr const auto kParamTag = "param";
 constexpr const auto kJointTag = "joint";
 constexpr const auto kSensorTag = "sensor";
+constexpr const auto kGPIOTag = "gpio";
 constexpr const auto kTransmissionTag = "transmission";
 constexpr const auto kCommandInterfaceTag = "command_interface";
 constexpr const auto kStateInterfaceTag = "state_interface";
@@ -231,6 +232,8 @@ HardwareInfo parse_resource_from_xml(const tinyxml2::XMLElement * ros2_control_i
       hardware.sensors.push_back(parse_component_from_xml(ros2_control_child_it) );
     } else if (!std::string(kTransmissionTag).compare(ros2_control_child_it->Name())) {
       hardware.transmissions.push_back(parse_component_from_xml(ros2_control_child_it) );
+    } else if (!std::string(kGPIOTag).compare(ros2_control_child_it->Name())) {
+      hardware.gpios.push_back(parse_component_from_xml(ros2_control_child_it) );
     } else {
       throw std::runtime_error("invalid tag name " + std::string(ros2_control_child_it->Name()));
     }

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -110,11 +110,11 @@ std::string get_attribute_value(
 /// Parse optional size attribute
 /**
  * Parses an XMLElement and returns the value of the size attribute.
- * If not specified, defaults to 1. If not given a positive int, throws an error.
+ * If not specified, defaults to 1. If not given a positive integer, throws an error.
  *
  * \param[in] elem XMLElement that has the size attribute.
  * \return The size.
- * \throws std::runtime_error if not given a positive non-zero int as value.
+ * \throws std::runtime_error if not given a positive non-zero integer as value.
  */
 std::size_t parse_size_attribute(
   const tinyxml2::XMLElement * elem)

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -120,12 +120,12 @@ std::size_t parse_size_attribute(
   const tinyxml2::XMLElement * elem)
 {
   const tinyxml2::XMLAttribute * attr = elem->FindAttribute(kSizeAttribute);
-  std::size_t size;
 
   if (!attr) {
     return 1;
   }
 
+  std::size_t size;
   // Regex used to check for non-zero positive int
   std::string s = attr->Value();
   std::regex int_re("[1-9][0-9]*");

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -497,3 +497,45 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_only)
   ASSERT_THAT(hardware_info.transmissions[0].parameters, SizeIs(1));
   EXPECT_EQ(hardware_info.transmissions[0].parameters.at("joint_to_actuator"), "${1024/PI}");
 }
+
+TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_gpio)
+{
+  std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_robot_with_gpio +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(control_hardware, SizeIs(1));
+  auto hardware_info = control_hardware.front();
+
+  EXPECT_EQ(hardware_info.name, "RRBotSystemWithGPIO");
+  EXPECT_EQ(hardware_info.type, "system");
+  EXPECT_EQ(
+    hardware_info.hardware_class_type,
+    "ros2_control_demo_hardware/RRBotSystemWithGPIOHardware");
+
+  ASSERT_THAT(hardware_info.joints, SizeIs(2));
+
+  EXPECT_EQ(hardware_info.joints[0].name, "joint1");
+  EXPECT_EQ(hardware_info.joints[0].type, "joint");
+
+  EXPECT_EQ(hardware_info.joints[1].name, "joint2");
+  EXPECT_EQ(hardware_info.joints[1].type, "joint");
+
+  ASSERT_THAT(hardware_info.gpios, SizeIs(2));
+
+  EXPECT_EQ(hardware_info.gpios[0].name, "flange_analog_IOs");
+  EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(3));
+  EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(1));
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[0].name, "analog_output1");
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[1].name, "analog_input1");
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[2].name, "analog_input2");
+
+  EXPECT_EQ(hardware_info.gpios[1].name, "flange_vacuum");
+  EXPECT_EQ(hardware_info.gpios[1].type, "gpio");
+  EXPECT_THAT(hardware_info.gpios[1].state_interfaces, SizeIs(1));
+  EXPECT_THAT(hardware_info.gpios[1].command_interfaces, SizeIs(1));
+  EXPECT_THAT(hardware_info.gpios[1].state_interfaces[0].name, "vacuum");
+  EXPECT_THAT(hardware_info.gpios[1].command_interfaces[0].name, "vacuum");
+}

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -536,6 +536,74 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_gpio
   EXPECT_EQ(hardware_info.gpios[1].type, "gpio");
   EXPECT_THAT(hardware_info.gpios[1].state_interfaces, SizeIs(1));
   EXPECT_THAT(hardware_info.gpios[1].command_interfaces, SizeIs(1));
-  EXPECT_THAT(hardware_info.gpios[1].state_interfaces[0].name, "vacuum");
-  EXPECT_THAT(hardware_info.gpios[1].command_interfaces[0].name, "vacuum");
+
+TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_data_type)
+{
+  std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_robot_with_size_and_data_type +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(control_hardware, SizeIs(1));
+  auto hardware_info = control_hardware.front();
+
+  EXPECT_EQ(hardware_info.name, "RRBotSystemWithSizeAndDataType");
+  EXPECT_EQ(hardware_info.type, "system");
+  EXPECT_EQ(
+    hardware_info.hardware_class_type,
+    "ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType");
+
+  ASSERT_THAT(hardware_info.joints, SizeIs(2));
+
+  EXPECT_EQ(hardware_info.joints[0].name, "joint1");
+  EXPECT_EQ(hardware_info.joints[0].type, "joint");
+  EXPECT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].data_type, "double");
+  EXPECT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.joints[1].name, "joint2");
+  EXPECT_EQ(hardware_info.joints[1].type, "joint");
+  EXPECT_THAT(hardware_info.joints[1].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].data_type, "double");
+  EXPECT_THAT(hardware_info.joints[1].state_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].data_type, "double");
+
+  ASSERT_THAT(hardware_info.gpios, SizeIs(1));
+
+  EXPECT_EQ(hardware_info.gpios[0].name, "flange_IOS");
+  EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
+  EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(2));
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].name, "digital_output1");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].data_type, "bool");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[1].name, "digital_output2");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[1].data_type, "bool");
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(3));
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].name, "analog_input0");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].name, "analog_input1");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].data_type, "double");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[2].name, "analog_input2");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[2].data_type, "double");
+
+  ASSERT_THAT(hardware_info.sensors, SizeIs(2));
+
+  EXPECT_EQ(hardware_info.sensors[0].name, "ft_ee");
+  EXPECT_EQ(hardware_info.sensors[0].type, "sensor");
+  EXPECT_THAT(hardware_info.sensors[0].state_interfaces, SizeIs(6));
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].name, "force.x");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[1].name, "force.y");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[1].data_type, "double");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[2].name, "force.z");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[2].data_type, "double");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[3].name, "torque.x");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[3].data_type, "double");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[4].name, "torque.y");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[4].data_type, "double");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[5].name, "torque.z");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[5].data_type, "double");
 }

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -528,14 +528,17 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_gpio
   EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
   EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(3));
   EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(1));
-  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[0].name, "analog_output1");
-  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[1].name, "analog_input1");
-  EXPECT_THAT(hardware_info.gpios[0].state_interfaces[2].name, "analog_input2");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].name, "analog_output1");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].name, "analog_input1");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[2].name, "analog_input2");
 
   EXPECT_EQ(hardware_info.gpios[1].name, "flange_vacuum");
   EXPECT_EQ(hardware_info.gpios[1].type, "gpio");
   EXPECT_THAT(hardware_info.gpios[1].state_interfaces, SizeIs(1));
   EXPECT_THAT(hardware_info.gpios[1].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.gpios[1].state_interfaces[0].name, "vacuum");
+  EXPECT_EQ(hardware_info.gpios[1].command_interfaces[0].name, "vacuum");
+}
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_data_type)
 {

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -556,57 +556,50 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_d
     hardware_info.hardware_class_type,
     "ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType");
 
-  ASSERT_THAT(hardware_info.joints, SizeIs(2));
+  ASSERT_THAT(hardware_info.joints, SizeIs(1));
 
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   EXPECT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].size, 1);
   EXPECT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
   EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
   EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].data_type, "double");
-  EXPECT_EQ(hardware_info.joints[1].name, "joint2");
-  EXPECT_EQ(hardware_info.joints[1].type, "joint");
-  EXPECT_THAT(hardware_info.joints[1].command_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].name, HW_IF_POSITION);
-  EXPECT_EQ(hardware_info.joints[1].command_interfaces[0].data_type, "double");
-  EXPECT_THAT(hardware_info.joints[1].state_interfaces, SizeIs(1));
-  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].name, HW_IF_POSITION);
-  EXPECT_EQ(hardware_info.joints[1].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].size, 1);
 
   ASSERT_THAT(hardware_info.gpios, SizeIs(1));
 
   EXPECT_EQ(hardware_info.gpios[0].name, "flange_IOS");
   EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
-  EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(2));
-  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].name, "digital_output1");
+  EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].name, "digital_output");
   EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].data_type, "bool");
-  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[1].name, "digital_output2");
-  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[1].data_type, "bool");
-  EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(3));
-  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].name, "analog_input0");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].size, 2);
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(2));
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].name, "analog_input");
   EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].data_type, "double");
-  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].name, "analog_input1");
-  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].data_type, "double");
-  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[2].name, "analog_input2");
-  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[2].data_type, "double");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].size, 3);
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].name, "image");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].data_type, "cv::Mat");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].size, 1);
+}
 
-  ASSERT_THAT(hardware_info.sensors, SizeIs(2));
+TEST_F(TestComponentParser, negative_size_throws_error)
+{
+  std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size +
+    ros2_control_test_assets::urdf_tail;
+  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
+}
 
-  EXPECT_EQ(hardware_info.sensors[0].name, "ft_ee");
-  EXPECT_EQ(hardware_info.sensors[0].type, "sensor");
-  EXPECT_THAT(hardware_info.sensors[0].state_interfaces, SizeIs(6));
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].name, "force.x");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].data_type, "double");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[1].name, "force.y");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[1].data_type, "double");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[2].name, "force.z");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[2].data_type, "double");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[3].name, "torque.x");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[3].data_type, "double");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[4].name, "torque.y");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[4].data_type, "double");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[5].name, "torque.z");
-  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[5].data_type, "double");
+TEST_F(TestComponentParser, noninteger_size_throws_error)
+{
+  std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size2 +
+    ros2_control_test_assets::urdf_tail;
+  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
 }

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -332,6 +332,42 @@ const auto valid_urdf_ros2_control_actuator_only =
   </ros2_control>
 )";
 
+// 10. Industrial Robots with integrated GPIO
+const auto valid_urdf_ros2_control_system_robot_with_gpio =
+  R"(
+  <ros2_control name="RRBotSystemWithGPIO" type="system">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemWithGPIOHardware</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="position">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+    </joint>
+    <gpio name="flange_analog_IOs">
+      <command_interface name="analog_output1"/>
+      <state_interface name="analog_output1"/> <!-- Needed to know current state of the output -->
+      <state_interface name="analog_input1"/>
+      <state_interface name="analog_input2"/>
+    </gpio>
+    <gpio name="flange_vacuum">
+      <command_interface name="vacuum"/>
+      <state_interface name="vacuum"/> <!-- Needed to know current state of the input -->
+    </gpio>
+  </ros2_control>
+)";
+
 // Errors
 const auto invalid_urdf_ros2_control_invalid_child =
   R"(

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -369,7 +369,7 @@ const auto valid_urdf_ros2_control_system_robot_with_gpio =
 )";
 
 // 11. Industrial Robots using size and data_type attributes
-const auto valid_urdf_ros2_control_system_robot_with_size_and_data_type = 
+const auto valid_urdf_ros2_control_system_robot_with_size_and_data_type =
   R"(
   <ros2_control name="RRBotSystemWithSizeAndDataType" type="system">
     <hardware>

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -368,6 +368,30 @@ const auto valid_urdf_ros2_control_system_robot_with_gpio =
   </ros2_control>
 )";
 
+// 11. Industrial Robots using size and data_type attributes
+const auto valid_urdf_ros2_control_system_robot_with_size_and_data_type = 
+  R"(
+  <ros2_control name="RRBotSystemWithSizeAndDataType" type="system">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint" size="2">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <gpio name="flange_IOS">
+      <command_interface name="digital_output" size="2" data_type="bool"/>
+      <state_interface name="analog_input" size="0 1 2"/>
+    </gpio>
+    <sensor name="ft_" size="ee table">
+      <state_interface name="force." size="x y z"/>
+      <state_interface name="torque." size="x y z"/>
+    </sensor>
+  </ros2_control>
+)";
+
 // Errors
 const auto invalid_urdf_ros2_control_invalid_child =
   R"(

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -377,18 +377,15 @@ const auto valid_urdf_ros2_control_system_robot_with_size_and_data_type =
       <param name="example_param_write_for_sec">2</param>
       <param name="example_param_read_for_sec">2</param>
     </hardware>
-    <joint name="joint" size="2">
+    <joint name="joint1">
       <command_interface name="position"/>
       <state_interface name="position"/>
     </joint>
     <gpio name="flange_IOS">
       <command_interface name="digital_output" size="2" data_type="bool"/>
-      <state_interface name="analog_input" size="0 1 2"/>
+      <state_interface name="analog_input" size="3"/>
+      <state_interface name="image" data_type="cv::Mat"/>
     </gpio>
-    <sensor name="ft_" size="ee table">
-      <state_interface name="force." size="x y z"/>
-      <state_interface name="torque." size="x y z"/>
-    </sensor>
   </ros2_control>
 )";
 
@@ -497,6 +494,29 @@ const auto invalid_urdf_ros2_control_parameter_empty =
   </ros2_control>
 )";
 
+const auto invalid_urdf2_ros2_control_illegal_size =
+  R"(
+  <ros2_control name="RRBotSystemWithIllegalSize" type="system">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemWithIllegalSize</plugin>
+    </hardware>
+    <gpio name="flange_IOS">
+      <command_interface name="digital_output" data_type="bool" size="-4"/>
+    </gpio>
+  </ros2_control>
+)";
+
+const auto invalid_urdf2_ros2_control_illegal_size2 =
+  R"(
+  <ros2_control name="RRBotSystemWithIllegalSize2" type="system">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemWithIllegalSize2</plugin>
+    </hardware>
+    <gpio name="flange_IOS">
+      <command_interface name="digital_output" data_type="bool" size="ILLEGAL"/>
+    </gpio>
+  </ros2_control>
+)";
 }  // namespace ros2_control_test_assets
 
 #endif  // ROS2_CONTROL_TEST_ASSETS__COMPONENTS_URDFS_HPP_


### PR DESCRIPTION
Adds support for non-joint components named `gpio` in the urdf, following the discussion from https://github.com/ros-controls/ros2_control/issues/318. 

The code can be tested with [ros2_control_demos/with_gpio](https://github.com/mahaarbo/ros2_control_demos/tree/with_gpio).

### How to run
1. Launch the hardware `ros2 launch ros2_control_demo_robot rrbot_system_with_sensor_and_gpio.launch.py`
2. In a new terminal load the controller `ros2 control load_controller --set-state start forward_gpio_controller`
3. Publish some command to the GPIO analog output 
```
ros2 topic pub /forward_gpio_controller/commands std_msgs/msg/Float64MultiArray "data:
- 0.1"
```
4. Watch the GPIO analog input and sensor react in the first terminal
5. Publish a command to reset the GPIO analog output command
```
ros2 topic pub /forward_gpio_controller/commands std_msgs/msg/Float64MultiArray "data:
- 0.0"
```
6. Watch the GPIO analog input and sensor react in the first terminal.

### Comments
The hardware demo has three GPIO inputs, one sensor, and one GPIO output. The GPIO inputs and sensor readings are affected by the GPIO output, but decay to zero on their own.

The `gpio` interfaces are basically the same as the `joint` interfaces, and the thought is that generalizations can be done using something like the semantic components to easily claim multiple GPIO interfaces.  