### PR TITLE
fixes unload_controller documentation issue

### DIFF
--- a/ros2controlcli/doc/index.rst
+++ b/ros2controlcli/doc/index.rst
@@ -209,6 +209,7 @@ unload_controller
 -----------------
 
 .. code-block:: console
+
     $ ros2 control unload_controller -h
     usage: ros2 control unload_controller [-h] [--spin-time SPIN_TIME] [-c CONTROLLER_MANAGER] [--include-hidden-nodes] controller_name
 


### PR DESCRIPTION
In [ros2controlcli](https://ros-controls.github.io/control.ros.org/ros2_control/ros2controlcli/doc/index.html) documentation, `unload_controller` is not displaying correctly. 

There was a missing new line after specifying the code block.