### PR TITLE
Bug, feature request, and pull request GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Version [e.g. Foxy]
+- Anything that may be unusual about your environment
+
+**Additional context**
+Add any other context about the problem here, especially include any modifications to ros2_control that relate to this issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+
+---
+name: Pull request
+about: Create a pull request
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+- [ ] You are working against the latest source on the master branch.
+- [ ] You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+- [ ] You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+
+To send us a pull request, please:
+
+- [ ] Fork the repository.
+- [ ] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+- [ ] Ensure local tests pass. (colcon test)
+- [ ] Commit to your fork using clear commit messages.
+- [ ] Send a pull request, answering any default questions in the pull request interface.
+- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.


### PR DESCRIPTION
Aims to address #415.

This is my first involvement with ros2_control so feel free to provide lots of feedback as I don't have a sense of how you guys want to do things.

The bug report and feature request templates are the default templates that GitHub has with some minor differences. I tried to change them to better reflect ros2_control's CONTRIBUTING.md and the ros2_control context.

The pull request template is just cut and pasted from CONTRIBUTING.md under the pull request section. I just made the bullet points checkboxes.

If you are unfamiliar with how the templates work, [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) is GitHub's documentation. Essentially, GitHub uses the information in the top section of the respective markdown file to populate some information about the bug, PR, etc. and then dumps everything below into the main textbox when creating the bug, PR, etc. A quick google around shows some good ideas about how to do them but I tried to stick with what you guys have in your CONTRIBUTING.md as I'm not familiar with how you run things.