### PR TITLE
Make controller_manager set controller's use_sim_time param when use_sim_time=True

### DIFF
--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -43,7 +43,7 @@ ControllerInterface::init(const std::string & controller_name, rclcpp::NodeOptio
     controller_name,
     node_options.allow_undeclared_parameters(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;
 }
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -628,8 +628,13 @@ ControllerManager::add_controller_impl(
 
   // ensure controller's `use_sim_time` parameter matches controller_manager's
   const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
-  controller.c->get_node()->set_parameter(use_sim_time);
-
+  if (use_sim_time.as_bool()) {
+    RCLCPP_INFO(
+      get_logger(),
+      "Setting use_sim_time=True for %s to match controller manager "
+      "(see ros2_control#325 for details)", controller.info.name.c_str());
+    controller.c->get_node()->set_parameter(use_sim_time);
+  }
   executor_->add_node(controller.c->get_node());
   to.emplace_back(controller);
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -616,23 +616,6 @@ ControllerManager::add_controller_impl(
       controller.info.name.c_str());
     return nullptr;
   }
-
-  // TESTING use_sim_time matching    
-  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");  
-  bool ust = use_sim_time.as_bool();
-  if(ust == true){
-    RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: True");
-  }else{
-    RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: False");
-  }
-  
-  //RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: %s", use_sim_time.as_string());
-  
-//  const std::vector<rclcpp::Parameter> params = {use_sim_time};
-  
-//  rclcpp::NodeOptions node_options;
-  
-//  node_options.parameter_overrides(params);
   
   if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR) {
 
@@ -643,19 +626,11 @@ ControllerManager::add_controller_impl(
       controller.info.name.c_str());
     return nullptr;
   }
-  controller.c->get_node()->set_parameter(use_sim_time);
-    
-  const rclcpp::Parameter use_sim_time2 = controller.c->get_node()->get_parameter("use_sim_time");  
-  bool ust2 = use_sim_time2.as_bool();
-  if(ust2 == true){
-    RCLCPP_ERROR(get_logger(), "controller.use_sim_time: True");
-  }else{
-    RCLCPP_ERROR(get_logger(), "controller.use_sim_time: False");
-  }
   
-  //RCLCPP_ERROR(get_logger(), "controller.use_sim_time: %s", use_sim_time2.as_string());
-  // end of modified code
-  
+  // ensure controller's `use_sim_time` parameter matches controller_manager's
+  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");  
+  controller.c->get_node()->set_parameter(use_sim_time); 
+
   executor_->add_node(controller.c->get_node());
   to.emplace_back(controller);
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -617,7 +617,25 @@ ControllerManager::add_controller_impl(
     return nullptr;
   }
 
+  // TESTING use_sim_time matching    
+  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");  
+  bool ust = use_sim_time.as_bool();
+  if(ust == true){
+    RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: True");
+  }else{
+    RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: False");
+  }
+  
+  //RCLCPP_ERROR(get_logger(), "controller_manager.use_sim_time: %s", use_sim_time.as_string());
+  
+//  const std::vector<rclcpp::Parameter> params = {use_sim_time};
+  
+//  rclcpp::NodeOptions node_options;
+  
+//  node_options.parameter_overrides(params);
+  
   if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR) {
+
     to.clear();
     RCLCPP_ERROR(
       get_logger(),
@@ -625,6 +643,19 @@ ControllerManager::add_controller_impl(
       controller.info.name.c_str());
     return nullptr;
   }
+  controller.c->get_node()->set_parameter(use_sim_time);
+    
+  const rclcpp::Parameter use_sim_time2 = controller.c->get_node()->get_parameter("use_sim_time");  
+  bool ust2 = use_sim_time2.as_bool();
+  if(ust2 == true){
+    RCLCPP_ERROR(get_logger(), "controller.use_sim_time: True");
+  }else{
+    RCLCPP_ERROR(get_logger(), "controller.use_sim_time: False");
+  }
+  
+  //RCLCPP_ERROR(get_logger(), "controller.use_sim_time: %s", use_sim_time2.as_string());
+  // end of modified code
+  
   executor_->add_node(controller.c->get_node());
   to.emplace_back(controller);
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -616,9 +616,8 @@ ControllerManager::add_controller_impl(
       controller.info.name.c_str());
     return nullptr;
   }
-  
-  if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR) {
 
+  if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR) {
     to.clear();
     RCLCPP_ERROR(
       get_logger(),
@@ -626,10 +625,10 @@ ControllerManager::add_controller_impl(
       controller.info.name.c_str());
     return nullptr;
   }
-  
+
   // ensure controller's `use_sim_time` parameter matches controller_manager's
-  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");  
-  controller.c->get_node()->set_parameter(use_sim_time); 
+  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
+  controller.c->get_node()->set_parameter(use_sim_time);
 
   executor_->add_node(controller.c->get_node());
   to.emplace_back(controller);


### PR DESCRIPTION
Per discussion in #325 , I have added a few lines to `controller_manager.cpp` to set the controller node's `use_sim_time` parameter to match the `controller_manager`'s when it is set to `true`. An `INFO` message is printed when this occurs to let the user know. 

I added this code to the `add_controller_impl()` function, as this is where controller nodes are added to the executor, but if this was the wrong place to do so, please let me know. 

That said, this code passes all tests, and works as expected in my own demo applications, loading via launch, setting different controller states, unloading and reloading. 