### PR TITLE
sort interfaces in resource manager

### DIFF
--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -189,7 +189,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
   ASSERT_EQ("active", result->controller[0].state);
   ASSERT_THAT(
     result->controller[0].claimed_interfaces,
-    testing::ElementsAre("joint3/velocity", "joint2/velocity", "joint1/position"));
+    testing::ElementsAre("joint1/position", "joint2/velocity", "joint3/velocity"));
 
   cm_->switch_controller(
     {}, {test_controller::TEST_CONTROLLER_NAME},

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "hardware_interface/resource_manager.hpp"
 
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -142,8 +143,8 @@ public:
 
   std::unordered_map<std::string, status> hardware_status_map_;
 
-  std::unordered_map<std::string, StateInterface> state_interface_map_;
-  std::unordered_map<std::string, CommandInterface> command_interface_map_;
+  std::map<std::string, StateInterface> state_interface_map_;
+  std::map<std::string, CommandInterface> command_interface_map_;
 };
 
 ResourceManager::ResourceManager()


### PR DESCRIPTION
In the current setup the command and state interfaces are in no particular order. That makes for a slightly confusing output of the joint_states topic in the joint_state_broadcaster, but makes it almost impossible to work with command interfaces as the order of joint commands can't be easily determined. That is, one can't simply use the order of the joint state broadcaster and copy&paste its output for a command input to the joint_group_position_controller.

Changing the data type within the resource manager is a trivial fix for this which should not contribute to any runtime overhead as the map is being constructed only once during startup. Given that we have a pimpl pattern employed in the resource manager, this fix won't technically break any ABI/API. I do understand however that this is a semantic change which might cause confusion - c.f. changes required in the controller manager test. 