### PR TITLE
expose complex data types through interfaces

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -157,7 +157,8 @@ public:
   }
 
   template<class DataT = double>
-  void set_value(DataT value) {
+  void set_value(DataT value)
+  {
     return ReadWriteHandle::set_value<DataT>(value);
   }
 };

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -66,14 +66,16 @@ public:
     return command_interface_.get_full_name();
   }
 
-  void set_value(double val)
+  template<class DataT = double>
+  void set_value(DataT val)
   {
-    command_interface_.set_value(val);
+    command_interface_.set_value<DataT>(val);
   }
 
-  double get_value() const
+  template<class DataT = double>
+  DataT get_value() const
   {
-    return command_interface_.get_value();
+    return command_interface_.get_value<DataT>();
   }
 
 protected:

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -66,9 +66,10 @@ public:
     return state_interface_.get_full_name();
   }
 
-  double get_value() const
+  template<class DataT = double>
+  DataT get_value() const
   {
-    return state_interface_.get_value();
+    return state_interface_.get_value<DataT>();
   }
 
 protected:

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
+#include <string>
+
 #include "hardware_interface/handle.hpp"
 
 using hardware_interface::CommandInterface;

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -33,6 +33,27 @@ TEST(TestHandle, command_interface)
   EXPECT_DOUBLE_EQ(interface.get_value(), 0.0);
 }
 
+TEST(TestHandle, complex_command_interface)
+{
+  struct Complex
+  {
+    std::string str;
+  };
+
+  std::string value = "Hello Complex Interface";
+  Complex c{value};
+
+  CommandInterface interface{JOINT_NAME, FOO_INTERFACE, &c};
+  EXPECT_EQ(interface.get_value<std::string>(), value);
+  // TODO(karsten1987): Make get_value (implicit as double) type safe on caller side.
+  // interface.get_value() is now undefined behavior.
+  // EXPECT_DOUBLE_EQ(interface.get_value(), 0.0);
+
+  value = "Hello Modified Complex Interface";
+  EXPECT_NO_THROW(interface.set_value<std::string>(value));
+  EXPECT_EQ(interface.get_value<std::string>(), value);
+}
+
 TEST(TestHandle, state_interface)
 {
   double value = 1.337;

--- a/transmission_interface/include/transmission_interface/handle.hpp
+++ b/transmission_interface/include/transmission_interface/handle.hpp
@@ -25,15 +25,18 @@ namespace transmission_interface
 class ActuatorHandle : public hardware_interface::ReadWriteHandle
 {
 public:
+  void set_value(double value) {
+    return hardware_interface::ReadWriteHandle::set_value<double>(value);
+  }
+  double get_value() {
+    return hardware_interface::ReadWriteHandle::get_value<double>();
+  }
+
   using hardware_interface::ReadWriteHandle::ReadWriteHandle;
 };
 
 /** A handle used to get and set a value on a given joint interface. */
-class JointHandle : public hardware_interface::ReadWriteHandle
-{
-public:
-  using hardware_interface::ReadWriteHandle::ReadWriteHandle;
-};
+using JointHandle = ActuatorHandle;
 
 }  // namespace transmission_interface
 

--- a/transmission_interface/include/transmission_interface/handle.hpp
+++ b/transmission_interface/include/transmission_interface/handle.hpp
@@ -25,10 +25,12 @@ namespace transmission_interface
 class ActuatorHandle : public hardware_interface::ReadWriteHandle
 {
 public:
-  void set_value(double value) {
+  void set_value(double value)
+  {
     return hardware_interface::ReadWriteHandle::set_value<double>(value);
   }
-  double get_value() {
+  double get_value()
+  {
     return hardware_interface::ReadWriteHandle::get_value<double>();
   }
 


### PR DESCRIPTION
This PR is a first set of changes towards a state/command interface which allows complex data types.
In order to preserve a stable behavior across all controllers, all calls to `get_value` or the equivalent `set_value` are defaulting to `double`. 
However, that introduces the following undefined behavior:

Assume we have a complex data type but try to access the interface through the standard getters
```
  // interface.get_value() is now undefined behavior.
  // EXPECT_DOUBLE_EQ(interface.get_value(), 0.0);
```

In a follow up PR, I propose to introduce a deprecation of the default template parameter and make it explicit for each controller to call `get_value` with a specific template argument. That way there is at least no ambiguity and the type safety concern is made explicit by forcing the caller to specify the template.
Additionally, I believe it makes sense to introduce an identifier in the ros2 control tags to expose the `type` of interface. I currently don't have a good way of having a type-safe yet type-erased way of getting around the `void *`.