### PR TITLE
Remove forgoten debug output

### DIFF
--- a/controller_interface/include/controller_interface/helpers.hpp
+++ b/controller_interface/include/controller_interface/helpers.hpp
@@ -19,8 +19,6 @@
 #include <string>
 #include <vector>
 
-#include <ostream>
-
 namespace controller_interface
 {
 
@@ -51,7 +49,6 @@ bool get_ordered_interfaces(
         }
       } else {
         if (name == interface.get_full_name()) {
-          std::cout << "Found interface: " << name << std::endl;
           ordered_interfaces.push_back(std::ref(interface));
         }
       }


### PR DESCRIPTION
In `helpers.hpp` there was a debug output which unintentionally slipped in.