### PR TITLE
feat: Add release and source Dockerfiles

### DIFF
--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,9 +1,37 @@
 # ROS2 Control Docker Containers
 
-Meant to provide basic docker containers for CI or development purposes.
+Meant to provide basic docker containers for CI or development purposes. To use them, make sure you have [Docker](https://docs.docker.com/get-docker/) installed, then build and run the image by following tag specific commands as described below:
 
 ## Source folder and tag
 Downloads and builds ros2_controls into a workspace for development use exactly as is found [here](https://ros-controls.github.io/control.ros.org/getting_started.html#compiling).
 
+This is primarily used for development and CI of ros2_control and related packages. To build and run the container, execute the following code in a terminal:
+```
+docker build --tag ros2_control:source --file .docker/source/Dockerfile .
+docker run -it ros2_control:source
+```
+
+If you are not familiar with docker, you'll want to consider how you want to maintain persistent data across container sessions. The above commands with start a **new** container and that container will persist as long as you don't remove it. If you want to return to it, you'll have to use the `docker start` command with the container id.
+
+A better way to maintain your code changes across coding sessions is to use docker volumes or bind mounts. Web search those terms for more documentation but a simple example is provided below. First, you must build the container as shown in the first command above, then:
+
+Bind mount example:
+```
+docker run -it --mount type=bind,source=/local/path/to/repo,destination=/root/ws_ros2_control/src/<path to repo you want replaced> ros2_control:source
+```
+Note: the above example replaces the containers contents with whatever you mount.
+
+Volume example:
+```
+docker run -it --mount type=volume,source=name-of-volume,destination=/root/ws_ros2_control/src/ ros2_control:source
+```
+Note: this is probably the preferred solution as changes persist across rebuilds of container and doesn't require you to pull all repositories that you want to edit as they'll already be in the container.
+
 ## Release folder and tag
 Installs ros2_control in the base ros2 docker container as mentioned [here](https://ros-controls.github.io/control.ros.org/getting_started.html#getting-started).
+
+This is mainly intended for development of external packages that rely on ros2_control. It can be built and run by the following commands in the directory of the ros2_control repository:
+```
+docker build --tag ros2_control:release --file .docker/release/Dockerfile .
+docker run -it ros2_control:release
+```

--- a/.docker/README.md
+++ b/.docker/README.md
@@ -1,0 +1,9 @@
+# ROS2 Control Docker Containers
+
+Meant to provide basic docker containers for CI or development purposes.
+
+## Source folder and tag
+Downloads and builds ros2_controls into a workspace for development use exactly as is found [here](https://ros-controls.github.io/control.ros.org/getting_started.html#compiling).
+
+## Release folder and tag
+Installs ros2_control in the base ros2 docker container as mentioned [here](https://ros-controls.github.io/control.ros.org/getting_started.html#getting-started).

--- a/.docker/release/Dockerfile
+++ b/.docker/release/Dockerfile
@@ -1,0 +1,7 @@
+ARG ROS_DISTRO="foxy"
+FROM ros:${ROS_DISTRO}
+
+# Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
+RUN apt-get update && \
+    apt-get install -y ros-${ROS_DISTRO}-ros2-control ros-${ROS_DISTRO}-ros2-controllers && \
+    rm -rf /var/lib/apt/lists/*

--- a/.docker/source/Dockerfile
+++ b/.docker/source/Dockerfile
@@ -1,0 +1,17 @@
+ARG ROS_DISTRO="foxy"
+FROM ros:${ROS_DISTRO}
+
+ENV ROS_UNDERLAY /root/ws_ros2_control/install
+WORKDIR $ROS_UNDERLAY/../src
+
+RUN apt-get update && apt-get install wget && \
+        wget https://raw.githubusercontent.com/ros-controls/ros2_control/master/ros2_control/ros2_control.repos && \
+        vcs import < ros2_control.repos
+
+RUN rosdep update && \
+    rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/
+
+RUN cd $ROS_UNDERLAY/.. && \
+        . /opt/ros/${ROS_DISTRO}/setup.sh && \
+        colcon build


### PR DESCRIPTION
I find that working inside docker containers makes my life easier and can be really useful for many purposes. I developed these for myself but thought I'd go ahead and offer them to others through a pull request. If you don't think they fit here, I'm not offended, just close the pull request. They are written very similarly to how moveit2 does it for familiarity.

Provides basic Dockerfiles to be used for development or CI purposes.
Source version clones and builds the ros2_control source files in a workspace.
Release version installs ros-foxy-ros2-control and ros-foxy-ros2-controllers from apt.