### PR TITLE
Add separate workflows for separate distros.

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -10,13 +10,17 @@ on:
 
 jobs:
   ci_binary:
-    name: Foxy binary job
+    name: Binary job
     runs-on: ubuntu-latest
     strategy:
       matrix:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
+          - {ROS_DISTRO: galactic, ROS_REPO: main}
+          - {ROS_DISTRO: galactic, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
     steps:
       - uses: actions/checkout@v1
       - uses: ros-industrial/industrial_ci@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,44 @@
+name: Coverage Build
+on:
+  pull_request:
+
+jobs:
+  coverage:
+    name: coverage build
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: ros-tooling/setup-ros@v0.2
+        with:
+          required-ros-distributions: rolling
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: rolling
+          # build all packages listed in the meta package
+          package-name:
+            controller_interface
+            controller_manager
+            controller_manager_msgs
+            hardware_interface
+            ros2controlcli
+            ros2_control
+            ros2_control_test_assets
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1.5.0
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros_ws/log

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: ros-tooling/setup-ros@v0.2
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
-        distribution: foxy
+        distribution: rolling
         linter: ${{ matrix.linter }}
         package-name:
           controller_interface

--- a/.github/workflows/semi-binary.yml
+++ b/.github/workflows/semi-binary.yml
@@ -1,0 +1,29 @@
+name: Build & Test ros2_control with binary install
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '17 8 * * *'
+
+jobs:
+  ci_binary:
+    name: Binary job
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: foxy, ROS_REPO: main}
+          - {ROS_DISTRO: foxy, ROS_REPO: testing}
+          - {ROS_DISTRO: galactic, ROS_REPO: main}
+          - {ROS_DISTRO: galactic, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
+    env:
+      - UPSTREAM_WORKSPACE: ros2_control/ros2_control.repos
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ros-industrial/industrial_ci@master
+        env: ${{matrix.env}}

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -8,7 +8,7 @@ on:
     - cron: '17 8 * * *'
 
 jobs:
-  ci_source:
+  foxy_source:
     name: Foxy source job
     runs-on: ubuntu-20.04
     strategy:
@@ -29,6 +29,74 @@ jobs:
             ros2_control_test_assets
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
+          colcon-mixin-name: coverage-gcc
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros_ws/log
+
+  galactic_source:
+    name: Galactic source job
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: galactic
+          # build all packages listed in the meta package
+          package-name:
+            controller_interface
+            controller_manager
+            controller_manager_msgs
+            hardware_interface
+            ros2controlcli
+            ros2_control
+            ros2_control_test_assets
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
+          colcon-mixin-name: coverage-gcc
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros_ws/log
+
+  rolling_source:
+    name: Rolling source job
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: rolling
+          # build all packages listed in the meta package
+          package-name:
+            controller_interface
+            controller_manager
+            controller_manager_msgs
+            hardware_interface
+            ros2controlcli
+            ros2_control
+            ros2_control_test_assets
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
           colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -30,13 +30,7 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ros_ws/lcov/total_coverage.info
-          flags: unittests
-          name: codecov-umbrella
       - uses: actions/upload-artifact@v1
         with:
           name: colcon-logs-${{ matrix.os }}
@@ -64,13 +58,7 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ros_ws/lcov/total_coverage.info
-          flags: unittests
-          name: codecov-umbrella
       - uses: actions/upload-artifact@v1
         with:
           name: colcon-logs-${{ matrix.os }}
@@ -98,13 +86,7 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: coverage-gcc
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v1
-        with:
-          file: ros_ws/lcov/total_coverage.info
-          flags: unittests
-          name: codecov-umbrella
       - uses: actions/upload-artifact@v1
         with:
           name: colcon-logs-${{ matrix.os }}


### PR DESCRIPTION
This should help to keep CI easily maintainable when branching out.﻿
