### PR TITLE
Use clang format as code formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+---
+Language:        Cpp
+BasedOnStyle:  Google
+
+ColumnLimit: 100
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BreakBeforeBraces: Allman
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+IncludeBlocks: Preserve
+...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           transmission_interface
 
   ament_lint_cpplint:
-    name: ament_${{ matrix.linter }}
+    name: ament_lint_cpplint
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,13 +55,13 @@ repos:
   # CPP hooks
   - repo: local
     hooks:
-      - id: ament_uncrustify
-        name: ament_uncrustify
-        description: Static code analysis of C/C++ files.
-        stages: [commit]
-        entry: ament_cppcheck
+      - id: clang-format
+        name: clang-format
+        description: Format files with ClangFormat.
+        entry: clang-format-10
         language: system
-        files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
+        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
+        args: ['-fallback-style=none', '-i']
 
   - repo: local
     hooks:

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -40,8 +40,14 @@ install(TARGETS controller_interface
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+
   find_package(hardware_interface REQUIRED)
   find_package(sensor_msgs REQUIRED)
+
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gmock(test_controller_with_options test/test_controller_with_options.cpp)

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -30,7 +30,6 @@
 
 namespace controller_interface
 {
-
 // TODO(karsten1987): Remove clang pragma within Galactic
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -73,16 +72,13 @@ public:
   ControllerInterface() = default;
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  ~ControllerInterface() = default;
+  virtual ~ControllerInterface() = default;
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  InterfaceConfiguration command_interface_configuration() const = 0;
+  virtual InterfaceConfiguration command_interface_configuration() const = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  InterfaceConfiguration state_interface_configuration() const = 0;
+  virtual InterfaceConfiguration state_interface_configuration() const = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
   void assign_interfaces(
@@ -93,23 +89,16 @@ public:
   void release_interfaces();
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  return_type
-  init(const std::string & controller_name);
+  virtual return_type init(const std::string & controller_name);
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  return_type
-  init(const std::string & controller_name, rclcpp::NodeOptions & node_options);
+  virtual return_type init(const std::string & controller_name, rclcpp::NodeOptions & node_options);
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual
-  return_type
-  update() = 0;
+  virtual return_type update() = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::shared_ptr<rclcpp::Node>
-  get_node();
+  std::shared_ptr<rclcpp::Node> get_node();
 
   /**
    * The methods below are a substitute to the LifecycleNode methods with the same name.

--- a/controller_interface/include/controller_interface/controller_state_names.hpp
+++ b/controller_interface/include/controller_interface/controller_state_names.hpp
@@ -21,7 +21,6 @@
 
 namespace controller_interface
 {
-
 namespace state_names
 {
 /// Constants defining string labels corresponding to lifecycle states

--- a/controller_interface/include/controller_interface/helpers.hpp
+++ b/controller_interface/include/controller_interface/helpers.hpp
@@ -21,7 +21,6 @@
 
 namespace controller_interface
 {
-
 /// Reorder interfaces with references according to joint names or full interface names.
 /**
   * Method to reorder and check if all expected interfaces are provided for the joint.
@@ -35,20 +34,27 @@ namespace controller_interface
   * \param[out] ordered_interfaces vector with ordered interfaces.
   * \return true if all interfaces or joints in \p ordered_names are found, otherwise false.
   */
-template<typename T>
+template <typename T>
 bool get_ordered_interfaces(
   std::vector<T> & unordered_interfaces, const std::vector<std::string> & ordered_names,
   const std::string & interface_type, std::vector<std::reference_wrapper<T>> & ordered_interfaces)
 {
   ordered_interfaces.reserve(ordered_names.size());
-  for (const auto & name : ordered_names) {
-    for (auto & interface : unordered_interfaces) {
-      if (!interface_type.empty()) {
-        if ((name == interface.get_name()) && (interface_type == interface.get_interface_name())) {
+  for (const auto & name : ordered_names)
+  {
+    for (auto & interface : unordered_interfaces)
+    {
+      if (!interface_type.empty())
+      {
+        if ((name == interface.get_name()) && (interface_type == interface.get_interface_name()))
+        {
           ordered_interfaces.push_back(std::ref(interface));
         }
-      } else {
-        if (name == interface.get_full_name()) {
+      }
+      else
+      {
+        if (name == interface.get_full_name())
+        {
           ordered_interfaces.push_back(std::ref(interface));
         }
       }
@@ -61,9 +67,8 @@ bool get_ordered_interfaces(
 bool interface_list_contains_interface_type(
   const std::vector<std::string> & interface_type_list, const std::string & interface_type)
 {
-  return std::find(
-    interface_type_list.begin(), interface_type_list.end(),
-    interface_type) != interface_type_list.end();
+  return std::find(interface_type_list.begin(), interface_type_list.end(), interface_type) !=
+         interface_type_list.end();
 }
 
 }  // namespace controller_interface

--- a/controller_interface/include/controller_interface/visibility_control.h
+++ b/controller_interface/include/controller_interface/visibility_control.h
@@ -19,31 +19,31 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define CONTROLLER_INTERFACE_EXPORT __attribute__ ((dllexport))
-    #define CONTROLLER_INTERFACE_IMPORT __attribute__ ((dllimport))
-  #else
-    #define CONTROLLER_INTERFACE_EXPORT __declspec(dllexport)
-    #define CONTROLLER_INTERFACE_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef CONTROLLER_INTERFACE_BUILDING_DLL
-    #define CONTROLLER_INTERFACE_PUBLIC CONTROLLER_INTERFACE_EXPORT
-  #else
-    #define CONTROLLER_INTERFACE_PUBLIC CONTROLLER_INTERFACE_IMPORT
-  #endif
-  #define CONTROLLER_INTERFACE_PUBLIC_TYPE CONTROLLER_INTERFACE_PUBLIC
-  #define CONTROLLER_INTERFACE_LOCAL
+#ifdef __GNUC__
+#define CONTROLLER_INTERFACE_EXPORT __attribute__((dllexport))
+#define CONTROLLER_INTERFACE_IMPORT __attribute__((dllimport))
 #else
-  #define CONTROLLER_INTERFACE_EXPORT __attribute__ ((visibility("default")))
-  #define CONTROLLER_INTERFACE_IMPORT
-  #if __GNUC__ >= 4
-    #define CONTROLLER_INTERFACE_PUBLIC __attribute__ ((visibility("default")))
-    #define CONTROLLER_INTERFACE_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define CONTROLLER_INTERFACE_PUBLIC
-    #define CONTROLLER_INTERFACE_LOCAL
-  #endif
-  #define CONTROLLER_INTERFACE_PUBLIC_TYPE
+#define CONTROLLER_INTERFACE_EXPORT __declspec(dllexport)
+#define CONTROLLER_INTERFACE_IMPORT __declspec(dllimport)
+#endif
+#ifdef CONTROLLER_INTERFACE_BUILDING_DLL
+#define CONTROLLER_INTERFACE_PUBLIC CONTROLLER_INTERFACE_EXPORT
+#else
+#define CONTROLLER_INTERFACE_PUBLIC CONTROLLER_INTERFACE_IMPORT
+#endif
+#define CONTROLLER_INTERFACE_PUBLIC_TYPE CONTROLLER_INTERFACE_PUBLIC
+#define CONTROLLER_INTERFACE_LOCAL
+#else
+#define CONTROLLER_INTERFACE_EXPORT __attribute__((visibility("default")))
+#define CONTROLLER_INTERFACE_IMPORT
+#if __GNUC__ >= 4
+#define CONTROLLER_INTERFACE_PUBLIC __attribute__((visibility("default")))
+#define CONTROLLER_INTERFACE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define CONTROLLER_INTERFACE_PUBLIC
+#define CONTROLLER_INTERFACE_LOCAL
+#endif
+#define CONTROLLER_INTERFACE_PUBLIC_TYPE
 #endif
 
 #endif  // CONTROLLER_INTERFACE__VISIBILITY_CONTROL_H_

--- a/controller_interface/include/semantic_components/force_torque_sensor.hpp
+++ b/controller_interface/include/semantic_components/force_torque_sensor.hpp
@@ -25,13 +25,11 @@
 
 namespace semantic_components
 {
-
 class ForceTorqueSensor : public SemanticComponentInterface<geometry_msgs::msg::Wrench>
 {
 public:
   /// Constructor for "standard" 6D FTS
-  explicit ForceTorqueSensor(const std::string & name)
-  : SemanticComponentInterface(name, 6)
+  explicit ForceTorqueSensor(const std::string & name) : SemanticComponentInterface(name, 6)
   {
     // If 6D FTS use standard names
     interface_names_.emplace_back(name_ + "/" + "force.x");
@@ -61,20 +59,20 @@ public:
   ForceTorqueSensor(
     const std::string & interface_force_x, const std::string & interface_force_y,
     const std::string & interface_force_z, const std::string & interface_torque_x,
-    const std::string & interface_torque_y, const std::string & interface_torque_z
-  )
+    const std::string & interface_torque_y, const std::string & interface_torque_z)
   : SemanticComponentInterface("", 6)
   {
-    auto check_and_add_interface =
-      [this](const std::string & interface_name, const int index)
+    auto check_and_add_interface = [this](const std::string & interface_name, const int index) {
+      if (!interface_name.empty())
       {
-        if (!interface_name.empty()) {
-          interface_names_.emplace_back(interface_name);
-          existing_axes_[index] = true;
-        } else {
-          existing_axes_[index] = false;
-        }
-      };
+        interface_names_.emplace_back(interface_name);
+        existing_axes_[index] = true;
+      }
+      else
+      {
+        existing_axes_[index] = false;
+      }
+    };
 
     check_and_add_interface(interface_force_x, 0);
     check_and_add_interface(interface_force_y, 1);
@@ -99,8 +97,10 @@ public:
   std::array<double, 3> get_forces()
   {
     size_t interface_counter = 0;
-    for (size_t i = 0; i < 3; ++i) {
-      if (existing_axes_[i]) {
+    for (size_t i = 0; i < 3; ++i)
+    {
+      if (existing_axes_[i])
+      {
         forces_[i] = state_interfaces_[interface_counter].get().get_value();
         ++interface_counter;
       }
@@ -118,12 +118,13 @@ public:
   {
     // find out how many force interfaces are being used
     // torque interfaces will be found from the next index onward
-    auto torque_interface_counter = std::count(
-      existing_axes_.begin(),
-      existing_axes_.begin() + 3, true);
+    auto torque_interface_counter =
+      std::count(existing_axes_.begin(), existing_axes_.begin() + 3, true);
 
-    for (size_t i = 3; i < 6; ++i) {
-      if (existing_axes_[i]) {
+    for (size_t i = 3; i < 6; ++i)
+    {
+      if (existing_axes_[i])
+      {
         torques_[i - 3] = state_interfaces_[torque_interface_counter].get().get_value();
         ++torque_interface_counter;
       }

--- a/controller_interface/include/semantic_components/imu_sensor.hpp
+++ b/controller_interface/include/semantic_components/imu_sensor.hpp
@@ -24,12 +24,10 @@
 
 namespace semantic_components
 {
-
 class IMUSensor : public SemanticComponentInterface<sensor_msgs::msg::Imu>
 {
 public:
-  explicit IMUSensor(const std::string & name)
-  : SemanticComponentInterface(name, 10)
+  explicit IMUSensor(const std::string & name) : SemanticComponentInterface(name, 10)
   {
     interface_names_.emplace_back(name_ + "/" + "orientation.x");
     interface_names_.emplace_back(name_ + "/" + "orientation.y");
@@ -59,7 +57,8 @@ public:
   std::array<double, 4> get_orientation()
   {
     size_t interface_offset = 0;
-    for (size_t i = 0; i < orientation_.size(); ++i) {
+    for (size_t i = 0; i < orientation_.size(); ++i)
+    {
       orientation_[i] = state_interfaces_[interface_offset + i].get().get_value();
     }
     return orientation_;
@@ -74,7 +73,8 @@ public:
   std::array<double, 3> get_angular_velocity()
   {
     size_t interface_offset = orientation_.size();
-    for (size_t i = 0; i < angular_velocity_.size(); ++i) {
+    for (size_t i = 0; i < angular_velocity_.size(); ++i)
+    {
       angular_velocity_[i] = state_interfaces_[interface_offset + i].get().get_value();
     }
     return angular_velocity_;
@@ -89,7 +89,8 @@ public:
   std::array<double, 3> get_linear_acceleration()
   {
     size_t interface_offset = orientation_.size() + angular_velocity_.size();
-    for (size_t i = 0; i < linear_acceleration_.size(); ++i) {
+    for (size_t i = 0; i < linear_acceleration_.size(); ++i)
+    {
       linear_acceleration_[i] = state_interfaces_[interface_offset + i].get().get_value();
     }
     return linear_acceleration_;

--- a/controller_interface/include/semantic_components/semantic_component_interface.hpp
+++ b/controller_interface/include/semantic_components/semantic_component_interface.hpp
@@ -23,8 +23,7 @@
 
 namespace semantic_components
 {
-
-template<typename MessageReturnType>
+template <typename MessageReturnType>
 class SemanticComponentInterface
 {
 public:
@@ -51,10 +50,7 @@ public:
   }
 
   /// Release loaned interfaces from the hardware.
-  void release_interfaces()
-  {
-    state_interfaces_.clear();
-  }
+  void release_interfaces() { state_interfaces_.clear(); }
 
   /// Definition of state interface names for the component.
   /**
@@ -67,8 +63,10 @@ public:
    */
   virtual std::vector<std::string> get_state_interface_names()
   {
-    if (interface_names_.empty()) {
-      for (auto i = 0u; i < interface_names_.capacity(); ++i) {
+    if (interface_names_.empty())
+    {
+      for (auto i = 0u; i < interface_names_.capacity(); ++i)
+      {
         interface_names_.emplace_back(name_ + "/" + std::to_string(i + 1));
       }
     }
@@ -82,11 +80,13 @@ public:
   bool get_values(std::vector<double> & values) const
   {
     // check we have sufficient memory
-    if (values.capacity() != state_interfaces_.size()) {
+    if (values.capacity() != state_interfaces_.size())
+    {
       return false;
     }
     // insert all the values
-    for (size_t i = 0; i < state_interfaces_.size(); ++i) {
+    for (size_t i = 0; i < state_interfaces_.size(); ++i)
+    {
       values.emplace_back(state_interfaces_[i].get().get_value());
     }
     return true;
@@ -96,10 +96,7 @@ public:
   /**
    * \return false by default
    */
-  bool get_values_as_message(MessageReturnType & /* message */)
-  {
-    return false;
-  }
+  bool get_values_as_message(MessageReturnType & /* message */) { return false; }
 
 protected:
   std::string name_;

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -24,24 +24,20 @@
 
 namespace controller_interface
 {
-
-return_type
-ControllerInterface::init(const std::string & controller_name)
+return_type ControllerInterface::init(const std::string & controller_name)
 {
   node_ = std::make_shared<rclcpp::Node>(
-    controller_name,
-    rclcpp::NodeOptions().allow_undeclared_parameters(true));
+    controller_name, rclcpp::NodeOptions().allow_undeclared_parameters(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;
 }
 
-return_type
-ControllerInterface::init(const std::string & controller_name, rclcpp::NodeOptions & node_options)
+return_type ControllerInterface::init(
+  const std::string & controller_name, rclcpp::NodeOptions & node_options)
 {
-  node_ = std::make_shared<rclcpp::Node>(
-    controller_name,
-    node_options.allow_undeclared_parameters(true));
+  node_ =
+    std::make_shared<rclcpp::Node>(controller_name, node_options.allow_undeclared_parameters(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;
@@ -49,12 +45,13 @@ ControllerInterface::init(const std::string & controller_name, rclcpp::NodeOptio
 
 const rclcpp_lifecycle::State & ControllerInterface::configure()
 {
-  if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
-    switch (on_configure(lifecycle_state_)) {
+  if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  {
+    switch (on_configure(lifecycle_state_))
+    {
       case LifecycleNodeInterface::CallbackReturn::SUCCESS:
         lifecycle_state_ = rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-          state_names::INACTIVE);
+          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, state_names::INACTIVE);
         break;
       case LifecycleNodeInterface::CallbackReturn::ERROR:
         on_error(lifecycle_state_);
@@ -70,7 +67,8 @@ const rclcpp_lifecycle::State & ControllerInterface::configure()
 
 const rclcpp_lifecycle::State & ControllerInterface::cleanup()
 {
-  switch (on_cleanup(lifecycle_state_)) {
+  switch (on_cleanup(lifecycle_state_))
+  {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
         lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
@@ -87,7 +85,8 @@ const rclcpp_lifecycle::State & ControllerInterface::cleanup()
 }
 const rclcpp_lifecycle::State & ControllerInterface::deactivate()
 {
-  switch (on_deactivate(lifecycle_state_)) {
+  switch (on_deactivate(lifecycle_state_))
+  {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
         lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, state_names::INACTIVE);
@@ -104,8 +103,10 @@ const rclcpp_lifecycle::State & ControllerInterface::deactivate()
 }
 const rclcpp_lifecycle::State & ControllerInterface::activate()
 {
-  if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
-    switch (on_activate(lifecycle_state_)) {
+  if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
+    switch (on_activate(lifecycle_state_))
+    {
       case LifecycleNodeInterface::CallbackReturn::SUCCESS:
         lifecycle_state_ = rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state_names::ACTIVE);
@@ -124,7 +125,8 @@ const rclcpp_lifecycle::State & ControllerInterface::activate()
 
 const rclcpp_lifecycle::State & ControllerInterface::shutdown()
 {
-  switch (on_shutdown(lifecycle_state_)) {
+  switch (on_shutdown(lifecycle_state_))
+  {
     case LifecycleNodeInterface::CallbackReturn::SUCCESS:
       lifecycle_state_ = rclcpp_lifecycle::State(
         lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state_names::FINALIZED);
@@ -159,10 +161,10 @@ void ControllerInterface::release_interfaces()
   state_interfaces_.clear();
 }
 
-std::shared_ptr<rclcpp::Node>
-ControllerInterface::get_node()
+std::shared_ptr<rclcpp::Node> ControllerInterface::get_node()
 {
-  if (!node_.get()) {
+  if (!node_.get())
+  {
     throw std::runtime_error("Node hasn't been initialized yet!");
   }
   return node_;

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "test_controller_with_options.hpp"
 #include <gtest/gtest.h>
 #include <string>
-#include "test_controller_with_options.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions
@@ -23,13 +23,19 @@ class FriendControllerWithOptions : public controller_with_options::ControllerWi
   FRIEND_TEST(ControllerWithOption, init_without_overrides);
 };
 
-template<class T, size_t N>
-constexpr size_t arrlen(T (&)[N]) {return N;}
+template <class T, size_t N>
+constexpr size_t arrlen(T (&)[N])
+{
+  return N;
+}
 
-TEST(ControllerWithOption, init_with_overrides) {
+TEST(ControllerWithOption, init_with_overrides)
+{
   // mocks the declaration of overrides parameters in a yaml file
-  char const * const argv[] = {"", "--ros-args", "-p", "parameter_list.parameter1:=1.", "-p",
-    "parameter_list.parameter2:=2.", "-p", "parameter_list.parameter3:=3."};
+  char const * const argv[] = {"",   "--ros-args",
+                               "-p", "parameter_list.parameter1:=1.",
+                               "-p", "parameter_list.parameter2:=2.",
+                               "-p", "parameter_list.parameter3:=3."};
   int argc = arrlen(argv);
   rclcpp::init(argc, argv);
   // creates the controller
@@ -47,7 +53,8 @@ TEST(ControllerWithOption, init_with_overrides) {
   rclcpp::shutdown();
 }
 
-TEST(ControllerWithOption, init_without_overrides) {
+TEST(ControllerWithOption, init_without_overrides)
+{
   // mocks the declaration of overrides parameters in a yaml file
   char const * const argv[] = {""};
   int argc = arrlen(argv);

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -16,8 +16,8 @@
 #define TEST_CONTROLLER_WITH_OPTIONS_HPP_
 
 #include <controller_interface/controller_interface.hpp>
-#include <string>
 #include <map>
+#include <string>
 
 namespace controller_with_options
 {
@@ -36,13 +36,17 @@ public:
     rclcpp::NodeOptions options;
     options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
     auto result = ControllerInterface::init(controller_name, options);
-    if (result == controller_interface::return_type::ERROR) {
+    if (result == controller_interface::return_type::ERROR)
+    {
       return result;
     }
-    if (node_->get_parameters("parameter_list", params)) {
+    if (node_->get_parameters("parameter_list", params))
+    {
       RCLCPP_INFO_STREAM(node_->get_logger(), "I found " << params.size() << " parameters.");
       return controller_interface::return_type::OK;
-    } else {
+    }
+    else
+    {
       return controller_interface::return_type::ERROR;
     }
   }
@@ -67,6 +71,5 @@ public:
   std::map<std::string, double> params;
 };
 }  // namespace controller_with_options
-
 
 #endif  // TEST_CONTROLLER_WITH_OPTIONS_HPP_

--- a/controller_interface/test/test_force_torque_sensor.cpp
+++ b/controller_interface/test/test_force_torque_sensor.cpp
@@ -23,10 +23,7 @@
 #include <string>
 #include <vector>
 
-void ForceTorqueSensorTest::TearDown()
-{
-  force_torque_sensor_.reset(nullptr);
-}
+void ForceTorqueSensorTest::TearDown() { force_torque_sensor_.reset(nullptr); }
 
 TEST_F(ForceTorqueSensorTest, validate_all_with_default_names)
 {
@@ -42,29 +39,28 @@ TEST_F(ForceTorqueSensorTest, validate_all_with_default_names)
   ASSERT_EQ(force_torque_sensor_->state_interfaces_.capacity(), size_);
 
   // validate the default interface_names_
-  ASSERT_TRUE(
-    std::equal(
-      force_torque_sensor_->interface_names_.begin(), force_torque_sensor_->interface_names_.end(),
-      full_interface_names_.begin(), full_interface_names_.end()));
+  ASSERT_TRUE(std::equal(
+    force_torque_sensor_->interface_names_.begin(), force_torque_sensor_->interface_names_.end(),
+    full_interface_names_.begin(), full_interface_names_.end()));
 
   // get the interface names
   std::vector<std::string> interface_names = force_torque_sensor_->get_state_interface_names();
 
   // assign values to force
-  hardware_interface::StateInterface force_x{sensor_name_, fts_interface_names_[0],
-    &force_values_[0]};
-  hardware_interface::StateInterface force_y{sensor_name_, fts_interface_names_[1],
-    &force_values_[1]};
-  hardware_interface::StateInterface force_z{sensor_name_, fts_interface_names_[2],
-    &force_values_[2]};
+  hardware_interface::StateInterface force_x{
+    sensor_name_, fts_interface_names_[0], &force_values_[0]};
+  hardware_interface::StateInterface force_y{
+    sensor_name_, fts_interface_names_[1], &force_values_[1]};
+  hardware_interface::StateInterface force_z{
+    sensor_name_, fts_interface_names_[2], &force_values_[2]};
 
   // assign values to torque
-  hardware_interface::StateInterface torque_x{sensor_name_, fts_interface_names_[3],
-    &torque_values_[0]};
-  hardware_interface::StateInterface torque_y{sensor_name_, fts_interface_names_[4],
-    &torque_values_[1]};
-  hardware_interface::StateInterface torque_z{sensor_name_, fts_interface_names_[5],
-    &torque_values_[2]};
+  hardware_interface::StateInterface torque_x{
+    sensor_name_, fts_interface_names_[3], &torque_values_[0]};
+  hardware_interface::StateInterface torque_y{
+    sensor_name_, fts_interface_names_[4], &torque_values_[1]};
+  hardware_interface::StateInterface torque_z{
+    sensor_name_, fts_interface_names_[5], &torque_values_[2]};
 
   // create local state interface vector
   std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;
@@ -113,8 +109,8 @@ TEST_F(ForceTorqueSensorTest, validate_all_with_custom_names)
 {
   // create the force torque sensor with force.x, force.z and torque.y, torque.z
   force_torque_sensor_ = std::make_unique<TestableForceTorqueSensor>(
-    sensor_name_ + "/" + "force.x", "", sensor_name_ + "/" + "force.z",
-    "", sensor_name_ + "/" + "torque.y", sensor_name_ + "/" + "torque.z");
+    sensor_name_ + "/" + "force.x", "", sensor_name_ + "/" + "force.z", "",
+    sensor_name_ + "/" + "torque.y", sensor_name_ + "/" + "torque.z");
 
   // validate the component name
   // it should be "" as we specified the interface's names explicitly
@@ -135,16 +131,16 @@ TEST_F(ForceTorqueSensorTest, validate_all_with_custom_names)
   std::vector<std::string> interface_names = force_torque_sensor_->get_state_interface_names();
 
   // assign values to force.x and force.z
-  hardware_interface::StateInterface force_x{sensor_name_, fts_interface_names_[0],
-    &force_values_[0]};
-  hardware_interface::StateInterface force_z{sensor_name_, fts_interface_names_[2],
-    &force_values_[2]};
+  hardware_interface::StateInterface force_x{
+    sensor_name_, fts_interface_names_[0], &force_values_[0]};
+  hardware_interface::StateInterface force_z{
+    sensor_name_, fts_interface_names_[2], &force_values_[2]};
 
   // assign values to torque.y and torque.z
-  hardware_interface::StateInterface torque_y{sensor_name_, fts_interface_names_[4],
-    &torque_values_[1]};
-  hardware_interface::StateInterface torque_z{sensor_name_, fts_interface_names_[5],
-    &torque_values_[2]};
+  hardware_interface::StateInterface torque_y{
+    sensor_name_, fts_interface_names_[4], &torque_values_[1]};
+  hardware_interface::StateInterface torque_z{
+    sensor_name_, fts_interface_names_[5], &torque_values_[2]};
 
   // create local state interface vector
   std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;
@@ -217,20 +213,20 @@ TEST_F(ForceTorqueSensorTest, validate_all_custom_names)
   ASSERT_EQ(force_torque_sensor_->interface_names_[5], sensor_name_ + "/" + "torque.z");
 
   // assign values to force
-  hardware_interface::StateInterface force_x{sensor_name_, fts_interface_names_[0],
-    &force_values_[0]};
-  hardware_interface::StateInterface force_y{sensor_name_, fts_interface_names_[1],
-    &force_values_[1]};
-  hardware_interface::StateInterface force_z{sensor_name_, fts_interface_names_[2],
-    &force_values_[2]};
+  hardware_interface::StateInterface force_x{
+    sensor_name_, fts_interface_names_[0], &force_values_[0]};
+  hardware_interface::StateInterface force_y{
+    sensor_name_, fts_interface_names_[1], &force_values_[1]};
+  hardware_interface::StateInterface force_z{
+    sensor_name_, fts_interface_names_[2], &force_values_[2]};
 
   // assign values to torque
-  hardware_interface::StateInterface torque_x{sensor_name_, fts_interface_names_[3],
-    &torque_values_[0]};
-  hardware_interface::StateInterface torque_y{sensor_name_, fts_interface_names_[4],
-    &torque_values_[1]};
-  hardware_interface::StateInterface torque_z{sensor_name_, fts_interface_names_[5],
-    &torque_values_[2]};
+  hardware_interface::StateInterface torque_x{
+    sensor_name_, fts_interface_names_[3], &torque_values_[0]};
+  hardware_interface::StateInterface torque_y{
+    sensor_name_, fts_interface_names_[4], &torque_values_[1]};
+  hardware_interface::StateInterface torque_z{
+    sensor_name_, fts_interface_names_[5], &torque_values_[2]};
 
   // create local state interface vector
   std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;

--- a/controller_interface/test/test_force_torque_sensor.hpp
+++ b/controller_interface/test/test_force_torque_sensor.hpp
@@ -28,8 +28,7 @@
 #include "semantic_components/force_torque_sensor.hpp"
 
 // implementing and friending so we can access member variables
-class TestableForceTorqueSensor : public semantic_components::
-  ForceTorqueSensor
+class TestableForceTorqueSensor : public semantic_components::ForceTorqueSensor
 {
   FRIEND_TEST(ForceTorqueSensorTest, validate_all_with_default_names);
   FRIEND_TEST(ForceTorqueSensorTest, validate_all_with_custom_names);
@@ -37,18 +36,17 @@ class TestableForceTorqueSensor : public semantic_components::
 
 public:
   // Use generation of interface names
-  explicit TestableForceTorqueSensor(const std::string & name)
-  : ForceTorqueSensor(name)
-  {}
+  explicit TestableForceTorqueSensor(const std::string & name) : ForceTorqueSensor(name) {}
   // Use custom interface names
   explicit TestableForceTorqueSensor(
     const std::string & interface_force_x, const std::string & interface_force_y,
     const std::string & interface_force_z, const std::string & interface_torque_x,
     const std::string & interface_torque_y, const std::string & interface_torque_z)
   : ForceTorqueSensor(
-      interface_force_x, interface_force_y, interface_force_z,
-      interface_torque_x, interface_torque_y, interface_torque_z)
-  {}
+      interface_force_x, interface_force_y, interface_force_z, interface_torque_x,
+      interface_torque_y, interface_torque_z)
+  {
+  }
 
   virtual ~TestableForceTorqueSensor() = default;
 };
@@ -59,7 +57,8 @@ public:
   void SetUp()
   {
     full_interface_names_.reserve(size_);
-    for (auto index = 0u; index < size_; ++index) {
+    for (auto index = 0u; index < size_; ++index)
+    {
       full_interface_names_.emplace_back(sensor_name_ + "/" + fts_interface_names_[index]);
     }
   }
@@ -74,8 +73,8 @@ protected:
   std::unique_ptr<TestableForceTorqueSensor> force_torque_sensor_;
 
   std::vector<std::string> full_interface_names_;
-  const std::vector<std::string> fts_interface_names_ = {"force.x", "force.y", "force.z",
-    "torque.x", "torque.y", "torque.z"};
+  const std::vector<std::string> fts_interface_names_ = {"force.x",  "force.y",  "force.z",
+                                                         "torque.x", "torque.y", "torque.z"};
 };
 
 #endif  // TEST_FORCE_TORQUE_SENSOR_HPP_

--- a/controller_interface/test/test_imu_sensor.cpp
+++ b/controller_interface/test/test_imu_sensor.cpp
@@ -22,10 +22,7 @@
 #include <string>
 #include <vector>
 
-void IMUSensorTest::TearDown()
-{
-  imu_sensor_.reset(nullptr);
-}
+void IMUSensorTest::TearDown() { imu_sensor_.reset(nullptr); }
 
 TEST_F(IMUSensorTest, validate_all)
 {
@@ -41,40 +38,38 @@ TEST_F(IMUSensorTest, validate_all)
   ASSERT_EQ(imu_sensor_->state_interfaces_.capacity(), size_);
 
   // validate the default interface_names_
-  ASSERT_TRUE(
-    std::equal(
-      imu_sensor_->interface_names_.begin(), imu_sensor_->interface_names_.end(),
-      full_interface_names_.begin(), full_interface_names_.end()));
+  ASSERT_TRUE(std::equal(
+    imu_sensor_->interface_names_.begin(), imu_sensor_->interface_names_.end(),
+    full_interface_names_.begin(), full_interface_names_.end()));
 
   // get the interface names
   std::vector<std::string> interface_names = imu_sensor_->get_state_interface_names();
 
   // assign values to orientation
-  hardware_interface::StateInterface orientation_x{sensor_name_, imu_interface_names_[0],
-    &orientation_values_[0]};
-  hardware_interface::StateInterface orientation_y{sensor_name_, imu_interface_names_[1],
-    &orientation_values_[1]};
-  hardware_interface::StateInterface orientation_z{sensor_name_, imu_interface_names_[2],
-    &orientation_values_[2]};
-  hardware_interface::StateInterface orientation_w{sensor_name_, imu_interface_names_[3],
-    &orientation_values_[4]};
+  hardware_interface::StateInterface orientation_x{
+    sensor_name_, imu_interface_names_[0], &orientation_values_[0]};
+  hardware_interface::StateInterface orientation_y{
+    sensor_name_, imu_interface_names_[1], &orientation_values_[1]};
+  hardware_interface::StateInterface orientation_z{
+    sensor_name_, imu_interface_names_[2], &orientation_values_[2]};
+  hardware_interface::StateInterface orientation_w{
+    sensor_name_, imu_interface_names_[3], &orientation_values_[4]};
 
   // assign values to angular velocity
-  hardware_interface::StateInterface angular_velocity_x{sensor_name_, imu_interface_names_[4],
-    &angular_velocity_values_[0]};
-  hardware_interface::StateInterface angular_velocity_y{sensor_name_, imu_interface_names_[5],
-    &angular_velocity_values_[1]};
-  hardware_interface::StateInterface angular_velocity_z{sensor_name_, imu_interface_names_[6],
-    &angular_velocity_values_[2]};
+  hardware_interface::StateInterface angular_velocity_x{
+    sensor_name_, imu_interface_names_[4], &angular_velocity_values_[0]};
+  hardware_interface::StateInterface angular_velocity_y{
+    sensor_name_, imu_interface_names_[5], &angular_velocity_values_[1]};
+  hardware_interface::StateInterface angular_velocity_z{
+    sensor_name_, imu_interface_names_[6], &angular_velocity_values_[2]};
 
   // assign values to linear acceleration
-  hardware_interface::StateInterface linear_acceleration_x{sensor_name_, imu_interface_names_[7],
-    &linear_acceleration_values_[0]};
-  hardware_interface::StateInterface linear_acceleration_y{sensor_name_, imu_interface_names_[8],
-    &linear_acceleration_values_[1]};
-  hardware_interface::StateInterface linear_acceleration_z{sensor_name_, imu_interface_names_[9],
-    &linear_acceleration_values_[2]};
-
+  hardware_interface::StateInterface linear_acceleration_x{
+    sensor_name_, imu_interface_names_[7], &linear_acceleration_values_[0]};
+  hardware_interface::StateInterface linear_acceleration_y{
+    sensor_name_, imu_interface_names_[8], &linear_acceleration_values_[1]};
+  hardware_interface::StateInterface linear_acceleration_z{
+    sensor_name_, imu_interface_names_[9], &linear_acceleration_values_[2]};
 
   // create local state interface vector
   std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;

--- a/controller_interface/test/test_imu_sensor.hpp
+++ b/controller_interface/test/test_imu_sensor.hpp
@@ -28,16 +28,13 @@
 #include "semantic_components/imu_sensor.hpp"
 
 // implementing and friending so we can access member variables
-class TestableIMUSensor : public semantic_components::
-  IMUSensor
+class TestableIMUSensor : public semantic_components::IMUSensor
 {
   FRIEND_TEST(IMUSensorTest, validate_all);
 
 public:
   // Use generation of interface names
-  explicit TestableIMUSensor(const std::string & name)
-  : IMUSensor(name)
-  {}
+  explicit TestableIMUSensor(const std::string & name) : IMUSensor(name) {}
 
   virtual ~TestableIMUSensor() = default;
 };
@@ -48,7 +45,8 @@ public:
   void SetUp()
   {
     full_interface_names_.reserve(size_);
-    for (auto index = 0u; index < size_; ++index) {
+    for (auto index = 0u; index < size_; ++index)
+    {
       full_interface_names_.emplace_back(sensor_name_ + "/" + imu_interface_names_[index]);
     }
   }
@@ -64,9 +62,9 @@ protected:
   std::unique_ptr<TestableIMUSensor> imu_sensor_;
 
   std::vector<std::string> full_interface_names_;
-  const std::vector<std::string> imu_interface_names_ =
-  {"orientation.x", "orientation.y", "orientation.z", "orientation.w",
-    "angular_velocity.x", "angular_velocity.y", "angular_velocity.z", "linear_acceleration.x",
+  const std::vector<std::string> imu_interface_names_ = {
+    "orientation.x",         "orientation.y",        "orientation.z",      "orientation.w",
+    "angular_velocity.x",    "angular_velocity.y",   "angular_velocity.z", "linear_acceleration.x",
     "linear_acceleration.y", "linear_acceleration.z"};
 };
 

--- a/controller_interface/test/test_semantic_component_interface.cpp
+++ b/controller_interface/test/test_semantic_component_interface.cpp
@@ -22,10 +22,7 @@
 #include <string>
 #include <vector>
 
-void SemanticComponentInterfaceTest::TearDown()
-{
-  semantic_component_.reset(nullptr);
-}
+void SemanticComponentInterfaceTest::TearDown() { semantic_component_.reset(nullptr); }
 
 TEST_F(SemanticComponentInterfaceTest, validate_default_names)
 {
@@ -70,10 +67,9 @@ TEST_F(SemanticComponentInterfaceTest, validate_custom_names)
 
   // validate the interface_names_
   std::vector<std::string> interface_names = semantic_component_->get_state_interface_names();
-  ASSERT_TRUE(
-    std::equal(
-      semantic_component_->interface_names_.begin(), semantic_component_->interface_names_.end(),
-      interface_names.begin(), interface_names.end()));
+  ASSERT_TRUE(std::equal(
+    semantic_component_->interface_names_.begin(), semantic_component_->interface_names_.end(),
+    interface_names.begin(), interface_names.end()));
 
   ASSERT_EQ(interface_names.size(), size_);
   ASSERT_EQ(interface_names[0], semantic_component_->test_name_ + "/i5");
@@ -98,12 +94,9 @@ TEST_F(SemanticComponentInterfaceTest, validate_state_interfaces)
   std::vector<double> interface_values = {1.1, 3.3, 5.5};
 
   // assign 1.1 to interface_1, 3.3 to interface_3 and 5.5 to interface_5
-  hardware_interface::StateInterface interface_1{
-    component_name_, "1", &interface_values[0]};
-  hardware_interface::StateInterface interface_3{
-    component_name_, "3", &interface_values[1]};
-  hardware_interface::StateInterface interface_5{
-    component_name_, "5", &interface_values[2]};
+  hardware_interface::StateInterface interface_1{component_name_, "1", &interface_values[0]};
+  hardware_interface::StateInterface interface_3{component_name_, "3", &interface_values[1]};
+  hardware_interface::StateInterface interface_5{component_name_, "5", &interface_values[2]};
 
   // create local state interface vector
   std::vector<hardware_interface::LoanedStateInterface> temp_state_interfaces;
@@ -136,8 +129,7 @@ TEST_F(SemanticComponentInterfaceTest, validate_state_interfaces)
   ASSERT_EQ(semantic_component_->state_interfaces_.size(), 0u);
 
   // validate that release_interfaces() does not touch interface_names_
-  ASSERT_TRUE(
-    std::equal(
-      semantic_component_->interface_names_.begin(), semantic_component_->interface_names_.end(),
-      interface_names.begin(), interface_names.end()));
+  ASSERT_TRUE(std::equal(
+    semantic_component_->interface_names_.begin(), semantic_component_->interface_names_.end(),
+    interface_names.begin(), interface_names.end()));
 }

--- a/controller_interface/test/test_semantic_component_interface.hpp
+++ b/controller_interface/test/test_semantic_component_interface.hpp
@@ -22,13 +22,13 @@
 #include <memory>
 #include <string>
 
-#include "gmock/gmock.h"
 #include "geometry_msgs/msg/wrench.hpp"
+#include "gmock/gmock.h"
 #include "semantic_components/semantic_component_interface.hpp"
 
 // implementing and friending so we can access member variables
-class TestableSemanticComponentInterface : public semantic_components::
-  SemanticComponentInterface<geometry_msgs::msg::Wrench>
+class TestableSemanticComponentInterface
+: public semantic_components::SemanticComponentInterface<geometry_msgs::msg::Wrench>
 {
   FRIEND_TEST(SemanticComponentInterfaceTest, validate_default_names);
   FRIEND_TEST(SemanticComponentInterfaceTest, validate_custom_names);
@@ -38,13 +38,15 @@ public:
   // Use generation of interface names
   explicit TestableSemanticComponentInterface(const std::string & name, size_t size)
   : SemanticComponentInterface<geometry_msgs::msg::Wrench>(name, size)
-  {}
+  {
+  }
   // Use custom interface names
   explicit TestableSemanticComponentInterface(size_t size)
   : SemanticComponentInterface("TestSemanticComponent", size)
   {
     // generate the interface_names_
-    for (auto i = 0u; i < size; ++i) {
+    for (auto i = 0u; i < size; ++i)
+    {
       interface_names_.emplace_back(
         std::string("TestSemanticComponent") + "/i" + std::to_string(i + 5));
     }

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -72,6 +72,10 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 
   ament_index_get_prefix_path(ament_index_build_path SKIP_AMENT_PREFIX_PATH)

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -26,11 +26,11 @@
 #include "controller_manager/visibility_control.h"
 #include "controller_manager_msgs/srv/configure_controller.hpp"
 #include "controller_manager_msgs/srv/configure_start_controller.hpp"
-#include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/list_controller_types.hpp"
+#include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/list_hardware_interfaces.hpp"
-#include "controller_manager_msgs/srv/load_controller.hpp"
 #include "controller_manager_msgs/srv/load_configure_controller.hpp"
+#include "controller_manager_msgs/srv/load_controller.hpp"
 #include "controller_manager_msgs/srv/load_start_controller.hpp"
 #include "controller_manager_msgs/srv/reload_controller_libraries.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
@@ -45,7 +45,6 @@
 
 namespace controller_manager
 {
-
 class ControllerManager : public rclcpp::Node
 {
 public:
@@ -66,14 +65,11 @@ public:
     const std::string & namespace_ = "");
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual
-  ~ControllerManager() = default;
+  virtual ~ControllerManager() = default;
 
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::ControllerInterfaceSharedPtr
-  load_controller(
-    const std::string & controller_name,
-    const std::string & controller_type);
+  controller_interface::ControllerInterfaceSharedPtr load_controller(
+    const std::string & controller_name, const std::string & controller_type);
 
   /// load_controller loads a controller by name, the type must be defined in the parameter server.
   /**
@@ -82,8 +78,8 @@ public:
    * \see Documentation in controller_manager_msgs/LoadController.srv
    */
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::ControllerInterfaceSharedPtr
-  load_controller(const std::string & controller_name);
+  controller_interface::ControllerInterfaceSharedPtr load_controller(
+    const std::string & controller_name);
 
   CONTROLLER_MANAGER_PUBLIC
   controller_interface::return_type unload_controller(const std::string & controller_name);
@@ -91,12 +87,11 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   std::vector<ControllerSpec> get_loaded_controllers() const;
 
-  template<
-    typename T,
-    typename std::enable_if<std::is_convertible<
-      T *, controller_interface::ControllerInterface *>::value, T>::type * = nullptr>
-  controller_interface::ControllerInterfaceSharedPtr
-  add_controller(
+  template <
+    typename T, typename std::enable_if<
+                  std::is_convertible<T *, controller_interface::ControllerInterface *>::value,
+                  T>::type * = nullptr>
+  controller_interface::ControllerInterfaceSharedPtr add_controller(
     std::shared_ptr<T> controller, const std::string & controller_name,
     const std::string & controller_type)
   {
@@ -114,8 +109,7 @@ public:
    * \see Documentation in controller_manager_msgs/ConfigureController.srv
    */
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::return_type
-  configure_controller(const std::string & controller_name);
+  controller_interface::return_type configure_controller(const std::string & controller_name);
 
   /// switch_controller Stops some controllers and start others.
   /**
@@ -125,14 +119,12 @@ public:
    * \see Documentation in controller_manager_msgs/SwitchController.srv
    */
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::return_type
-  switch_controller(
+  controller_interface::return_type switch_controller(
     const std::vector<std::string> & start_controllers,
-    const std::vector<std::string> & stop_controllers,
-    int strictness,
+    const std::vector<std::string> & stop_controllers, int strictness,
     bool start_asap = kWaitForAllResources,
     const rclcpp::Duration & timeout =
-    rclcpp::Duration(static_cast<rcl_duration_value_t>(kInfiniteTimeout)));
+      rclcpp::Duration(static_cast<rcl_duration_value_t>(kInfiniteTimeout)));
 
   CONTROLLER_MANAGER_PUBLIC
   void read();
@@ -157,8 +149,8 @@ protected:
   void init_services();
 
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::ControllerInterfaceSharedPtr
-  add_controller_impl(const ControllerSpec & controller);
+  controller_interface::ControllerInterfaceSharedPtr add_controller_impl(
+    const ControllerSpec & controller);
 
   CONTROLLER_MANAGER_PUBLIC
   void manage_switch();
@@ -256,9 +248,9 @@ private:
    */
   class RTControllerListWrapper
   {
-// *INDENT-OFF*
+    // *INDENT-OFF*
   public:
-// *INDENT-ON*
+    // *INDENT-ON*
     /// update_and_get_used_by_rt_list Makes the "updated" list the "used by rt" list
     /**
      * \warning Should only be called by the RT thread, no one should modify the
@@ -296,9 +288,9 @@ private:
     // must be acquired before using any list other than the "used by rt"
     mutable std::recursive_mutex controllers_lock_;
 
-// *INDENT-OFF*
+    // *INDENT-OFF*
   private:
-// *INDENT-ON*
+    // *INDENT-ON*
     /// get_other_list get the list not pointed by index
     /**
      * \param[in] index int
@@ -306,8 +298,7 @@ private:
     int get_other_list(int index) const;
 
     void wait_until_rt_not_using(
-      int index,
-      std::chrono::microseconds sleep_delay = std::chrono::microseconds(200)) const;
+      int index, std::chrono::microseconds sleep_delay = std::chrono::microseconds(200)) const;
 
     std::vector<ControllerSpec> controllers_lists_[2];
     /// The index of the controller list with the most updated information
@@ -326,8 +317,7 @@ private:
     list_controller_types_service_;
   rclcpp::Service<controller_manager_msgs::srv::ListHardwareInterfaces>::SharedPtr
     list_hardware_interfaces_service_;
-  rclcpp::Service<controller_manager_msgs::srv::LoadController>::SharedPtr
-    load_controller_service_;
+  rclcpp::Service<controller_manager_msgs::srv::LoadController>::SharedPtr load_controller_service_;
   rclcpp::Service<controller_manager_msgs::srv::ConfigureController>::SharedPtr
     configure_controller_service_;
   rclcpp::Service<controller_manager_msgs::srv::LoadConfigureController>::SharedPtr

--- a/controller_manager/include/controller_manager/controller_spec.hpp
+++ b/controller_manager/include/controller_manager/controller_spec.hpp
@@ -27,7 +27,6 @@
 
 namespace controller_manager
 {
-
 /// Controller Specification
 /**
  * This struct contains both a pointer to a given controller, \ref c, as well

--- a/controller_manager/include/controller_manager/visibility_control.h
+++ b/controller_manager/include/controller_manager/visibility_control.h
@@ -19,31 +19,31 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define CONTROLLER_MANAGER_EXPORT __attribute__ ((dllexport))
-    #define CONTROLLER_MANAGER_IMPORT __attribute__ ((dllimport))
-  #else
-    #define CONTROLLER_MANAGER_EXPORT __declspec(dllexport)
-    #define CONTROLLER_MANAGER_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef CONTROLLER_MANAGER_BUILDING_DLL
-    #define CONTROLLER_MANAGER_PUBLIC CONTROLLER_MANAGER_EXPORT
-  #else
-    #define CONTROLLER_MANAGER_PUBLIC CONTROLLER_MANAGER_IMPORT
-  #endif
-  #define CONTROLLER_MANAGER_PUBLIC_TYPE CONTROLLER_MANAGER_PUBLIC
-  #define CONTROLLER_MANAGER_LOCAL
+#ifdef __GNUC__
+#define CONTROLLER_MANAGER_EXPORT __attribute__((dllexport))
+#define CONTROLLER_MANAGER_IMPORT __attribute__((dllimport))
 #else
-  #define CONTROLLER_MANAGER_EXPORT __attribute__ ((visibility("default")))
-  #define CONTROLLER_MANAGER_IMPORT
-  #if __GNUC__ >= 4
-    #define CONTROLLER_MANAGER_PUBLIC __attribute__ ((visibility("default")))
-    #define CONTROLLER_MANAGER_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define CONTROLLER_MANAGER_PUBLIC
-    #define CONTROLLER_MANAGER_LOCAL
-  #endif
-  #define CONTROLLER_MANAGER_PUBLIC_TYPE
+#define CONTROLLER_MANAGER_EXPORT __declspec(dllexport)
+#define CONTROLLER_MANAGER_IMPORT __declspec(dllimport)
+#endif
+#ifdef CONTROLLER_MANAGER_BUILDING_DLL
+#define CONTROLLER_MANAGER_PUBLIC CONTROLLER_MANAGER_EXPORT
+#else
+#define CONTROLLER_MANAGER_PUBLIC CONTROLLER_MANAGER_IMPORT
+#endif
+#define CONTROLLER_MANAGER_PUBLIC_TYPE CONTROLLER_MANAGER_PUBLIC
+#define CONTROLLER_MANAGER_LOCAL
+#else
+#define CONTROLLER_MANAGER_EXPORT __attribute__((visibility("default")))
+#define CONTROLLER_MANAGER_IMPORT
+#if __GNUC__ >= 4
+#define CONTROLLER_MANAGER_PUBLIC __attribute__((visibility("default")))
+#define CONTROLLER_MANAGER_LOCAL __attribute__((visibility("hidden")))
+#else
+#define CONTROLLER_MANAGER_PUBLIC
+#define CONTROLLER_MANAGER_LOCAL
+#endif
+#define CONTROLLER_MANAGER_PUBLIC_TYPE
 #endif
 
 #endif  // CONTROLLER_MANAGER__VISIBILITY_CONTROL_H_

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -26,14 +26,12 @@
 
 namespace controller_manager
 {
-
 static constexpr const char * kControllerInterfaceName = "controller_interface";
 static constexpr const char * kControllerInterface = "controller_interface::ControllerInterface";
 
 inline bool is_controller_running(controller_interface::ControllerInterface & controller)
 {
-  return controller.get_current_state().id() ==
-         lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+  return controller.get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
 }
 
 bool controller_name_compare(const ControllerSpec & a, const std::string & name)
@@ -51,18 +49,18 @@ rclcpp::NodeOptions get_cm_node_options()
 }
 
 ControllerManager::ControllerManager(
-  std::shared_ptr<rclcpp::Executor> executor,
-  const std::string & manager_node_name,
+  std::shared_ptr<rclcpp::Executor> executor, const std::string & manager_node_name,
   const std::string & namespace_)
 : rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::make_unique<hardware_interface::ResourceManager>()),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(
-      kControllerInterfaceName, kControllerInterface))
+    kControllerInterfaceName, kControllerInterface))
 {
   std::string robot_description = "";
   get_parameter("robot_description", robot_description);
-  if (robot_description.empty()) {
+  if (robot_description.empty())
+  {
     throw std::runtime_error("Unable to initialize resource manager, no robot description found.");
   }
 
@@ -76,14 +74,13 @@ ControllerManager::ControllerManager(
 
 ControllerManager::ControllerManager(
   std::unique_ptr<hardware_interface::ResourceManager> resource_manager,
-  std::shared_ptr<rclcpp::Executor> executor,
-  const std::string & manager_node_name,
+  std::shared_ptr<rclcpp::Executor> executor, const std::string & manager_node_name,
   const std::string & namespace_)
 : rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::move(resource_manager)),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(
-      kControllerInterfaceName, kControllerInterface))
+    kControllerInterfaceName, kControllerInterface))
 {
   init_services();
 }
@@ -94,86 +91,70 @@ void ControllerManager::init_services()
   // the executor (see issue #260).
   // deterministic_callback_group_ = create_callback_group(
   //   rclcpp::CallbackGroupType::MutuallyExclusive);
-  best_effort_callback_group_ = create_callback_group(
-    rclcpp::CallbackGroupType::MutuallyExclusive);
+  best_effort_callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   using namespace std::placeholders;
   list_controllers_service_ = create_service<controller_manager_msgs::srv::ListControllers>(
-    "~/list_controllers",
-    std::bind(&ControllerManager::list_controllers_srv_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+    "~/list_controllers", std::bind(&ControllerManager::list_controllers_srv_cb, this, _1, _2),
+    rmw_qos_profile_services_default, best_effort_callback_group_);
   list_controller_types_service_ =
     create_service<controller_manager_msgs::srv::ListControllerTypes>(
-    "~/list_controller_types",
-    std::bind(&ControllerManager::list_controller_types_srv_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+      "~/list_controller_types",
+      std::bind(&ControllerManager::list_controller_types_srv_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   list_hardware_interfaces_service_ =
     create_service<controller_manager_msgs::srv::ListHardwareInterfaces>(
-    "~/list_hardware_interfaces",
-    std::bind(&ControllerManager::list_hardware_interfaces_srv_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+      "~/list_hardware_interfaces",
+      std::bind(&ControllerManager::list_hardware_interfaces_srv_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   load_controller_service_ = create_service<controller_manager_msgs::srv::LoadController>(
-    "~/load_controller",
-    std::bind(&ControllerManager::load_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+    "~/load_controller", std::bind(&ControllerManager::load_controller_service_cb, this, _1, _2),
+    rmw_qos_profile_services_default, best_effort_callback_group_);
   configure_controller_service_ = create_service<controller_manager_msgs::srv::ConfigureController>(
     "~/configure_controller",
     std::bind(&ControllerManager::configure_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+    rmw_qos_profile_services_default, best_effort_callback_group_);
   load_and_configure_controller_service_ =
     create_service<controller_manager_msgs::srv::LoadConfigureController>(
-    "~/load_and_configure_controller",
-    std::bind(&ControllerManager::load_and_configure_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_
-    );
+      "~/load_and_configure_controller",
+      std::bind(&ControllerManager::load_and_configure_controller_service_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   load_and_start_controller_service_ =
     create_service<controller_manager_msgs::srv::LoadStartController>(
-    "~/load_and_start_controller",
-    std::bind(&ControllerManager::load_and_start_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_
-    );
+      "~/load_and_start_controller",
+      std::bind(&ControllerManager::load_and_start_controller_service_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   configure_and_start_controller_service_ =
     create_service<controller_manager_msgs::srv::ConfigureStartController>(
-    "~/configure_and_start_controller",
-    std::bind(&ControllerManager::configure_and_start_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_
-    );
+      "~/configure_and_start_controller",
+      std::bind(&ControllerManager::configure_and_start_controller_service_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   reload_controller_libraries_service_ =
     create_service<controller_manager_msgs::srv::ReloadControllerLibraries>(
-    "~/reload_controller_libraries",
-    std::bind(&ControllerManager::reload_controller_libraries_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+      "~/reload_controller_libraries",
+      std::bind(&ControllerManager::reload_controller_libraries_service_cb, this, _1, _2),
+      rmw_qos_profile_services_default, best_effort_callback_group_);
   switch_controller_service_ = create_service<controller_manager_msgs::srv::SwitchController>(
     "~/switch_controller",
     std::bind(&ControllerManager::switch_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+    rmw_qos_profile_services_default, best_effort_callback_group_);
   unload_controller_service_ = create_service<controller_manager_msgs::srv::UnloadController>(
     "~/unload_controller",
     std::bind(&ControllerManager::unload_controller_service_cb, this, _1, _2),
-    rmw_qos_profile_services_default,
-    best_effort_callback_group_);
+    rmw_qos_profile_services_default, best_effort_callback_group_);
 }
 
 controller_interface::ControllerInterfaceSharedPtr ControllerManager::load_controller(
-  const std::string & controller_name,
-  const std::string & controller_type)
+  const std::string & controller_name, const std::string & controller_type)
 {
   RCLCPP_INFO(get_logger(), "Loading controller '%s'", controller_name.c_str());
 
-  if (!loader_->isClassAvailable(controller_type)) {
+  if (!loader_->isClassAvailable(controller_type))
+  {
     const std::string error_msg("Loader for controller '" + controller_name + "' not found.");
     RCLCPP_ERROR(get_logger(), "Available classes:");
-    for (const auto & c : loader_->getDeclaredClasses()) {
+    for (const auto & c : loader_->getDeclaredClasses())
+    {
       RCLCPP_ERROR(get_logger(), "%s", c.c_str());
     }
     RCLCPP_ERROR(get_logger(), "%s", error_msg.c_str());
@@ -201,10 +182,12 @@ controller_interface::ControllerInterfaceSharedPtr ControllerManager::load_contr
   // we haven't done so, and then read it.
 
   // Check if parameter has been declared
-  if (!has_parameter(param_name)) {
+  if (!has_parameter(param_name))
+  {
     declare_parameter(param_name, rclcpp::ParameterValue());
   }
-  if (!get_parameter(param_name, controller_type)) {
+  if (!get_parameter(param_name, controller_type))
+  {
     RCLCPP_ERROR(get_logger(), "The 'type' param not defined for '%s'.", controller_name.c_str());
     return nullptr;
   }
@@ -224,7 +207,8 @@ controller_interface::return_type ControllerManager::unload_controller(
   auto found_it = std::find_if(
     to.begin(), to.end(),
     std::bind(controller_name_compare, std::placeholders::_1, controller_name));
-  if (found_it == to.end()) {
+  if (found_it == to.end())
+  {
     // Fails if we could not remove the controllers
     to.clear();
     RCLCPP_ERROR(
@@ -236,11 +220,11 @@ controller_interface::return_type ControllerManager::unload_controller(
 
   auto & controller = *found_it;
 
-  if (is_controller_running(*controller.c)) {
+  if (is_controller_running(*controller.c))
+  {
     to.clear();
     RCLCPP_ERROR(
-      get_logger(),
-      "Could not unload controller with name '%s' because it is still running",
+      get_logger(), "Could not unload controller with name '%s' because it is still running",
       controller_name.c_str());
     return controller_interface::return_type::ERROR;
   }
@@ -253,8 +237,7 @@ controller_interface::return_type ControllerManager::unload_controller(
   // Destroys the old controllers list when the realtime thread is finished with it.
   RCLCPP_DEBUG(get_logger(), "Realtime switches over to new controller list");
   rt_controllers_wrapper_.switch_updated_list(guard);
-  std::vector<ControllerSpec> & new_unused_list = rt_controllers_wrapper_.get_unused_list(
-    guard);
+  std::vector<ControllerSpec> & new_unused_list = rt_controllers_wrapper_.get_unused_list(guard);
   RCLCPP_DEBUG(get_logger(), "Destruct controller");
   new_unused_list.clear();
   RCLCPP_DEBUG(get_logger(), "Destruct controller finished");
@@ -280,7 +263,8 @@ controller_interface::return_type ControllerManager::configure_controller(
     controllers.begin(), controllers.end(),
     std::bind(controller_name_compare, std::placeholders::_1, controller_name));
 
-  if (found_it == controllers.end()) {
+  if (found_it == controllers.end())
+  {
     RCLCPP_ERROR(
       get_logger(),
       "Could not configure controller with name '%s' because no controller with this name exists",
@@ -290,40 +274,37 @@ controller_interface::return_type ControllerManager::configure_controller(
   auto controller = found_it->c;
 
   auto state = controller->get_current_state();
-  if (state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE ||
+  if (
+    state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE ||
     state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {
     RCLCPP_ERROR(
-      get_logger(),
-      "Controller '%s' can not be configured from '%s' state.",
-      controller_name.c_str(),
-      state.label().c_str());
+      get_logger(), "Controller '%s' can not be configured from '%s' state.",
+      controller_name.c_str(), state.label().c_str());
     return controller_interface::return_type::ERROR;
   }
 
   auto new_state = controller->get_current_state();
-  if (state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
     RCLCPP_DEBUG(
-      get_logger(),
-      "Controller '%s' is cleaned-up before configuring",
-      controller_name.c_str());
+      get_logger(), "Controller '%s' is cleaned-up before configuring", controller_name.c_str());
     new_state = controller->cleanup();
-    if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+    if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+    {
       RCLCPP_ERROR(
-        get_logger(),
-        "Controller '%s' can not be cleaned-up before configuring",
+        get_logger(), "Controller '%s' can not be cleaned-up before configuring",
         controller_name.c_str());
       return controller_interface::return_type::ERROR;
     }
   }
 
   new_state = controller->configure();
-  if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+  {
     RCLCPP_ERROR(
-      get_logger(),
-      "After configuring, controller '%s' is in state '%s' , expected inactive.",
-      controller_name.c_str(),
-      new_state.label().c_str());
+      get_logger(), "After configuring, controller '%s' is in state '%s' , expected inactive.",
+      controller_name.c_str(), new_state.label().c_str());
     return controller_interface::return_type::ERROR;
   }
 
@@ -332,28 +313,30 @@ controller_interface::return_type ControllerManager::configure_controller(
 
 controller_interface::return_type ControllerManager::switch_controller(
   const std::vector<std::string> & start_controllers,
-  const std::vector<std::string> & stop_controllers,
-  int strictness,
-  bool start_asap,
+  const std::vector<std::string> & stop_controllers, int strictness, bool start_asap,
   const rclcpp::Duration & timeout)
 {
   switch_params_ = SwitchParams();
 
-  if (!stop_request_.empty() || !start_request_.empty()) {
+  if (!stop_request_.empty() || !start_request_.empty())
+  {
     RCLCPP_FATAL(
       get_logger(),
       "The internal stop and start request lists are not empty at the beginning of the "
       "switchController() call. This should not happen.");
   }
-  if (!stop_command_interface_request_.empty() || !start_command_interface_request_.empty()) {
+  if (!stop_command_interface_request_.empty() || !start_command_interface_request_.empty())
+  {
     RCLCPP_FATAL(
       get_logger(),
       "The internal stop and start requests command interface lists are not empty at the "
       "switch_controller() call. This should not happen.");
   }
-  if (strictness == 0) {
+  if (strictness == 0)
+  {
     RCLCPP_WARN(
-      get_logger(), "Controller Manager: to switch controllers you need to specify a "
+      get_logger(),
+      "Controller Manager: to switch controllers you need to specify a "
       "strictness level of controller_manager_msgs::SwitchController::STRICT "
       "(%d) or ::BEST_EFFORT (%d). Defaulting to ::BEST_EFFORT",
       controller_manager_msgs::srv::SwitchController::Request::STRICT,
@@ -362,170 +345,174 @@ controller_interface::return_type ControllerManager::switch_controller(
   }
 
   RCLCPP_DEBUG(get_logger(), "Switching controllers:");
-  for (const auto & controller : start_controllers) {
+  for (const auto & controller : start_controllers)
+  {
     RCLCPP_DEBUG(get_logger(), "- Starting controller '%s'", controller.c_str());
   }
-  for (const auto & controller : stop_controllers) {
+  for (const auto & controller : stop_controllers)
+  {
     RCLCPP_DEBUG(get_logger(), "- Stopping controller '%s'", controller.c_str());
   }
 
-  const auto list_controllers = [this, strictness](const std::vector<std::string> & controller_list,
-      std::vector<std::string> & request_list,
-      const std::string & action)
+  const auto list_controllers = [this, strictness](
+                                  const std::vector<std::string> & controller_list,
+                                  std::vector<std::string> & request_list,
+                                  const std::string & action) {
+    // lock controllers
+    std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
+
+    // list all controllers to stop/start
+    for (const auto & controller : controller_list)
     {
-      // lock controllers
-      std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
+      const auto & updated_controllers = rt_controllers_wrapper_.get_updated_list(guard);
 
-      // list all controllers to stop/start
-      for (const auto & controller : controller_list) {
-        const auto & updated_controllers = rt_controllers_wrapper_.get_updated_list(guard);
+      auto found_it = std::find_if(
+        updated_controllers.begin(), updated_controllers.end(),
+        std::bind(controller_name_compare, std::placeholders::_1, controller));
 
-        auto found_it = std::find_if(
-          updated_controllers.begin(), updated_controllers.end(),
-          std::bind(controller_name_compare, std::placeholders::_1, controller));
-
-        if (found_it == updated_controllers.end()) {
-          if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT) {
-            RCLCPP_ERROR(
-              get_logger(),
-              R"(Could not '%s' controller with name '%s' because
+      if (found_it == updated_controllers.end())
+      {
+        if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
+        {
+          RCLCPP_ERROR(
+            get_logger(),
+            R"(Could not '%s' controller with name '%s' because
                 no controller with this name exists)",
-              action.c_str(),
-              controller.c_str());
-            return controller_interface::return_type::ERROR;
-          }
-          RCLCPP_DEBUG(
-            get_logger(),
-            "Could not '%s' controller with name '%s' because no controller with this name exists",
-            action.c_str(),
-            controller.c_str());
-        } else {
-          RCLCPP_DEBUG(
-            get_logger(),
-            "Found controller '%s' that needs to be %sed in list of controllers",
-            controller.c_str(),
-            action.c_str());
-          request_list.push_back(controller);
+            action.c_str(), controller.c_str());
+          return controller_interface::return_type::ERROR;
         }
+        RCLCPP_DEBUG(
+          get_logger(),
+          "Could not '%s' controller with name '%s' because no controller with this name exists",
+          action.c_str(), controller.c_str());
       }
-      RCLCPP_DEBUG(
-        get_logger(), "'%s' request vector has size %i",
-        action.c_str(), (int)request_list.size());
+      else
+      {
+        RCLCPP_DEBUG(
+          get_logger(), "Found controller '%s' that needs to be %sed in list of controllers",
+          controller.c_str(), action.c_str());
+        request_list.push_back(controller);
+      }
+    }
+    RCLCPP_DEBUG(
+      get_logger(), "'%s' request vector has size %i", action.c_str(), (int)request_list.size());
 
-      return controller_interface::return_type::OK;
-    };
+    return controller_interface::return_type::OK;
+  };
 
   // list all controllers to stop
   auto ret = list_controllers(stop_controllers, stop_request_, "stop");
-  if (ret != controller_interface::return_type::OK) {
+  if (ret != controller_interface::return_type::OK)
+  {
     stop_request_.clear();
     return ret;
   }
 
   // list all controllers to start
   ret = list_controllers(start_controllers, start_request_, "start");
-  if (ret != controller_interface::return_type::OK) {
+  if (ret != controller_interface::return_type::OK)
+  {
     stop_request_.clear();
     start_request_.clear();
     return ret;
   }
 
-  const auto list_interfaces = [this](const ControllerSpec controller,
-      std::vector<std::string> & request_interface_list)
+  const auto list_interfaces = [this](
+                                 const ControllerSpec controller,
+                                 std::vector<std::string> & request_interface_list) {
+    auto command_interface_config = controller.c->command_interface_configuration();
+    std::vector<std::string> command_interface_names = {};
+    if (command_interface_config.type == controller_interface::interface_configuration_type::ALL)
     {
-      auto command_interface_config = controller.c->command_interface_configuration();
-      std::vector<std::string> command_interface_names = {};
-      if (command_interface_config.type ==
-        controller_interface::interface_configuration_type::ALL)
-      {
-        command_interface_names = resource_manager_->command_interface_keys();
-      }
-      if (command_interface_config.type ==
-        controller_interface::interface_configuration_type::INDIVIDUAL)
-      {
-        command_interface_names = command_interface_config.names;
-      }
-      request_interface_list.insert(
-        request_interface_list.end(),
-        command_interface_names.begin(),
-        command_interface_names.end()
-      );
-    };
+      command_interface_names = resource_manager_->command_interface_keys();
+    }
+    if (
+      command_interface_config.type ==
+      controller_interface::interface_configuration_type::INDIVIDUAL)
+    {
+      command_interface_names = command_interface_config.names;
+    }
+    request_interface_list.insert(
+      request_interface_list.end(), command_interface_names.begin(), command_interface_names.end());
+  };
 
   // lock controllers
   std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
 
-  const std::vector<ControllerSpec> & controllers =
-    rt_controllers_wrapper_.get_updated_list(guard);
+  const std::vector<ControllerSpec> & controllers = rt_controllers_wrapper_.get_updated_list(guard);
 
-  for (const auto & controller : controllers) {
-    auto stop_list_it = std::find(
-      stop_request_.begin(), stop_request_.end(), controller.info.name);
+  for (const auto & controller : controllers)
+  {
+    auto stop_list_it = std::find(stop_request_.begin(), stop_request_.end(), controller.info.name);
     bool in_stop_list = stop_list_it != stop_request_.end();
 
-    auto start_list_it = std::find(
-      start_request_.begin(), start_request_.end(), controller.info.name);
+    auto start_list_it =
+      std::find(start_request_.begin(), start_request_.end(), controller.info.name);
     bool in_start_list = start_list_it != start_request_.end();
 
     const bool is_running = is_controller_running(*controller.c);
 
-    auto handle_conflict = [&](const std::string & msg)
+    auto handle_conflict = [&](const std::string & msg) {
+      if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
       {
-        if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT) {
-          RCLCPP_ERROR(get_logger(), "%s", msg.c_str());
-          stop_request_.clear();
-          stop_command_interface_request_.clear();
-          start_request_.clear();
-          start_command_interface_request_.clear();
-          return controller_interface::return_type::ERROR;
-        }
-        RCLCPP_DEBUG(
-          get_logger(),
-          "Could not stop controller '%s' since it is not running",
-          controller.info.name.c_str());
-        return controller_interface::return_type::OK;
-      };
-    if (!is_running && in_stop_list) {      // check for double stop
+        RCLCPP_ERROR(get_logger(), "%s", msg.c_str());
+        stop_request_.clear();
+        stop_command_interface_request_.clear();
+        start_request_.clear();
+        start_command_interface_request_.clear();
+        return controller_interface::return_type::ERROR;
+      }
+      RCLCPP_DEBUG(
+        get_logger(), "Could not stop controller '%s' since it is not running",
+        controller.info.name.c_str());
+      return controller_interface::return_type::OK;
+    };
+    if (!is_running && in_stop_list)
+    {  // check for double stop
       auto ret = handle_conflict(
-        "Could not stop controller '" + controller.info.name +
-        "' since it is not running");
-      if (ret != controller_interface::return_type::OK) {
+        "Could not stop controller '" + controller.info.name + "' since it is not running");
+      if (ret != controller_interface::return_type::OK)
+      {
         return ret;
       }
       in_stop_list = false;
       stop_request_.erase(stop_list_it);
     }
 
-    if (is_running && !in_stop_list && in_start_list) {  // check for doubled start
+    if (is_running && !in_stop_list && in_start_list)
+    {  // check for doubled start
       auto ret = handle_conflict(
-        "Could not start controller '" + controller.info.name +
-        "' since it is already running");
-      if (ret != controller_interface::return_type::OK) {
+        "Could not start controller '" + controller.info.name + "' since it is already running");
+      if (ret != controller_interface::return_type::OK)
+      {
         return ret;
       }
       in_start_list = false;
       start_request_.erase(start_list_it);
     }
 
-    if (in_start_list) {
+    if (in_start_list)
+    {
       list_interfaces(controller, start_command_interface_request_);
     }
-    if (in_stop_list) {
+    if (in_stop_list)
+    {
       list_interfaces(controller, stop_command_interface_request_);
     }
   }
 
-  if (start_request_.empty() && stop_request_.empty()) {
+  if (start_request_.empty() && stop_request_.empty())
+  {
     RCLCPP_INFO(get_logger(), "Empty start and stop list, not requesting switch");
     start_command_interface_request_.clear();
     stop_command_interface_request_.clear();
     return controller_interface::return_type::OK;
   }
 
-  if (!start_command_interface_request_.empty() || !stop_command_interface_request_.empty()) {
+  if (!start_command_interface_request_.empty() || !stop_command_interface_request_.empty())
+  {
     if (!resource_manager_->prepare_command_mode_switch(
-        start_command_interface_request_,
-        stop_command_interface_request_))
+          start_command_interface_request_, stop_command_interface_request_))
     {
       RCLCPP_ERROR(
         get_logger(),
@@ -546,8 +533,10 @@ controller_interface::return_type ControllerManager::switch_controller(
 
   // wait until switch is finished
   RCLCPP_DEBUG(get_logger(), "Request atomic controller switch from realtime loop");
-  while (rclcpp::ok() && switch_params_.do_switch) {
-    if (!rclcpp::ok()) {
+  while (rclcpp::ok() && switch_params_.do_switch)
+  {
+    if (!rclcpp::ok())
+    {
       return controller_interface::return_type::ERROR;
     }
     std::this_thread::sleep_for(std::chrono::microseconds(100));
@@ -558,22 +547,24 @@ controller_interface::return_type ControllerManager::switch_controller(
   to = controllers;
 
   // update the claimed interface controller info
-  for (auto & controller : to) {
-    if (controller.c->get_current_state().id() ==
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  for (auto & controller : to)
+  {
+    if (controller.c->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
     {
       auto command_interface_config = controller.c->command_interface_configuration();
-      if (command_interface_config.type ==
-        controller_interface::interface_configuration_type::ALL)
+      if (command_interface_config.type == controller_interface::interface_configuration_type::ALL)
       {
         controller.info.claimed_interfaces = resource_manager_->command_interface_keys();
       }
-      if (command_interface_config.type ==
+      if (
+        command_interface_config.type ==
         controller_interface::interface_configuration_type::INDIVIDUAL)
       {
         controller.info.claimed_interfaces = command_interface_config.names;
       }
-    } else {
+    }
+    else
+    {
       controller.info.claimed_interfaces.clear();
     }
   }
@@ -591,8 +582,7 @@ controller_interface::return_type ControllerManager::switch_controller(
   return controller_interface::return_type::OK;
 }
 
-controller_interface::ControllerInterfaceSharedPtr
-ControllerManager::add_controller_impl(
+controller_interface::ControllerInterfaceSharedPtr ControllerManager::add_controller_impl(
   const ControllerSpec & controller)
 {
   // lock controllers
@@ -608,31 +598,32 @@ ControllerManager::add_controller_impl(
     to.begin(), to.end(),
     std::bind(controller_name_compare, std::placeholders::_1, controller.info.name));
   // Checks that we're not duplicating controllers
-  if (found_it != to.end()) {
+  if (found_it != to.end())
+  {
     to.clear();
     RCLCPP_ERROR(
-      get_logger(),
-      "A controller named '%s' was already loaded inside the controller manager",
+      get_logger(), "A controller named '%s' was already loaded inside the controller manager",
       controller.info.name.c_str());
     return nullptr;
   }
 
-  if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR) {
+  if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR)
+  {
     to.clear();
     RCLCPP_ERROR(
-      get_logger(),
-      "Could not initialize the controller named '%s'",
-      controller.info.name.c_str());
+      get_logger(), "Could not initialize the controller named '%s'", controller.info.name.c_str());
     return nullptr;
   }
 
   // ensure controller's `use_sim_time` parameter matches controller_manager's
   const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
-  if (use_sim_time.as_bool()) {
+  if (use_sim_time.as_bool())
+  {
     RCLCPP_INFO(
       get_logger(),
       "Setting use_sim_time=True for %s to match controller manager "
-      "(see ros2_control#325 for details)", controller.info.name.c_str());
+      "(see ros2_control#325 for details)",
+      controller.info.name.c_str());
     controller.c->get_node()->set_parameter(use_sim_time);
   }
   executor_->add_node(controller.c->get_node());
@@ -642,8 +633,7 @@ ControllerManager::add_controller_impl(
   RCLCPP_DEBUG(get_logger(), "Realtime switches over to new controller list");
   rt_controllers_wrapper_.switch_updated_list(guard);
   RCLCPP_DEBUG(get_logger(), "Destruct controller");
-  std::vector<ControllerSpec> & new_unused_list = rt_controllers_wrapper_.get_unused_list(
-    guard);
+  std::vector<ControllerSpec> & new_unused_list = rt_controllers_wrapper_.get_unused_list(guard);
   new_unused_list.clear();
   RCLCPP_DEBUG(get_logger(), "Destruct controller finished");
 
@@ -654,20 +644,20 @@ void ControllerManager::manage_switch()
 {
   // Ask hardware interfaces to change mode
   if (!resource_manager_->perform_command_mode_switch(
-      start_command_interface_request_,
-      stop_command_interface_request_))
+        start_command_interface_request_, stop_command_interface_request_))
   {
-    RCLCPP_ERROR(
-      get_logger(),
-      "Error while performing mode switch.");
+    RCLCPP_ERROR(get_logger(), "Error while performing mode switch.");
   }
 
   stop_controllers();
 
   // start controllers once the switch is fully complete
-  if (!switch_params_.start_asap) {
+  if (!switch_params_.start_asap)
+  {
     start_controllers();
-  } else {
+  }
+  else
+  {
     // start controllers as soon as their required joints are done switching
     start_controllers_asap();
   }
@@ -678,11 +668,13 @@ void ControllerManager::stop_controllers()
   std::vector<ControllerSpec> & rt_controller_list =
     rt_controllers_wrapper_.update_and_get_used_by_rt_list();
   // stop controllers
-  for (const auto & request : stop_request_) {
+  for (const auto & request : stop_request_)
+  {
     auto found_it = std::find_if(
       rt_controller_list.begin(), rt_controller_list.end(),
       std::bind(controller_name_compare, std::placeholders::_1, request));
-    if (found_it == rt_controller_list.end()) {
+    if (found_it == rt_controller_list.end())
+    {
       RCLCPP_ERROR(
         get_logger(),
         "Got request to stop controller '%s' but it is not in the realtime controller list",
@@ -690,15 +682,15 @@ void ControllerManager::stop_controllers()
       continue;
     }
     auto controller = found_it->c;
-    if (is_controller_running(*controller)) {
+    if (is_controller_running(*controller))
+    {
       const auto new_state = controller->deactivate();
       controller->release_interfaces();
-      if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+      {
         RCLCPP_ERROR(
-          get_logger(),
-          "After deactivating, controller '%s' is in state '%s', expected Inactive",
-          request.c_str(),
-          new_state.label().c_str());
+          get_logger(), "After deactivating, controller '%s' is in state '%s', expected Inactive",
+          request.c_str(), new_state.label().c_str());
       }
     }
   }
@@ -708,11 +700,13 @@ void ControllerManager::start_controllers()
 {
   std::vector<ControllerSpec> & rt_controller_list =
     rt_controllers_wrapper_.update_and_get_used_by_rt_list();
-  for (const auto & request : start_request_) {
+  for (const auto & request : start_request_)
+  {
     auto found_it = std::find_if(
       rt_controller_list.begin(), rt_controller_list.end(),
       std::bind(controller_name_compare, std::placeholders::_1, request));
-    if (found_it == rt_controller_list.end()) {
+    if (found_it == rt_controller_list.end())
+    {
       RCLCPP_ERROR(
         get_logger(),
         "Got request to start controller '%s' but it is not in the realtime controller list",
@@ -726,18 +720,22 @@ void ControllerManager::start_controllers()
     auto command_interface_config = controller->command_interface_configuration();
     // default to controller_interface::configuration_type::NONE
     std::vector<std::string> command_interface_names = {};
-    if (command_interface_config.type == controller_interface::interface_configuration_type::ALL) {
+    if (command_interface_config.type == controller_interface::interface_configuration_type::ALL)
+    {
       command_interface_names = resource_manager_->command_interface_keys();
     }
-    if (command_interface_config.type ==
+    if (
+      command_interface_config.type ==
       controller_interface::interface_configuration_type::INDIVIDUAL)
     {
       command_interface_names = command_interface_config.names;
     }
     std::vector<hardware_interface::LoanedCommandInterface> command_loans;
     command_loans.reserve(command_interface_names.size());
-    for (const auto & command_interface : command_interface_names) {
-      if (resource_manager_->command_interface_is_claimed(command_interface)) {
+    for (const auto & command_interface : command_interface_names)
+    {
+      if (resource_manager_->command_interface_is_claimed(command_interface))
+      {
         RCLCPP_ERROR(
           get_logger(),
           "Resource conflict for controller '%s'. Command interface '%s' is already claimed.",
@@ -745,19 +743,20 @@ void ControllerManager::start_controllers()
         assignment_successful = false;
         break;
       }
-      try {
+      try
+      {
         command_loans.emplace_back(resource_manager_->claim_command_interface(command_interface));
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Can't activate controller '%s': %s",
-          request.c_str(), e.what());
+      }
+      catch (const std::exception & e)
+      {
+        RCLCPP_ERROR(get_logger(), "Can't activate controller '%s': %s", request.c_str(), e.what());
         assignment_successful = false;
         break;
       }
     }
     // something went wrong during command interfaces, go skip the controller
-    if (!assignment_successful) {
+    if (!assignment_successful)
+    {
       continue;
     }
 
@@ -765,41 +764,43 @@ void ControllerManager::start_controllers()
     auto state_interface_config = controller->state_interface_configuration();
     // default to controller_interface::configuration_type::NONE
     std::vector<std::string> state_interface_names = {};
-    if (state_interface_config.type == controller_interface::interface_configuration_type::ALL) {
+    if (state_interface_config.type == controller_interface::interface_configuration_type::ALL)
+    {
       state_interface_names = resource_manager_->state_interface_keys();
     }
-    if (state_interface_config.type ==
-      controller_interface::interface_configuration_type::INDIVIDUAL)
+    if (
+      state_interface_config.type == controller_interface::interface_configuration_type::INDIVIDUAL)
     {
       state_interface_names = state_interface_config.names;
     }
     std::vector<hardware_interface::LoanedStateInterface> state_loans;
     state_loans.reserve(state_interface_names.size());
-    for (const auto & state_interface : state_interface_names) {
-      try {
+    for (const auto & state_interface : state_interface_names)
+    {
+      try
+      {
         state_loans.emplace_back(resource_manager_->claim_state_interface(state_interface));
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(
-          get_logger(),
-          "Can't activate controller '%s': %s",
-          request.c_str(), e.what());
+      }
+      catch (const std::exception & e)
+      {
+        RCLCPP_ERROR(get_logger(), "Can't activate controller '%s': %s", request.c_str(), e.what());
         assignment_successful = false;
         break;
       }
     }
     // something went wrong during state interfaces, go skip the controller
-    if (!assignment_successful) {
+    if (!assignment_successful)
+    {
       continue;
     }
     controller->assign_interfaces(std::move(command_loans), std::move(state_loans));
 
     const auto new_state = controller->activate();
-    if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    {
       RCLCPP_ERROR(
-        get_logger(),
-        "After activating, controller '%s' is in state '%s', expected Active",
-        controller->get_node()->get_name(),
-        new_state.label().c_str());
+        get_logger(), "After activating, controller '%s' is in state '%s', expected Active",
+        controller->get_node()->get_name(), new_state.label().c_str());
     }
   }
   // All controllers started, switching done
@@ -823,11 +824,11 @@ void ControllerManager::list_controllers_srv_cb(
 
   // lock controllers
   std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
-  const std::vector<ControllerSpec> & controllers =
-    rt_controllers_wrapper_.get_updated_list(guard);
+  const std::vector<ControllerSpec> & controllers = rt_controllers_wrapper_.get_updated_list(guard);
   response->controller.resize(controllers.size());
 
-  for (size_t i = 0; i < controllers.size(); ++i) {
+  for (size_t i = 0; i < controllers.size(); ++i)
+  {
     controller_manager_msgs::msg::ControllerState & cs = response->controller[i];
     cs.name = controllers[i].info.name;
     cs.type = controllers[i].info.type;
@@ -848,7 +849,8 @@ void ControllerManager::list_controller_types_srv_cb(
   RCLCPP_DEBUG(get_logger(), "list types service locked");
 
   auto cur_types = loader_->getDeclaredClasses();
-  for (const auto & cur_type : cur_types) {
+  for (const auto & cur_type : cur_types)
+  {
     response->types.push_back(cur_type);
     response->base_classes.push_back(kControllerInterface);
     RCLCPP_DEBUG(get_logger(), "%s", cur_type.c_str());
@@ -862,14 +864,16 @@ void ControllerManager::list_hardware_interfaces_srv_cb(
   std::shared_ptr<controller_manager_msgs::srv::ListHardwareInterfaces::Response> response)
 {
   auto state_interface_names = resource_manager_->state_interface_keys();
-  for (const auto & state_interface_name : state_interface_names) {
+  for (const auto & state_interface_name : state_interface_names)
+  {
     controller_manager_msgs::msg::HardwareInterface hwi;
     hwi.name = state_interface_name;
     hwi.is_claimed = false;
     response->state_interfaces.push_back(hwi);
   }
   auto command_interface_names = resource_manager_->command_interface_keys();
-  for (const auto & command_interface_name : command_interface_names) {
+  for (const auto & command_interface_name : command_interface_names)
+  {
     controller_manager_msgs::msg::HardwareInterface hwi;
     hwi.name = command_interface_name;
     hwi.is_claimed = resource_manager_->command_interface_is_claimed(command_interface_name);
@@ -902,8 +906,7 @@ void ControllerManager::configure_controller_service_cb(
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "configuring service locked");
 
-  response->ok =
-    configure_controller(request->name) == controller_interface::return_type::OK;
+  response->ok = configure_controller(request->name) == controller_interface::return_type::OK;
 
   RCLCPP_DEBUG(
     get_logger(), "configuring service finished for controller '%s' ", request->name.c_str());
@@ -915,22 +918,20 @@ void ControllerManager::load_and_configure_controller_service_cb(
 {
   // lock services
   RCLCPP_DEBUG(
-    get_logger(),
-    "loading and configure service called for controller '%s' ",
+    get_logger(), "loading and configure service called for controller '%s' ",
     request->name.c_str());
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "loading and configure service locked");
 
   response->ok = load_controller(request->name).get();
 
-  if (response->ok) {
-    response->ok =
-      configure_controller(request->name) == controller_interface::return_type::OK;
+  if (response->ok)
+  {
+    response->ok = configure_controller(request->name) == controller_interface::return_type::OK;
   }
 
   RCLCPP_DEBUG(
-    get_logger(),
-    "loading and configure service finished for controller '%s' ",
+    get_logger(), "loading and configure service finished for controller '%s' ",
     request->name.c_str());
 }
 
@@ -940,32 +941,30 @@ void ControllerManager::load_and_start_controller_service_cb(
 {
   // lock services
   RCLCPP_DEBUG(
-    get_logger(),
-    "loading and starting service called for controller '%s' ",
+    get_logger(), "loading and starting service called for controller '%s' ",
     request->name.c_str());
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "loading and starting service locked");
 
   response->ok = load_controller(request->name).get();
 
-  if (response->ok) {
-    response->ok =
-      configure_controller(request->name) == controller_interface::return_type::OK;
+  if (response->ok)
+  {
+    response->ok = configure_controller(request->name) == controller_interface::return_type::OK;
   }
 
-  if (response->ok) {
+  if (response->ok)
+  {
     std::vector<std::string> start_controller = {request->name};
     std::vector<std::string> empty;
-    response->ok =
-      switch_controller(
-      start_controller, empty,
-      controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT) ==
-      controller_interface::return_type::OK;
+    response->ok = switch_controller(
+                     start_controller, empty,
+                     controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT) ==
+                   controller_interface::return_type::OK;
   }
 
   RCLCPP_DEBUG(
-    get_logger(),
-    "loading and starting service finished for controller '%s' ",
+    get_logger(), "loading and starting service finished for controller '%s' ",
     request->name.c_str());
 }
 
@@ -975,28 +974,25 @@ void ControllerManager::configure_and_start_controller_service_cb(
 {
   // lock services
   RCLCPP_DEBUG(
-    get_logger(),
-    "configuring and starting service called for controller '%s' ",
+    get_logger(), "configuring and starting service called for controller '%s' ",
     request->name.c_str());
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "configuring and starting service locked");
 
-  response->ok =
-    configure_controller(request->name) == controller_interface::return_type::OK;
+  response->ok = configure_controller(request->name) == controller_interface::return_type::OK;
 
-  if (response->ok) {
+  if (response->ok)
+  {
     std::vector<std::string> start_controller = {request->name};
     std::vector<std::string> empty;
-    response->ok =
-      switch_controller(
-      start_controller, empty,
-      controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT) ==
-      controller_interface::return_type::OK;
+    response->ok = switch_controller(
+                     start_controller, empty,
+                     controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT) ==
+                   controller_interface::return_type::OK;
   }
 
   RCLCPP_DEBUG(
-    get_logger(),
-    "configuring and starting service finished for controller '%s' ",
+    get_logger(), "configuring and starting service finished for controller '%s' ",
     request->name.c_str());
 }
 
@@ -1015,15 +1011,19 @@ void ControllerManager::reload_controller_libraries_service_cb(
   {
     // lock controllers
     std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
-    for (const auto & controller : rt_controllers_wrapper_.get_updated_list(guard)) {
-      if (is_controller_running(*controller.c)) {
+    for (const auto & controller : rt_controllers_wrapper_.get_updated_list(guard))
+    {
+      if (is_controller_running(*controller.c))
+      {
         running_controllers.push_back(controller.info.name);
       }
     }
   }
-  if (!running_controllers.empty() && !request->force_kill) {
+  if (!running_controllers.empty() && !request->force_kill)
+  {
     RCLCPP_ERROR(
-      get_logger(), "Controller manager: Cannot reload controller libraries because"
+      get_logger(),
+      "Controller manager: Cannot reload controller libraries because"
       " there are still %i controllers running",
       (int)running_controllers.size());
     response->ok = false;
@@ -1031,10 +1031,12 @@ void ControllerManager::reload_controller_libraries_service_cb(
   }
 
   // stop running controllers if requested
-  if (!loaded_controllers.empty()) {
+  if (!loaded_controllers.empty())
+  {
     RCLCPP_INFO(get_logger(), "Controller manager: Stopping all running controllers");
     std::vector<std::string> empty;
-    if (switch_controller(
+    if (
+      switch_controller(
         empty, running_controllers,
         controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT) !=
       controller_interface::return_type::OK)
@@ -1046,10 +1048,13 @@ void ControllerManager::reload_controller_libraries_service_cb(
       response->ok = false;
       return;
     }
-    for (const auto & controller : loaded_controllers) {
-      if (unload_controller(controller) != controller_interface::return_type::OK) {
+    for (const auto & controller : loaded_controllers)
+    {
+      if (unload_controller(controller) != controller_interface::return_type::OK)
+      {
         RCLCPP_ERROR(
-          get_logger(), "Controller manager: Cannot reload controller libraries because "
+          get_logger(),
+          "Controller manager: Cannot reload controller libraries because "
           "failed to unload controller '%s'",
           controller.c_str());
         response->ok = false;
@@ -1082,8 +1087,8 @@ void ControllerManager::switch_controller_service_cb(
   RCLCPP_DEBUG(get_logger(), "switching service locked");
 
   response->ok = switch_controller(
-    request->start_controllers, request->stop_controllers, request->strictness,
-    request->start_asap, request->timeout) == controller_interface::return_type::OK;
+                   request->start_controllers, request->stop_controllers, request->strictness,
+                   request->start_asap, request->timeout) == controller_interface::return_type::OK;
 
   RCLCPP_DEBUG(get_logger(), "switching service finished");
 }
@@ -1094,16 +1099,14 @@ void ControllerManager::unload_controller_service_cb(
 {
   // lock services
   RCLCPP_DEBUG(
-    get_logger(), "unloading service called for controller '%s' ",
-    request->name.c_str());
+    get_logger(), "unloading service called for controller '%s' ", request->name.c_str());
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "unloading service locked");
 
   response->ok = unload_controller(request->name) == controller_interface::return_type::OK;
 
   RCLCPP_DEBUG(
-    get_logger(), "unloading service finished for controller '%s' ",
-    request->name.c_str());
+    get_logger(), "unloading service finished for controller '%s' ", request->name.c_str());
 }
 
 std::vector<std::string> ControllerManager::get_controller_names()
@@ -1112,16 +1115,14 @@ std::vector<std::string> ControllerManager::get_controller_names()
 
   // lock controllers
   std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
-  for (const auto & controller : rt_controllers_wrapper_.get_updated_list(guard)) {
+  for (const auto & controller : rt_controllers_wrapper_.get_updated_list(guard))
+  {
     names.push_back(controller.info.name);
   }
   return names;
 }
 
-void ControllerManager::read()
-{
-  resource_manager_->read();
-}
+void ControllerManager::read() { resource_manager_->read(); }
 
 controller_interface::return_type ControllerManager::update()
 {
@@ -1129,29 +1130,30 @@ controller_interface::return_type ControllerManager::update()
     rt_controllers_wrapper_.update_and_get_used_by_rt_list();
 
   auto ret = controller_interface::return_type::OK;
-  for (auto loaded_controller : rt_controller_list) {
+  for (auto loaded_controller : rt_controller_list)
+  {
     // TODO(v-lopez) we could cache this information
     // https://github.com/ros-controls/ros2_control/issues/153
-    if (is_controller_running(*loaded_controller.c)) {
+    if (is_controller_running(*loaded_controller.c))
+    {
       auto controller_ret = loaded_controller.c->update();
-      if (controller_ret != controller_interface::return_type::OK) {
+      if (controller_ret != controller_interface::return_type::OK)
+      {
         ret = controller_ret;
       }
     }
   }
 
   // there are controllers to start/stop
-  if (switch_params_.do_switch) {
+  if (switch_params_.do_switch)
+  {
     manage_switch();
   }
 
   return ret;
 }
 
-void ControllerManager::write()
-{
-  resource_manager_->write();
-}
+void ControllerManager::write() { resource_manager_->write(); }
 
 std::vector<ControllerSpec> &
 ControllerManager::RTControllerListWrapper::update_and_get_used_by_rt_list()
@@ -1163,7 +1165,8 @@ ControllerManager::RTControllerListWrapper::update_and_get_used_by_rt_list()
 std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::get_unused_list(
   const std::lock_guard<std::recursive_mutex> &)
 {
-  if (!controllers_lock_.try_lock()) {
+  if (!controllers_lock_.try_lock())
+  {
     throw std::runtime_error("controllers_lock_ not owned by thread");
   }
   controllers_lock_.unlock();
@@ -1178,7 +1181,8 @@ std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::get_un
 const std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::get_updated_list(
   const std::lock_guard<std::recursive_mutex> &) const
 {
-  if (!controllers_lock_.try_lock()) {
+  if (!controllers_lock_.try_lock())
+  {
     throw std::runtime_error("controllers_lock_ not owned by thread");
   }
   controllers_lock_.unlock();
@@ -1188,7 +1192,8 @@ const std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::
 void ControllerManager::RTControllerListWrapper::switch_updated_list(
   const std::lock_guard<std::recursive_mutex> &)
 {
-  if (!controllers_lock_.try_lock()) {
+  if (!controllers_lock_.try_lock())
+  {
     throw std::runtime_error("controllers_lock_ not owned by thread");
   }
   controllers_lock_.unlock();
@@ -1205,8 +1210,10 @@ int ControllerManager::RTControllerListWrapper::get_other_list(int index) const
 void ControllerManager::RTControllerListWrapper::wait_until_rt_not_using(
   int index, std::chrono::microseconds sleep_period) const
 {
-  while (used_by_realtime_controllers_index_ == index) {
-    if (!rclcpp::ok()) {
+  while (used_by_realtime_controllers_index_ == index)
+  {
+    if (!rclcpp::ok())
+    {
       throw std::runtime_error("rclcpp interrupted");
     }
     std::this_thread::sleep_for(sleep_period);

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -33,35 +33,34 @@ int main(int argc, char ** argv)
     std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   std::string manager_node_name = "controller_manager";
 
-  auto cm = std::make_shared<controller_manager::ControllerManager>(
-    executor,
-    manager_node_name);
+  auto cm = std::make_shared<controller_manager::ControllerManager>(executor, manager_node_name);
 
   // TODO(anyone): Due to issues with the MutliThreadedExecutor, this control loop does not rely on
   // the executor (see issue #260).
   // When the MutliThreadedExecutor issues are fixed (ros2/rclcpp#1168), this loop should be
   // converted back to a timer.
   std::thread cm_thread([cm]() {
-      // load controller_manager update time parameter
-      int update_rate = DEFAULT_UPDATE_RATE;
-      if (!cm->get_parameter("update_rate", update_rate)) {
-        RCLCPP_WARN(cm->get_logger(), "'update_rate' parameter not set, using default value.");
-      }
-      RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);
+    // load controller_manager update time parameter
+    int update_rate = DEFAULT_UPDATE_RATE;
+    if (!cm->get_parameter("update_rate", update_rate))
+    {
+      RCLCPP_WARN(cm->get_logger(), "'update_rate' parameter not set, using default value.");
+    }
+    RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", update_rate);
 
-      while (rclcpp::ok()) {
-        std::chrono::system_clock::time_point begin = std::chrono::system_clock::now();
-        cm->read();
-        cm->update();
-        cm->write();
-        std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-        std::this_thread::sleep_for(
-          std::max(
-            std::chrono::nanoseconds(0),
-            std::chrono::nanoseconds(1000000000 / update_rate) -
-            std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)));
-      }
-    });
+    while (rclcpp::ok())
+    {
+      std::chrono::system_clock::time_point begin = std::chrono::system_clock::now();
+      cm->read();
+      cm->update();
+      cm->write();
+      std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
+      std::this_thread::sleep_for(std::max(
+        std::chrono::nanoseconds(0),
+        std::chrono::nanoseconds(1000000000 / update_rate) -
+          std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin)));
+    }
+  });
 
   executor->add_node(cm);
   executor->spin();

--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -41,47 +41,38 @@ constexpr auto BEST_EFFORT = controller_manager_msgs::srv::SwitchController::Req
 class ControllerManagerFixture : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
-  {
-    rclcpp::init(0, nullptr);
-  }
+  static void SetUpTestCase() { rclcpp::init(0, nullptr); }
 
-  static void TearDownTestCase()
-  {
-    rclcpp::shutdown();
-  }
+  static void TearDownTestCase() { rclcpp::shutdown(); }
 
   void SetUp()
   {
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     cm_ = std::make_shared<controller_manager::ControllerManager>(
       std::make_unique<hardware_interface::ResourceManager>(
-        ros2_control_test_assets::
-        minimal_robot_urdf),
+        ros2_control_test_assets::minimal_robot_urdf),
       executor_, "test_controller_manager");
     run_updater_ = false;
   }
 
-  void TearDown()
-  {
-    stopCmUpdater();
-  }
+  void TearDown() { stopCmUpdater(); }
 
   void startCmUpdater()
   {
     run_updater_ = true;
-    updater_ = std::thread(
-      [&](void) -> void {
-        while (run_updater_) {
-          cm_->update();
-          std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
-      });
+    updater_ = std::thread([&](void) -> void {
+      while (run_updater_)
+      {
+        cm_->update();
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+    });
   }
 
   void stopCmUpdater()
   {
-    if (run_updater_) {
+    if (run_updater_)
+    {
       run_updater_ = false;
       updater_.join();
     }
@@ -97,16 +88,12 @@ public:
 class ControllerManagerRunner
 {
 public:
-  explicit ControllerManagerRunner(ControllerManagerFixture * cmf)
-  : cmf_(cmf)
+  explicit ControllerManagerRunner(ControllerManagerFixture * cmf) : cmf_(cmf)
   {
     cmf_->startCmUpdater();
   }
 
-  ~ControllerManagerRunner()
-  {
-    cmf_->stopCmUpdater();
-  }
+  ~ControllerManagerRunner() { cmf_->stopCmUpdater(); }
 
   ControllerManagerFixture * cmf_;
 };

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -21,14 +21,13 @@
 
 namespace test_controller
 {
-
 TestController::TestController()
 : controller_interface::ControllerInterface(),
   cmd_iface_cfg_{controller_interface::interface_configuration_type::NONE}
-{}
+{
+}
 
-controller_interface::return_type
-TestController::update()
+controller_interface::return_type TestController::update()
 {
   ++internal_counter;
   return controller_interface::return_type::OK;
@@ -41,14 +40,15 @@ TestController::on_configure(const rclcpp_lifecycle::State & /*previous_state*/)
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-TestController::on_cleanup(
-  const rclcpp_lifecycle::State & /*previous_state*/)
+TestController::on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  if (simulate_cleanup_failure) {
+  if (simulate_cleanup_failure)
+  {
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
   }
 
-  if (cleanup_calls) {
+  if (cleanup_calls)
+  {
     (*cleanup_calls)++;
   }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -18,12 +18,11 @@
 #include <memory>
 #include <string>
 
-#include "controller_manager/controller_manager.hpp"
 #include "controller_interface/visibility_control.h"
+#include "controller_manager/controller_manager.hpp"
 
 namespace test_controller
 {
-
 // indicating the node name under which the controller node
 // is being loaded.
 constexpr char TEST_CONTROLLER_NAME[] = "test_controller_name";
@@ -36,8 +35,7 @@ public:
   TestController();
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual
-  ~TestController() = default;
+  virtual ~TestController() = default;
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
@@ -51,16 +49,15 @@ public:
   }
 
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::return_type
-  update() override;
+  controller_interface::return_type update() override;
 
   CONTROLLER_MANAGER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State & previous_state) override;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
   void set_command_interface_configuration(

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
@@ -21,19 +21,17 @@
 
 namespace test_controller_failed_init
 {
+TestControllerFailedInit::TestControllerFailedInit() : controller_interface::ControllerInterface()
+{
+}
 
-TestControllerFailedInit::TestControllerFailedInit()
-: controller_interface::ControllerInterface()
-{}
-
-controller_interface::return_type
-TestControllerFailedInit::init(const std::string & /* controller_name */)
+controller_interface::return_type TestControllerFailedInit::init(
+  const std::string & /* controller_name */)
 {
   return controller_interface::return_type::ERROR;
 }
 
-controller_interface::return_type
-TestControllerFailedInit::update()
+controller_interface::return_type TestControllerFailedInit::update()
 {
   return controller_interface::return_type::OK;
 }
@@ -43,5 +41,4 @@ TestControllerFailedInit::update()
 #include "pluginlib/class_list_macros.hpp"
 
 PLUGINLIB_EXPORT_CLASS(
-  test_controller_failed_init::TestControllerFailedInit,
-  controller_interface::ControllerInterface)
+  test_controller_failed_init::TestControllerFailedInit, controller_interface::ControllerInterface)

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
@@ -18,12 +18,11 @@
 #include <memory>
 #include <string>
 
-#include "controller_manager/controller_manager.hpp"
 #include "controller_interface/visibility_control.h"
+#include "controller_manager/controller_manager.hpp"
 
 namespace test_controller_failed_init
 {
-
 // indicating the node name under which the controller node
 // is being loaded.
 constexpr char TEST_CONTROLLER_NAME[] = "test_controller_failed_init_name";
@@ -37,12 +36,10 @@ public:
   TestControllerFailedInit();
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual
-  ~TestControllerFailedInit() = default;
+  virtual ~TestControllerFailedInit() = default;
 
   CONTROLLER_INTERFACE_PUBLIC
-  controller_interface::return_type
-  init(const std::string & controller_name) override;
+  controller_interface::return_type init(const std::string & controller_name) override;
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
@@ -57,8 +54,7 @@ public:
   }
 
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::return_type
-  update() override;
+  controller_interface::return_type update() override;
 };
 
 }  // namespace test_controller_failed_init

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -17,19 +17,21 @@
 #include <string>
 #include <vector>
 
+#include "./test_controller/test_controller.hpp"
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_test_common.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
-#include "./test_controller/test_controller.hpp"
 
 using ::testing::_;
 using ::testing::Return;
 
 class TestControllerManager : public ControllerManagerFixture
-{};
+{
+};
 
-TEST_F(TestControllerManager, controller_lifecycle) {
+TEST_F(TestControllerManager, controller_lifecycle)
+{
   auto test_controller = std::make_shared<test_controller::TestController>();
   cm_->add_controller(
     test_controller, test_controller::TEST_CONTROLLER_NAME,
@@ -38,10 +40,8 @@ TEST_F(TestControllerManager, controller_lifecycle) {
   EXPECT_EQ(2, test_controller.use_count());
 
   EXPECT_EQ(controller_interface::return_type::OK, cm_->update());
-  EXPECT_EQ(
-    0u,
-    test_controller->internal_counter) <<
-    "Update should not reach an unconfigured controller";
+  EXPECT_EQ(0u, test_controller->internal_counter)
+    << "Update should not reach an unconfigured controller";
 
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
@@ -53,35 +53,26 @@ TEST_F(TestControllerManager, controller_lifecycle) {
   EXPECT_EQ(0u, test_controller->internal_counter) << "Controller is not started";
 
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_current_state().id());
 
   // Start controller, will take effect at the end of the update function
   std::vector<std::string> start_controllers = {test_controller::TEST_CONTROLLER_NAME};
   std::vector<std::string> stop_controllers = {};
   auto switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    start_controllers, stop_controllers,
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+    start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
 
   EXPECT_EQ(controller_interface::return_type::OK, cm_->update());
   EXPECT_EQ(0u, test_controller->internal_counter) << "Controller is started at the end of update";
   {
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
   }
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_current_state().id());
 
   EXPECT_EQ(controller_interface::return_type::OK, cm_->update());
   EXPECT_GE(test_controller->internal_counter, 1u);
@@ -91,46 +82,30 @@ TEST_F(TestControllerManager, controller_lifecycle) {
   start_controllers = {};
   stop_controllers = {test_controller::TEST_CONTROLLER_NAME};
   switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    start_controllers, stop_controllers,
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+    start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
 
   EXPECT_EQ(controller_interface::return_type::OK, cm_->update());
-  EXPECT_EQ(
-    last_internal_counter + 1u,
-    test_controller->internal_counter) <<
-    "Controller is stopped at the end of update, so it should have done one more update";
+  EXPECT_EQ(last_internal_counter + 1u, test_controller->internal_counter)
+    << "Controller is stopped at the end of update, so it should have done one more update";
   {
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
   }
 
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_current_state().id());
   auto unload_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::unload_controller, cm_,
+    std::launch::async, &controller_manager::ControllerManager::unload_controller, cm_,
     test_controller::TEST_CONTROLLER_NAME);
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    unload_future.wait_for(std::chrono::milliseconds(100))) <<
-    "unload_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, unload_future.wait_for(std::chrono::milliseconds(100)))
+    << "unload_controller should be blocking until next update cycle";
   ControllerManagerRunner cm_runner(this);
-  EXPECT_EQ(
-    controller_interface::return_type::OK,
-    unload_future.get()
-  );
+  EXPECT_EQ(controller_interface::return_type::OK, unload_future.get());
 
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -18,12 +18,12 @@
 #include <string>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager/controller_manager.hpp"
-#include "controller_manager_msgs/srv/switch_controller.hpp"
 #include "controller_manager_msgs/srv/list_controller_types.hpp"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
+#include "controller_manager_msgs/srv/switch_controller.hpp"
+#include "controller_manager_test_common.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 using ::testing::_;
@@ -34,59 +34,48 @@ using namespace std::chrono_literals;
 class TestControllerManagerSrvs : public ControllerManagerFixture
 {
 public:
-  TestControllerManagerSrvs()
-  {
-  }
+  TestControllerManagerSrvs() {}
 
   void SetUp() override
   {
     ControllerManagerFixture::SetUp();
 
-    update_timer_ = cm_->create_wall_timer(
-      std::chrono::milliseconds(10), [&]() {
-        cm_->read();
-        cm_->update();
-        cm_->write();
-      }
-    );
+    update_timer_ = cm_->create_wall_timer(std::chrono::milliseconds(10), [&]() {
+      cm_->read();
+      cm_->update();
+      cm_->write();
+    });
 
     executor_->add_node(cm_);
 
-    executor_spin_future_ = std::async(
-      std::launch::async, [this]() -> void {
-        executor_->spin();
-      });
+    executor_spin_future_ = std::async(std::launch::async, [this]() -> void { executor_->spin(); });
     // This sleep is needed to prevent a too fast test from ending before the
     // executor has began to spin, which causes it to hang
     std::this_thread::sleep_for(50ms);
   }
 
-  void TearDown() override
-  {
-    executor_->cancel();
-  }
+  void TearDown() override { executor_->cancel(); }
 
-  template<typename T>
+  template <typename T>
   std::shared_ptr<typename T::Response> call_service_and_wait(
-    rclcpp::Client<T> & client,
-    std::shared_ptr<typename T::Request> request,
-    rclcpp::Executor & service_executor,
-    bool update_controller_while_spinning = false)
+    rclcpp::Client<T> & client, std::shared_ptr<typename T::Request> request,
+    rclcpp::Executor & service_executor, bool update_controller_while_spinning = false)
   {
     EXPECT_TRUE(client.wait_for_service(std::chrono::milliseconds(500)));
     auto result = client.async_send_request(request);
     // Wait for the result.
-    if (update_controller_while_spinning) {
-      while (service_executor.spin_until_future_complete(
-          result,
-          50ms) != rclcpp::FutureReturnCode::SUCCESS)
+    if (update_controller_while_spinning)
+    {
+      while (service_executor.spin_until_future_complete(result, 50ms) !=
+             rclcpp::FutureReturnCode::SUCCESS)
       {
         cm_->update();
       }
-    } else {
+    }
+    else
+    {
       EXPECT_EQ(
-        service_executor.spin_until_future_complete(result),
-        rclcpp::FutureReturnCode::SUCCESS);
+        service_executor.spin_until_future_complete(result), rclcpp::FutureReturnCode::SUCCESS);
     }
     return result.get();
   }
@@ -103,39 +92,35 @@ TEST_F(TestControllerManagerSrvs, list_controller_types)
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::ListControllerTypes>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::ListControllerTypes>(
-    "test_controller_manager/list_controller_types");
+      "test_controller_manager/list_controller_types");
   auto request = std::make_shared<controller_manager_msgs::srv::ListControllerTypes::Request>();
 
   auto result = call_service_and_wait(*client, request, srv_executor);
   // Number depends on the controllers that exist on the system
   size_t controller_types = result->types.size();
-  ASSERT_GE(
-    controller_types,
-    1u);
-  ASSERT_EQ(
-    controller_types,
-    result->base_classes.size());
+  ASSERT_GE(controller_types, 1u);
+  ASSERT_EQ(controller_types, result->base_classes.size());
   ASSERT_THAT(result->types, ::testing::Contains(test_controller::TEST_CONTROLLER_CLASS_NAME));
   ASSERT_THAT(
-    result->base_classes,
-    ::testing::Contains("controller_interface::ControllerInterface"));
+    result->base_classes, ::testing::Contains("controller_interface::ControllerInterface"));
 }
 
-TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
+TEST_F(TestControllerManagerSrvs, list_controllers_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::ListControllers>(
-    "test_controller_manager/list_controllers");
+      "test_controller_manager/list_controllers");
   auto request = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
 
   auto result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(0u, result->controller.size());
 
   auto test_controller = std::make_shared<test_controller::TestController>();
-  controller_interface::InterfaceConfiguration cfg =
-  {controller_interface::interface_configuration_type::INDIVIDUAL,
+  controller_interface::InterfaceConfiguration cfg = {
+    controller_interface::interface_configuration_type::INDIVIDUAL,
     {"joint1/position", "joint2/velocity"}};
   test_controller->set_command_interface_configuration(cfg);
   auto abstract_test_controller = cm_->add_controller(
@@ -157,8 +142,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
 
   cm_->switch_controller(
     {test_controller::TEST_CONTROLLER_NAME}, {},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
@@ -169,8 +153,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
 
   cm_->switch_controller(
     {}, {test_controller::TEST_CONTROLLER_NAME},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
@@ -181,8 +164,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
   test_controller->set_command_interface_configuration(cfg);
   cm_->switch_controller(
     {test_controller::TEST_CONTROLLER_NAME}, {},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
@@ -193,8 +175,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
 
   cm_->switch_controller(
     {}, {test_controller::TEST_CONTROLLER_NAME},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
@@ -208,13 +189,14 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv) {
   ASSERT_EQ(0u, result->controller.size());
 }
 
-TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
+TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::ReloadControllerLibraries>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::ReloadControllerLibraries>(
-    "test_controller_manager/reload_controller_libraries");
+      "test_controller_manager/reload_controller_libraries");
   auto request =
     std::make_shared<controller_manager_msgs::srv::ReloadControllerLibraries::Request>();
 
@@ -225,10 +207,8 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
 
   // Add a controller, but unconfigured
   std::shared_ptr<test_controller::TestController> test_controller =
-    std::dynamic_pointer_cast<test_controller::TestController>(
-    cm_->load_controller(
-      test_controller::TEST_CONTROLLER_NAME,
-      test_controller::TEST_CONTROLLER_CLASS_NAME));
+    std::dynamic_pointer_cast<test_controller::TestController>(cm_->load_controller(
+      test_controller::TEST_CONTROLLER_NAME, test_controller::TEST_CONTROLLER_CLASS_NAME));
 
   // weak_ptr so the only controller shared_ptr instance is owned by the controller_manager and
   // can be completely destroyed before reloading the library
@@ -237,9 +217,8 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     test_controller->get_current_state().id());
-  ASSERT_GT(
-    test_controller.use_count(),
-    1) << "Controller manager should have have a copy of this shared ptr";
+  ASSERT_GT(test_controller.use_count(), 1)
+    << "Controller manager should have have a copy of this shared ptr";
 
   size_t cleanup_calls = 0;
   test_controller->cleanup_calls = &cleanup_calls;
@@ -249,26 +228,20 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   result = call_service_and_wait(*client, request, srv_executor, true);
   ASSERT_TRUE(result->ok);
   ASSERT_EQ(cleanup_calls, 1u);
-  ASSERT_EQ(
-    test_controller.use_count(),
-    0) << "No more references to the controller after reloading.";
+  ASSERT_EQ(test_controller.use_count(), 0)
+    << "No more references to the controller after reloading.";
   test_controller.reset();
 
   // Add a controller, but inactive
-  test_controller =
-    std::dynamic_pointer_cast<test_controller::TestController>(
-    cm_->load_controller(
-      test_controller::TEST_CONTROLLER_NAME,
-      test_controller::TEST_CONTROLLER_CLASS_NAME));
+  test_controller = std::dynamic_pointer_cast<test_controller::TestController>(cm_->load_controller(
+    test_controller::TEST_CONTROLLER_NAME, test_controller::TEST_CONTROLLER_CLASS_NAME));
   test_controller_weak = test_controller;
   cm_->configure_controller(test_controller::TEST_CONTROLLER_NAME);
 
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    test_controller->get_current_state().id());
-  ASSERT_GT(
-    test_controller.use_count(),
-    1) << "Controller manager should have have a copy of this shared ptr";
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_current_state().id());
+  ASSERT_GT(test_controller.use_count(), 1)
+    << "Controller manager should have have a copy of this shared ptr";
 
   cleanup_calls = 0;
   test_controller->cleanup_calls = &cleanup_calls;
@@ -278,39 +251,30 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   result = call_service_and_wait(*client, request, srv_executor, true);
   ASSERT_TRUE(result->ok);
   ASSERT_EQ(cleanup_calls, 1u);
-  ASSERT_EQ(
-    test_controller.use_count(),
-    0) << "No more references to the controller after reloading.";
+  ASSERT_EQ(test_controller.use_count(), 0)
+    << "No more references to the controller after reloading.";
   test_controller.reset();
 
-  test_controller =
-    std::dynamic_pointer_cast<test_controller::TestController>(
-    cm_->load_controller(
-      test_controller::TEST_CONTROLLER_NAME,
-      test_controller::TEST_CONTROLLER_CLASS_NAME));
+  test_controller = std::dynamic_pointer_cast<test_controller::TestController>(cm_->load_controller(
+    test_controller::TEST_CONTROLLER_NAME, test_controller::TEST_CONTROLLER_CLASS_NAME));
   test_controller_weak = test_controller;
   cm_->configure_controller(test_controller::TEST_CONTROLLER_NAME);
   // Start Controller
   cm_->switch_controller(
     {test_controller::TEST_CONTROLLER_NAME}, {},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_current_state().id());
 
   // Failed reload due to active controller
   request->force_kill = false;
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Cannot reload if controllers are running";
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller->get_current_state().id());
-  ASSERT_GT(
-    test_controller.use_count(),
-    1) <<
-    "Controller manager should still have have a copy of "
-    "this shared ptr, no unloading was performed";
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_current_state().id());
+  ASSERT_GT(test_controller.use_count(), 1)
+    << "Controller manager should still have have a copy of "
+       "this shared ptr, no unloading was performed";
 
   cleanup_calls = 0;
   test_controller->cleanup_calls = &cleanup_calls;
@@ -321,20 +285,20 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv) {
   result = call_service_and_wait(*client, request, srv_executor, true);
   ASSERT_TRUE(result->ok);
 
-  ASSERT_EQ(
-    test_controller_weak.use_count(),
-    0) << "No more references to the controller after reloading.";
-  ASSERT_EQ(cleanup_calls, 1u) <<
-    "Controller should have been stopped and cleaned up with force_kill = true";
+  ASSERT_EQ(test_controller_weak.use_count(), 0)
+    << "No more references to the controller after reloading.";
+  ASSERT_EQ(cleanup_calls, 1u)
+    << "Controller should have been stopped and cleaned up with force_kill = true";
 }
 
-TEST_F(TestControllerManagerSrvs, load_controller_srv) {
+TEST_F(TestControllerManagerSrvs, load_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::LoadController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::LoadController>(
-    "test_controller_manager/load_controller");
+      "test_controller_manager/load_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::LoadController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -352,13 +316,14 @@ TEST_F(TestControllerManagerSrvs, load_controller_srv) {
     cm_->get_loaded_controllers()[0].c->get_current_state().id());
 }
 
-TEST_F(TestControllerManagerSrvs, unload_controller_srv) {
+TEST_F(TestControllerManagerSrvs, unload_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::UnloadController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::UnloadController>(
-    "test_controller_manager/unload_controller");
+      "test_controller_manager/unload_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::UnloadController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -376,13 +341,14 @@ TEST_F(TestControllerManagerSrvs, unload_controller_srv) {
   EXPECT_EQ(0u, cm_->get_loaded_controllers().size());
 }
 
-TEST_F(TestControllerManagerSrvs, configure_controller_srv) {
+TEST_F(TestControllerManagerSrvs, configure_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::ConfigureController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::ConfigureController>(
-    "test_controller_manager/configure_controller");
+      "test_controller_manager/configure_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::ConfigureController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -403,13 +369,14 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv) {
     cm_->get_loaded_controllers()[0].c->get_current_state().id());
 }
 
-TEST_F(TestControllerManagerSrvs, load_configure_controller_srv) {
+TEST_F(TestControllerManagerSrvs, load_configure_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::LoadConfigureController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::LoadConfigureController>(
-    "test_controller_manager/load_and_configure_controller");
+      "test_controller_manager/load_and_configure_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::LoadConfigureController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -428,13 +395,14 @@ TEST_F(TestControllerManagerSrvs, load_configure_controller_srv) {
     cm_->get_loaded_controllers()[0].c->get_current_state().id());
 }
 
-TEST_F(TestControllerManagerSrvs, load_start_controller_srv) {
+TEST_F(TestControllerManagerSrvs, load_start_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::LoadStartController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::LoadStartController>(
-    "test_controller_manager/load_and_start_controller");
+      "test_controller_manager/load_and_start_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::LoadStartController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -453,13 +421,14 @@ TEST_F(TestControllerManagerSrvs, load_start_controller_srv) {
     cm_->get_loaded_controllers()[0].c->get_current_state().id());
 }
 
-TEST_F(TestControllerManagerSrvs, configure_start_controller_srv) {
+TEST_F(TestControllerManagerSrvs, configure_start_controller_srv)
+{
   rclcpp::executors::SingleThreadedExecutor srv_executor;
   rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
   srv_executor.add_node(srv_node);
   rclcpp::Client<controller_manager_msgs::srv::ConfigureStartController>::SharedPtr client =
     srv_node->create_client<controller_manager_msgs::srv::ConfigureStartController>(
-    "test_controller_manager/configure_and_start_controller");
+      "test_controller_manager/configure_and_start_controller");
 
   auto request =
     std::make_shared<controller_manager_msgs::srv::ConfigureStartController::Request>();

--- a/controller_manager/test/test_controller_with_interfaces/test_controller_with_interfaces.cpp
+++ b/controller_manager/test/test_controller_with_interfaces/test_controller_with_interfaces.cpp
@@ -21,13 +21,12 @@
 
 namespace test_controller_with_interfaces
 {
-
 TestControllerWithInterfaces::TestControllerWithInterfaces()
 : controller_interface::ControllerInterface()
-{}
+{
+}
 
-controller_interface::return_type
-TestControllerWithInterfaces::update()
+controller_interface::return_type TestControllerWithInterfaces::update()
 {
   return controller_interface::return_type::OK;
 }
@@ -39,8 +38,7 @@ TestControllerWithInterfaces::on_configure(const rclcpp_lifecycle::State & /*pre
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-TestControllerWithInterfaces::on_cleanup(
-  const rclcpp_lifecycle::State & /*previous_state*/)
+TestControllerWithInterfaces::on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }

--- a/controller_manager/test/test_controller_with_interfaces/test_controller_with_interfaces.hpp
+++ b/controller_manager/test/test_controller_with_interfaces/test_controller_with_interfaces.hpp
@@ -18,12 +18,11 @@
 #include <memory>
 #include <string>
 
-#include "controller_manager/controller_manager.hpp"
 #include "controller_interface/visibility_control.h"
+#include "controller_manager/controller_manager.hpp"
 
 namespace test_controller_with_interfaces
 {
-
 // Corresponds to the name listed within the pluginglib xml
 constexpr char TEST_CONTROLLER_WITH_INTERFACES_CLASS_NAME[] =
   "controller_manager/test_controller_with_interfaces";
@@ -36,8 +35,7 @@ public:
   TestControllerWithInterfaces();
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual
-  ~TestControllerWithInterfaces() = default;
+  virtual ~TestControllerWithInterfaces() = default;
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
@@ -53,16 +51,15 @@ public:
   }
 
   CONTROLLER_MANAGER_PUBLIC
-  controller_interface::return_type
-  update() override;
+  controller_interface::return_type update() override;
 
   CONTROLLER_MANAGER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State & previous_state) override;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State & previous_state) override;
 };
 
 }  // namespace test_controller_with_interfaces

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -19,20 +19,21 @@
 #include <tuple>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager/controller_manager.hpp"
+#include "controller_manager_test_common.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
+using test_controller::TEST_CONTROLLER_CLASS_NAME;
 using ::testing::_;
 using ::testing::Return;
-using test_controller::TEST_CONTROLLER_CLASS_NAME;
 const auto controller_name1 = "test_controller1";
 const auto controller_name2 = "test_controller2";
 using strvec = std::vector<std::string>;
 
 class TestLoadController : public ControllerManagerFixture
-{};
+{
+};
 
 TEST_F(TestLoadController, load_unknown_controller)
 {
@@ -60,8 +61,7 @@ TEST_F(TestLoadController, load_and_configure_one_known_controller)
 
   cm_->configure_controller(controller_name1);
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
 }
 
 TEST_F(TestLoadController, load_and_configure_two_known_controllers)
@@ -70,8 +70,7 @@ TEST_F(TestLoadController, load_and_configure_two_known_controllers)
   auto controller_if1 = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if1, nullptr);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
-  EXPECT_STREQ(
-    controller_name1, controller_if1->get_node()->get_name());
+  EXPECT_STREQ(controller_name1, controller_if1->get_node()->get_name());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     controller_if1->get_current_state().id());
@@ -80,8 +79,7 @@ TEST_F(TestLoadController, load_and_configure_two_known_controllers)
   auto controller_if2 = cm_->load_controller(controller_name2, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if2, nullptr);
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
-  EXPECT_STREQ(
-    controller_name2, controller_if2->get_node()->get_name());
+  EXPECT_STREQ(controller_name2, controller_if2->get_node()->get_name());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     controller_if2->get_current_state().id());
@@ -89,15 +87,12 @@ TEST_F(TestLoadController, load_and_configure_two_known_controllers)
   // Configure controllers
   cm_->configure_controller(controller_name1);
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if1->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if1->get_current_state().id());
 
   cm_->configure_controller(controller_name2);
   EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if2->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if2->get_current_state().id());
 }
-
 
 TEST_F(TestLoadController, configuring_non_loaded_controller_fails)
 {
@@ -117,8 +112,7 @@ TEST_F(TestLoadController, can_configure_loaded_controller)
 
   EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
 }
 
 TEST_F(TestLoadController, can_start_configured_controller)
@@ -126,36 +120,25 @@ TEST_F(TestLoadController, can_start_configured_controller)
   // load and start controller with name1
   auto controller_if = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if, nullptr);
-  EXPECT_EQ(
-    cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
+  EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
 
-  { //  Start controller
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting stopped controller");
+  {  //  Start controller
+    RCLCPP_INFO(cm_->get_logger(), "Starting stopped controller");
     std::vector<std::string> start_controllers = {controller_name1};
     std::vector<std::string> stop_controllers = {};
 
     // First activation not possible because controller not configured
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      controller_if->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if->get_current_state().id());
   }
 }
 
@@ -164,122 +147,85 @@ TEST_F(TestLoadController, can_not_configure_active_controller)
   // load and start controller with name1
   auto controller_if = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if, nullptr);
-  EXPECT_EQ(
-    cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
+  EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
 
   //  Start controller
   strvec start_controllers = {controller_name1};
   strvec stop_controllers = {};
   auto switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    start_controllers, stop_controllers,
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+    start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
   ControllerManagerRunner cm_runner(this);
-  EXPECT_EQ(
-    controller_interface::return_type::OK,
-    switch_future.get()
-  );
+  EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
   // Can not configure active controller
   EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::ERROR);
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if->get_current_state().id());
 }
 
 TEST_F(TestLoadController, can_stop_active_controller)
 {
   auto controller_if = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if, nullptr);
-  EXPECT_EQ(
-    cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
+  EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
   // load and start controller with name1
   {
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      strvec{controller_name1}, strvec{},
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      strvec{controller_name1}, strvec{}, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK, switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
   }
   // Stop controller
   RCLCPP_INFO(cm_->get_logger(), "Stopping started controller");
   auto switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    strvec{}, strvec{controller_name1},
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_, strvec{},
+    strvec{controller_name1}, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
   ControllerManagerRunner cm_runner(this);
   EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
 }
 
 TEST_F(TestLoadController, inactive_controller_cannot_be_cleaned_up)
 {
   auto controller_if = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if, nullptr);
-  EXPECT_EQ(
-    cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
+  EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
   // load and start controller with name1
   {
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      strvec{controller_name1}, strvec{},
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      strvec{controller_name1}, strvec{}, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
   }
   // Stop controller
   auto switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    strvec{}, strvec{controller_name1},
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_, strvec{},
+    strvec{controller_name1}, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
   ControllerManagerRunner cm_runner(this);
-  EXPECT_EQ(
-    controller_interface::return_type::OK,
-    switch_future.get()
-  );
+  EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
 
   std::shared_ptr<test_controller::TestController> test_controller =
     std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
@@ -289,8 +235,7 @@ TEST_F(TestLoadController, inactive_controller_cannot_be_cleaned_up)
   test_controller->simulate_cleanup_failure = true;
   EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::ERROR);
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
   EXPECT_EQ(0u, cleanup_calls);
 }
 
@@ -298,47 +243,31 @@ TEST_F(TestLoadController, inactive_controller_cannot_be_configured)
 {
   auto controller_if = cm_->load_controller(controller_name1, TEST_CONTROLLER_CLASS_NAME);
   ASSERT_NE(controller_if, nullptr);
-  EXPECT_EQ(
-    cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
+  EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
 
   // load and start controller with name1
   {
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      strvec{controller_name1}, strvec{},
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      strvec{controller_name1}, strvec{}, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
   }
   // Stop controller
   auto switch_future = std::async(
-    std::launch::async,
-    &controller_manager::ControllerManager::switch_controller, cm_,
-    strvec{}, strvec{controller_name1},
-    STRICT, true, rclcpp::Duration(0, 0));
+    std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_, strvec{},
+    strvec{controller_name1}, STRICT, true, rclcpp::Duration(0, 0));
 
-  ASSERT_EQ(
-    std::future_status::timeout,
-    switch_future.wait_for(std::chrono::milliseconds(100))) <<
-    "switch_controller should be blocking until next update cycle";
+  ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+    << "switch_controller should be blocking until next update cycle";
   ControllerManagerRunner cm_runner(this);
-  EXPECT_EQ(
-    controller_interface::return_type::OK,
-    switch_future.get()
-  );
+  EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
 
   std::shared_ptr<test_controller::TestController> test_controller =
     std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
@@ -348,15 +277,16 @@ TEST_F(TestLoadController, inactive_controller_cannot_be_configured)
   test_controller->simulate_cleanup_failure = false;
   EXPECT_EQ(cm_->configure_controller(controller_name1), controller_interface::return_type::OK);
   ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-    controller_if->get_current_state().id());
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
   EXPECT_EQ(1u, cleanup_calls);
 }
 
-class SwitchTest : public TestLoadController,
-  public ::testing::WithParamInterface<std::tuple<controller_interface::return_type, int,
-    strvec, strvec, std::string>>
-{};
+class SwitchTest
+: public TestLoadController,
+  public ::testing::WithParamInterface<
+    std::tuple<controller_interface::return_type, int, strvec, strvec, std::string>>
+{
+};
 
 const auto UNSPECIFIED = 0;
 const auto EMPTY_STR_VEC = strvec{};
@@ -383,48 +313,45 @@ TEST_P(SwitchTest, EmptyListOrNonExistentTest)
   auto error_message = std::get<4>(params);
 
   EXPECT_EQ(
-    result,
-    cm_->switch_controller(
-      start_controllers, stop_controllers,
-      strictness, true, rclcpp::Duration(0, 0))
-  ) << error_message;
+    result, cm_->switch_controller(
+              start_controllers, stop_controllers, strictness, true, rclcpp::Duration(0, 0)))
+    << error_message;
 }
 
 // TODO(anyone): For Galactic+, follow up on https://github.com/ros-controls/ros2_control/issues/406
 #ifdef __APPLE__
 INSTANTIATE_TEST_CASE_P(
-  EmptyListOrNonExistentTest,
-  SwitchTest,
+  EmptyListOrNonExistentTest, SwitchTest,
   ::testing::Values(
     // empty lists
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC,
-      EMPTY_STR_VEC, "Switch with no controllers specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC, EMPTY_STR_VEC,
+      "Switch with no controllers specified"),
     std::make_tuple(
       controller_interface::return_type::OK, STRICT, EMPTY_STR_VEC, EMPTY_STR_VEC,
       "Switch with no controllers specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC,
-      EMPTY_STR_VEC, "Switch with no controllers specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC, EMPTY_STR_VEC,
+      "Switch with no controllers specified"),
     // combination of empty and non-existent controller
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent controller specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent start controller specified"),
+      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent start controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::ERROR, STRICT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
       controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER,
       NONEXISTENT_CONTROLLER, "Switch with nonexistent start and stop controllers specified"),
@@ -436,53 +363,52 @@ INSTANTIATE_TEST_CASE_P(
       NONEXISTENT_CONTROLLER, "Switch with nonexistent start and stop controllers specified"),
     // valid controller used
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER,
-      VALID_CONTROLLER, "Switch with valid stopped controller specified"),
+      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
+      "Switch with valid stopped controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER,
-      VALID_CONTROLLER, "Switch with valid stopped controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
+      "Switch with valid stopped controller specified"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, VALID_PLUS_NONEXISTENT_CONTROLLERS,
       EMPTY_STR_VEC, "Switch with valid and nonexistent controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, VALID_CONTROLLER,
-      NONEXISTENT_CONTROLLER, "Switch with  valid and nonexistent controller specified"))
-// cppcheck-suppress syntaxError
+      controller_interface::return_type::ERROR, STRICT, VALID_CONTROLLER, NONEXISTENT_CONTROLLER,
+      "Switch with  valid and nonexistent controller specified"))
+  // cppcheck-suppress syntaxError
   , );
 #else
 INSTANTIATE_TEST_CASE_P(
-  EmptyListOrNonExistentTest,
-  SwitchTest,
+  EmptyListOrNonExistentTest, SwitchTest,
   ::testing::Values(
     // empty lists
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC,
-      EMPTY_STR_VEC, "Switch with no controllers specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC, EMPTY_STR_VEC,
+      "Switch with no controllers specified"),
     std::make_tuple(
       controller_interface::return_type::OK, STRICT, EMPTY_STR_VEC, EMPTY_STR_VEC,
       "Switch with no controllers specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC,
-      EMPTY_STR_VEC, "Switch with no controllers specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC, EMPTY_STR_VEC,
+      "Switch with no controllers specified"),
     // combination of empty and non-existent controller
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent controller specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent start controller specified"),
+      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER,
-      EMPTY_STR_VEC, "Switch with nonexistent start controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::ERROR, STRICT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC,
-      NONEXISTENT_CONTROLLER, "Switch with nonexistent stop controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified"),
     std::make_tuple(
       controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER,
       NONEXISTENT_CONTROLLER, "Switch with nonexistent start and stop controllers specified"),
@@ -494,18 +420,17 @@ INSTANTIATE_TEST_CASE_P(
       NONEXISTENT_CONTROLLER, "Switch with nonexistent start and stop controllers specified"),
     // valid controller used
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER,
-      VALID_CONTROLLER, "Switch with valid stopped controller specified"),
+      controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
+      "Switch with valid stopped controller specified"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER,
-      VALID_CONTROLLER, "Switch with valid stopped controller specified"),
+      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
+      "Switch with valid stopped controller specified"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, VALID_PLUS_NONEXISTENT_CONTROLLERS,
       EMPTY_STR_VEC, "Switch with valid and nonexistent controller specified"),
     std::make_tuple(
-      controller_interface::return_type::ERROR, STRICT, VALID_CONTROLLER,
-      NONEXISTENT_CONTROLLER, "Switch with  valid and nonexistent controller specified")
-));
+      controller_interface::return_type::ERROR, STRICT, VALID_CONTROLLER, NONEXISTENT_CONTROLLER,
+      "Switch with  valid and nonexistent controller specified")));
 #endif
 
 TEST_F(TestLoadController, starting_and_stopping_a_controller)
@@ -515,30 +440,21 @@ TEST_F(TestLoadController, starting_and_stopping_a_controller)
   ASSERT_NE(controller_if, nullptr);
 
   // Only testing with STRICT now for simplicity
-  { //  Test starting an stopped controller, and stopping afterwards
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting stopped controller");
+  {  //  Test starting an stopped controller, and stopping afterwards
+    RCLCPP_INFO(cm_->get_logger(), "Starting stopped controller");
     strvec start_controllers = {controller_name1};
     strvec stop_controllers = {};
 
     // First activation not possible because controller not configured
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     {
       ControllerManagerRunner cm_runner(this);
-      EXPECT_EQ(
-        controller_interface::return_type::OK,
-        switch_future.get()
-      );
+      EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     }
 
     ASSERT_EQ(
@@ -548,49 +464,34 @@ TEST_F(TestLoadController, starting_and_stopping_a_controller)
     // Activate configured controller
     cm_->configure_controller(controller_name1);
     switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     {
       ControllerManagerRunner cm_runner(this);
-      EXPECT_EQ(
-        controller_interface::return_type::OK,
-        switch_future.get()
-      );
+      EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     }
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      controller_if->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if->get_current_state().id());
   }
 
-  { // Stop controller
+  {  // Stop controller
     strvec start_controllers = {};
     strvec stop_controllers = {controller_name1};
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Stopping started controller");
+    RCLCPP_INFO(cm_->get_logger(), "Stopping started controller");
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      controller_if->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_current_state().id());
   }
 }
 
@@ -611,65 +512,45 @@ TEST_F(TestLoadController, switch_multiple_controllers)
     controller_if2->get_current_state().id());
 
   // Only testing with STRICT now for simplicity
-  { //  Test starting an stopped controller, and stopping afterwards
+  {  //  Test starting an stopped controller, and stopping afterwards
     // configure controller 1
     cm_->configure_controller(controller_name1);
 
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting stopped controller #1");
+    RCLCPP_INFO(cm_->get_logger(), "Starting stopped controller #1");
     strvec start_controllers = {controller_name1};
     strvec stop_controllers = {};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      controller_if1->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if1->get_current_state().id());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
       controller_if2->get_current_state().id());
   }
 
-  { // Stop controller 1, start controller 2
+  {  // Stop controller 1, start controller 2
     // Fails starting of controller 2 because it is not configured
     strvec start_controllers = {controller_name2};
     strvec stop_controllers = {controller_name1};
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Stopping controller #1, starting controller #2 fails");
+    RCLCPP_INFO(cm_->get_logger(), "Stopping controller #1, starting controller #2 fails");
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      controller_if1->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if1->get_current_state().id());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
       controller_if2->get_current_state().id());
@@ -678,86 +559,58 @@ TEST_F(TestLoadController, switch_multiple_controllers)
     cm_->configure_controller(controller_name2);
   }
 
-  { // Start controller 1 again
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting stopped controller #1");
+  {  // Start controller 1 again
+    RCLCPP_INFO(cm_->get_logger(), "Starting stopped controller #1");
     strvec start_controllers = {controller_name1};
     strvec stop_controllers = {};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
 
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
-    ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
-
-    ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      controller_if1->get_current_state().id());
-    ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      controller_if2->get_current_state().id());
-  }
-
-  { // Stop controller 1, start controller 2
-    strvec start_controllers = {controller_name2};
-    strvec stop_controllers = {controller_name1};
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Stopping controller #1, starting controller #2");
-    auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
-    ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK, switch_future.get()
-    );
-
-    ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      controller_if1->get_current_state().id());
-    ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      controller_if2->get_current_state().id());
-  }
-
-  { // stop controller 2
-    strvec start_controllers = {};
-    strvec stop_controllers = {controller_name2};
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Stopping controller #1, starting controller #2");
-    auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
     EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
 
     ASSERT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      controller_if2->get_current_state().id());
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if1->get_current_state().id());
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if2->get_current_state().id());
+  }
+
+  {  // Stop controller 1, start controller 2
+    strvec start_controllers = {controller_name2};
+    strvec stop_controllers = {controller_name1};
+    RCLCPP_INFO(cm_->get_logger(), "Stopping controller #1, starting controller #2");
+    auto switch_future = std::async(
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
+    ControllerManagerRunner cm_runner(this);
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
+
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if1->get_current_state().id());
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller_if2->get_current_state().id());
+  }
+
+  {  // stop controller 2
+    strvec start_controllers = {};
+    strvec stop_controllers = {controller_name2};
+    RCLCPP_INFO(cm_->get_logger(), "Stopping controller #1, starting controller #2");
+    auto switch_future = std::async(
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
+    ControllerManagerRunner cm_runner(this);
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
+
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if2->get_current_state().id());
   }
 }

--- a/controller_manager/test/test_release_interfaces.cpp
+++ b/controller_manager/test/test_release_interfaces.cpp
@@ -18,9 +18,9 @@
 #include <string>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager/controller_manager.hpp"
+#include "controller_manager_test_common.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_controller_with_interfaces/test_controller_with_interfaces.hpp"
 
@@ -28,7 +28,8 @@ using ::testing::_;
 using ::testing::Return;
 
 class TestReleaseInterfaces : public ControllerManagerFixture
-{};
+{
+};
 
 TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
 {
@@ -41,18 +42,12 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
   ASSERT_NO_THROW(cm_->load_controller(controller_name1, controller_type));
   ASSERT_NO_THROW(cm_->load_controller(controller_name2, controller_type));
   ASSERT_EQ(2u, cm_->get_loaded_controllers().size());
-  controller_manager::ControllerSpec abstract_test_controller1 =
-    cm_->get_loaded_controllers()[0];
-  controller_manager::ControllerSpec abstract_test_controller2 =
-    cm_->get_loaded_controllers()[1];
+  controller_manager::ControllerSpec abstract_test_controller1 = cm_->get_loaded_controllers()[0];
+  controller_manager::ControllerSpec abstract_test_controller2 = cm_->get_loaded_controllers()[1];
 
   // Configure controllers
-  ASSERT_EQ(
-    controller_interface::return_type::OK,
-    cm_->configure_controller(controller_name1));
-  ASSERT_EQ(
-    controller_interface::return_type::OK,
-    cm_->configure_controller(controller_name2));
+  ASSERT_EQ(controller_interface::return_type::OK, cm_->configure_controller(controller_name1));
+  ASSERT_EQ(controller_interface::return_type::OK, cm_->configure_controller(controller_name2));
 
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
@@ -61,26 +56,17 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     abstract_test_controller2.c->get_current_state().id());
 
-  { // Test starting the first controller
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting controller #1");
+  {  // Test starting the first controller
+    RCLCPP_INFO(cm_->get_logger(), "Starting controller #1");
     std::vector<std::string> start_controllers = {controller_name1};
     std::vector<std::string> stop_controllers = {};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -89,27 +75,18 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       abstract_test_controller2.c->get_current_state().id());
   }
 
-  { // Test starting the second controller when the first is running
+  {  // Test starting the second controller when the first is running
     // Fails as they have the same command interface
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting controller #2");
+    RCLCPP_INFO(cm_->get_logger(), "Starting controller #2");
     std::vector<std::string> start_controllers = {controller_name2};
     std::vector<std::string> stop_controllers = {};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -118,26 +95,17 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       abstract_test_controller2.c->get_current_state().id());
   }
 
-  { // Test stopping controller #1 and starting controller #2
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Stopping controller #1 and starting controller #2");
+  {  // Test stopping controller #1 and starting controller #2
+    RCLCPP_INFO(cm_->get_logger(), "Stopping controller #1 and starting controller #2");
     std::vector<std::string> start_controllers = {controller_name2};
     std::vector<std::string> stop_controllers = {controller_name1};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -146,26 +114,17 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       abstract_test_controller2.c->get_current_state().id());
   }
 
-  { // Test stopping controller #2 and starting controller #1
-    RCLCPP_INFO(
-      cm_->get_logger(),
-      "Starting controller #1 and stopping controller #2");
+  {  // Test stopping controller #2 and starting controller #1
+    RCLCPP_INFO(cm_->get_logger(), "Starting controller #1 and stopping controller #2");
     std::vector<std::string> start_controllers = {controller_name1};
     std::vector<std::string> stop_controllers = {controller_name2};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -174,27 +133,22 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       abstract_test_controller2.c->get_current_state().id());
   }
 
-  { // Test stopping both controllers when only controller #1 is running
+  {  // Test stopping both controllers when only controller #1 is running
     RCLCPP_INFO(
       cm_->get_logger(),
       "Stopping both controllers (will fail in STRICT mode as controller #2 is not running)");
     std::vector<std::string> start_controllers = {};
     std::vector<std::string> stop_controllers = {controller_name1, controller_name2};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
     // The call to switch above will fail and the CM will not block
     // ASSERT_EQ(
     //   std::future_status::timeout,
     //   switch_future.wait_for(std::chrono::milliseconds(100))) <<
     //   "switch_controller should be blocking until next update cycle";
     // ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::ERROR,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::ERROR, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -203,26 +157,19 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
       abstract_test_controller2.c->get_current_state().id());
   }
 
-  { // Test stopping both controllers when only controller #1 is running
+  {  // Test stopping both controllers when only controller #1 is running
     RCLCPP_INFO(
       cm_->get_logger(),
       "Stopping both controllers (will fail in BEST EFFORT mode as controller #2 is not running)");
     std::vector<std::string> start_controllers = {};
     std::vector<std::string> stop_controllers = {controller_name1, controller_name2};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      BEST_EFFORT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, BEST_EFFORT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
       abstract_test_controller1.c->get_current_state().id());
@@ -238,19 +185,12 @@ TEST_F(TestReleaseInterfaces, switch_controllers_same_interface)
     std::vector<std::string> start_controllers = {controller_name1, controller_name2};
     std::vector<std::string> stop_controllers = {};
     auto switch_future = std::async(
-      std::launch::async,
-      &controller_manager::ControllerManager::switch_controller, cm_,
-      start_controllers, stop_controllers,
-      STRICT, true, rclcpp::Duration(0, 0));
-    ASSERT_EQ(
-      std::future_status::timeout,
-      switch_future.wait_for(std::chrono::milliseconds(100))) <<
-      "switch_controller should be blocking until next update cycle";
+      std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,
+      start_controllers, stop_controllers, STRICT, true, rclcpp::Duration(0, 0));
+    ASSERT_EQ(std::future_status::timeout, switch_future.wait_for(std::chrono::milliseconds(100)))
+      << "switch_controller should be blocking until next update cycle";
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      controller_interface::return_type::OK,
-      switch_future.get()
-    );
+    EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
     ASSERT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
       abstract_test_controller1.c->get_current_state().id());

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -19,9 +19,9 @@
 #include <string>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager/controller_manager.hpp"
+#include "controller_manager_test_common.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 
 using ::testing::_;
@@ -34,31 +34,24 @@ class TestLoadController : public ControllerManagerFixture
   {
     ControllerManagerFixture::SetUp();
 
-    update_timer_ = cm_->create_wall_timer(
-      std::chrono::milliseconds(10), [&]() {
-        cm_->read();
-        cm_->update();
-        cm_->write();
-      }
-    );
+    update_timer_ = cm_->create_wall_timer(std::chrono::milliseconds(10), [&]() {
+      cm_->read();
+      cm_->update();
+      cm_->write();
+    });
 
-    update_executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(
-      rclcpp::ExecutorOptions(), 2);
+    update_executor_ =
+      std::make_shared<rclcpp::executors::MultiThreadedExecutor>(rclcpp::ExecutorOptions(), 2);
 
     update_executor_->add_node(cm_);
-    update_executor_spin_future_ = std::async(
-      std::launch::async, [this]() -> void {
-        update_executor_->spin();
-      });
+    update_executor_spin_future_ =
+      std::async(std::launch::async, [this]() -> void { update_executor_->spin(); });
     // This sleep is needed to prevent a too fast test from ending before the
     // executor has began to spin, which causes it to hang
     std::this_thread::sleep_for(50ms);
   }
 
-  void TearDown() override
-  {
-    update_executor_->cancel();
-  }
+  void TearDown() override { update_executor_->cancel(); }
 
 protected:
   rclcpp::TimerBase::SharedPtr update_timer_;
@@ -121,7 +114,8 @@ TEST_F(TestLoadController, spawner_test_type_in_arg)
   EXPECT_EQ(
     call_spawner(
       "ctrl_2 -c test_controller_manager -t " +
-      std::string(test_controller::TEST_CONTROLLER_CLASS_NAME)), 0);
+      std::string(test_controller::TEST_CONTROLLER_CLASS_NAME)),
+    0);
 
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
   auto ctrl_2 = cm_->get_loaded_controllers()[0];
@@ -135,15 +129,13 @@ TEST_F(TestLoadController, unload_on_kill)
   // Launch spawner.py with unload on kill
   // timeout command will kill it after the specified time with signal SIGINT
   std::stringstream ss;
-  ss << "timeout --signal=INT 5 " <<
-    "ros2 run controller_manager spawner.py " <<
-    "ctrl_3 -c test_controller_manager -t " <<
-    std::string(test_controller::TEST_CONTROLLER_CLASS_NAME) <<
-    " --unload-on-kill";
+  ss << "timeout --signal=INT 5 "
+     << "ros2 run controller_manager spawner.py "
+     << "ctrl_3 -c test_controller_manager -t "
+     << std::string(test_controller::TEST_CONTROLLER_CLASS_NAME) << " --unload-on-kill";
 
-  EXPECT_NE(
-    std::system(ss.str().c_str()),
-    0) << "timeout should have killed spawner and returned non 0 code";
+  EXPECT_NE(std::system(ss.str().c_str()), 0)
+    << "timeout should have killed spawner and returned non 0 code";
 
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 0ul);
 }

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -90,6 +90,10 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gmock REQUIRED)

--- a/hardware_interface/include/fake_components/generic_system.hpp
+++ b/hardware_interface/include/fake_components/generic_system.hpp
@@ -32,19 +32,15 @@ using hardware_interface::return_type;
 
 namespace fake_components
 {
-
 class HARDWARE_INTERFACE_PUBLIC GenericSystem
-  : public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+: public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
 {
 public:
-  return_type
-  configure(const hardware_interface::HardwareInfo & info) override;
+  return_type configure(const hardware_interface::HardwareInfo & info) override;
 
-  std::vector<hardware_interface::StateInterface>
-  export_state_interfaces() override;
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
 
-  std::vector<hardware_interface::CommandInterface>
-  export_command_interfaces() override;
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
 
   return_type start() override
   {
@@ -60,10 +56,7 @@ public:
 
   return_type read() override;
 
-  return_type write() override
-  {
-    return return_type::OK;
-  }
+  return_type write() override { return return_type::OK; }
 
 protected:
   /// Use standard interfaces for joints because they are relevant for dynamic behaviour
@@ -74,11 +67,8 @@ protected:
    * controllers.
    */
   const std::vector<std::string> standard_interfaces_ = {
-    hardware_interface::HW_IF_POSITION,
-    hardware_interface::HW_IF_VELOCITY,
-    hardware_interface::HW_IF_ACCELERATION,
-    hardware_interface::HW_IF_EFFORT
-  };
+    hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY,
+    hardware_interface::HW_IF_ACCELERATION, hardware_interface::HW_IF_EFFORT};
 
   const size_t POSITION_INTERFACE_INDEX = 0;
 
@@ -105,18 +95,14 @@ protected:
   std::vector<std::vector<double>> sensor_states_;
 
 private:
-  template<typename HandleType>
+  template <typename HandleType>
   bool get_interface(
-    const std::string & name,
-    const std::vector<std::string> & interface_list,
-    const std::string & interface_name,
-    const size_t vector_index,
-    std::vector<std::vector<double>> & values,
-    std::vector<HandleType> & interfaces);
+    const std::string & name, const std::vector<std::string> & interface_list,
+    const std::string & interface_name, const size_t vector_index,
+    std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces);
 
   void initialize_storage_vectors(
-    std::vector<std::vector<double>> & commands,
-    std::vector<std::vector<double>> & states,
+    std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
     const std::vector<std::string> & interfaces);
 
   bool fake_sensor_command_interfaces_;

--- a/hardware_interface/include/fake_components/visibility_control.h
+++ b/hardware_interface/include/fake_components/visibility_control.h
@@ -19,31 +19,31 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define FAKE_COMPONENTS_EXPORT __attribute__ ((dllexport))
-    #define FAKE_COMPONENTS_IMPORT __attribute__ ((dllimport))
-  #else
-    #define FAKE_COMPONENTS_EXPORT __declspec(dllexport)
-    #define FAKE_COMPONENTS_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef FAKE_COMPONENTS_BUILDING_DLL
-    #define FAKE_COMPONENTS_PUBLIC FAKE_COMPONENTS_EXPORT
-  #else
-    #define FAKE_COMPONENTS_PUBLIC FAKE_COMPONENTS_IMPORT
-  #endif
-  #define FAKE_COMPONENTS_PUBLIC_TYPE FAKE_COMPONENTS_PUBLIC
-  #define FAKE_COMPONENTS_LOCAL
+#ifdef __GNUC__
+#define FAKE_COMPONENTS_EXPORT __attribute__((dllexport))
+#define FAKE_COMPONENTS_IMPORT __attribute__((dllimport))
 #else
-  #define FAKE_COMPONENTS_EXPORT __attribute__ ((visibility("default")))
-  #define FAKE_COMPONENTS_IMPORT
-  #if __GNUC__ >= 4
-    #define FAKE_COMPONENTS_PUBLIC __attribute__ ((visibility("default")))
-    #define FAKE_COMPONENTS_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define FAKE_COMPONENTS_PUBLIC
-    #define FAKE_COMPONENTS_LOCAL
-  #endif
-  #define FAKE_COMPONENTS_PUBLIC_TYPE
+#define FAKE_COMPONENTS_EXPORT __declspec(dllexport)
+#define FAKE_COMPONENTS_IMPORT __declspec(dllimport)
+#endif
+#ifdef FAKE_COMPONENTS_BUILDING_DLL
+#define FAKE_COMPONENTS_PUBLIC FAKE_COMPONENTS_EXPORT
+#else
+#define FAKE_COMPONENTS_PUBLIC FAKE_COMPONENTS_IMPORT
+#endif
+#define FAKE_COMPONENTS_PUBLIC_TYPE FAKE_COMPONENTS_PUBLIC
+#define FAKE_COMPONENTS_LOCAL
+#else
+#define FAKE_COMPONENTS_EXPORT __attribute__((visibility("default")))
+#define FAKE_COMPONENTS_IMPORT
+#if __GNUC__ >= 4
+#define FAKE_COMPONENTS_PUBLIC __attribute__((visibility("default")))
+#define FAKE_COMPONENTS_LOCAL __attribute__((visibility("hidden")))
+#else
+#define FAKE_COMPONENTS_PUBLIC
+#define FAKE_COMPONENTS_LOCAL
+#endif
+#define FAKE_COMPONENTS_PUBLIC_TYPE
 #endif
 
 #endif  // FAKE_COMPONENTS__VISIBILITY_CONTROL_H_

--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -27,7 +27,6 @@
 
 namespace hardware_interface
 {
-
 class ActuatorInterface;
 
 class Actuator final

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -26,7 +26,6 @@
 
 namespace hardware_interface
 {
-
 /// Virtual Class to implement when integrating a 1 DoF actuator into ros2_control.
 /**
   * The typical examples are conveyors or motors.
@@ -36,8 +35,7 @@ class ActuatorInterface
 public:
   ActuatorInterface() = default;
 
-  virtual
-  ~ActuatorInterface() = default;
+  virtual ~ActuatorInterface() = default;
 
   /// Configuration of the actuator from data parsed from the robot's URDF.
   /**
@@ -45,8 +43,7 @@ public:
    * \return return_type::OK if required data are provided and can be parsed,
    * return_type::ERROR otherwise.
    */
-  virtual
-  return_type configure(const HardwareInfo & actuator_info) = 0;
+  virtual return_type configure(const HardwareInfo & actuator_info) = 0;
 
   /// Exports all state interfaces for this actuator.
   /**
@@ -57,8 +54,7 @@ public:
    *
    * \return vector of state interfaces
    */
-  virtual
-  std::vector<StateInterface> export_state_interfaces() = 0;
+  virtual std::vector<StateInterface> export_state_interfaces() = 0;
 
   /// Exports all command interfaces for this actuator.
   /**
@@ -69,8 +65,7 @@ public:
    *
    * \return vector of command interfaces
    */
-  virtual
-  std::vector<CommandInterface> export_command_interfaces() = 0;
+  virtual std::vector<CommandInterface> export_command_interfaces() = 0;
 
   /// Prepare for a new command interface switch.
   /**
@@ -85,8 +80,7 @@ public:
    * \return return_type::OK if the new command interface combination can be prepared,
    * or if the interface key is not relevant to this system. Returns return_type::ERROR otherwise.
    */
-  virtual
-  return_type prepare_command_mode_switch(
+  virtual return_type prepare_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
   {
@@ -105,8 +99,7 @@ public:
    * \return return_type::OK if the new command interface combination can be switched to,
    * or if the interface key is not relevant to this system. Returns return_type::ERROR otherwise.
    */
-  virtual
-  return_type perform_command_mode_switch(
+  virtual return_type perform_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
   {
@@ -117,29 +110,25 @@ public:
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type start() = 0;
+  virtual return_type start() = 0;
 
   /// Stop exchange data with the hardware.
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type stop() = 0;
+  virtual return_type stop() = 0;
 
   /// Get name of the actuator hardware.
   /**
    * \return name.
    */
-  virtual
-  std::string get_name() const = 0;
+  virtual std::string get_name() const = 0;
 
   /// Get current state of the actuator hardware.
   /**
    * \return current status.
    */
-  virtual
-  status get_status() const = 0;
+  virtual status get_status() const = 0;
 
   /// Read the current state values from the actuator.
   /**
@@ -149,8 +138,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual
-  return_type read() = 0;
+  virtual return_type read() = 0;
 
   /// Write the current command values to the actuator.
   /**
@@ -159,8 +147,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual
-  return_type write() = 0;
+  virtual return_type write() = 0;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/base_interface.hpp
+++ b/hardware_interface/include/hardware_interface/base_interface.hpp
@@ -23,8 +23,7 @@
 
 namespace hardware_interface
 {
-
-template<class InterfaceType>
+template <class InterfaceType>
 class BaseInterface : public InterfaceType
 {
 public:
@@ -40,15 +39,9 @@ public:
     return BaseInterface<InterfaceType>::configure(info);
   }
 
-  std::string get_name() const final
-  {
-    return info_.name;
-  }
+  std::string get_name() const final { return info_.name; }
 
-  status get_status() const final
-  {
-    return status_;
-  }
+  status get_status() const final { return status_; }
 
 protected:
   HardwareInfo info_;

--- a/hardware_interface/include/hardware_interface/component_parser.hpp
+++ b/hardware_interface/include/hardware_interface/component_parser.hpp
@@ -24,7 +24,6 @@
 
 namespace hardware_interface
 {
-
 /// Search XML snippet from URDF for information about a control component.
 /**
   * \param[in] urdf string with robot's URDF

--- a/hardware_interface/include/hardware_interface/controller_info.hpp
+++ b/hardware_interface/include/hardware_interface/controller_info.hpp
@@ -20,7 +20,6 @@
 
 namespace hardware_interface
 {
-
 /// Controller Information
 /**
  * This struct contains information about a given controller.

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -28,9 +28,7 @@ class ReadOnlyHandle
 {
 public:
   ReadOnlyHandle(
-    const std::string & name,
-    const std::string & interface_name,
-    double * value_ptr = nullptr)
+    const std::string & name, const std::string & interface_name, double * value_ptr = nullptr)
   : name_(name), interface_name_(interface_name), value_ptr_(value_ptr)
   {
   }
@@ -56,22 +54,13 @@ public:
   virtual ~ReadOnlyHandle() = default;
 
   /// Returns true if handle references a value.
-  inline operator bool() const {return value_ptr_ != nullptr;}
+  inline operator bool() const { return value_ptr_ != nullptr; }
 
-  const std::string & get_name() const
-  {
-    return name_;
-  }
+  const std::string & get_name() const { return name_; }
 
-  const std::string & get_interface_name() const
-  {
-    return interface_name_;
-  }
+  const std::string & get_interface_name() const { return interface_name_; }
 
-  const std::string get_full_name() const
-  {
-    return name_ + "/" + interface_name_;
-  }
+  const std::string get_full_name() const { return name_ + "/" + interface_name_; }
 
   double get_value() const
   {
@@ -89,19 +78,14 @@ class ReadWriteHandle : public ReadOnlyHandle
 {
 public:
   ReadWriteHandle(
-    const std::string & name,
-    const std::string & interface_name,
-    double * value_ptr = nullptr)
+    const std::string & name, const std::string & interface_name, double * value_ptr = nullptr)
   : ReadOnlyHandle(name, interface_name, value_ptr)
-  {}
+  {
+  }
 
-  explicit ReadWriteHandle(const std::string & interface_name)
-  : ReadOnlyHandle(interface_name)
-  {}
+  explicit ReadWriteHandle(const std::string & interface_name) : ReadOnlyHandle(interface_name) {}
 
-  explicit ReadWriteHandle(const char * interface_name)
-  : ReadOnlyHandle(interface_name)
-  {}
+  explicit ReadWriteHandle(const char * interface_name) : ReadOnlyHandle(interface_name) {}
 
   ReadWriteHandle(const ReadWriteHandle & other) = default;
 

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #ifndef HARDWARE_INTERFACE__HARDWARE_INFO_HPP_
 #define HARDWARE_INTERFACE__HARDWARE_INFO_HPP_
 
@@ -22,7 +21,6 @@
 
 namespace hardware_interface
 {
-
 /**
  * This structure stores information about components defined for a specific hardware
  * in robot's URDF.

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -23,22 +23,20 @@
 
 namespace hardware_interface
 {
-
 class LoanedCommandInterface
 {
 public:
-  using Deleter = std::function<void (void)>;
+  using Deleter = std::function<void(void)>;
 
   explicit LoanedCommandInterface(CommandInterface & command_interface)
   : LoanedCommandInterface(command_interface, nullptr)
-  {}
+  {
+  }
 
-  LoanedCommandInterface(
-    CommandInterface & command_interface,
-    Deleter && deleter)
-  : command_interface_(command_interface),
-    deleter_(std::forward<Deleter>(deleter))
-  {}
+  LoanedCommandInterface(CommandInterface & command_interface, Deleter && deleter)
+  : command_interface_(command_interface), deleter_(std::forward<Deleter>(deleter))
+  {
+  }
 
   LoanedCommandInterface(const LoanedCommandInterface & other) = delete;
 
@@ -46,35 +44,21 @@ public:
 
   virtual ~LoanedCommandInterface()
   {
-    if (deleter_) {
+    if (deleter_)
+    {
       deleter_();
     }
   }
 
-  const std::string & get_name() const
-  {
-    return command_interface_.get_name();
-  }
+  const std::string & get_name() const { return command_interface_.get_name(); }
 
-  const std::string & get_interface_name() const
-  {
-    return command_interface_.get_interface_name();
-  }
+  const std::string & get_interface_name() const { return command_interface_.get_interface_name(); }
 
-  const std::string get_full_name() const
-  {
-    return command_interface_.get_full_name();
-  }
+  const std::string get_full_name() const { return command_interface_.get_full_name(); }
 
-  void set_value(double val)
-  {
-    command_interface_.set_value(val);
-  }
+  void set_value(double val) { command_interface_.set_value(val); }
 
-  double get_value() const
-  {
-    return command_interface_.get_value();
-  }
+  double get_value() const { return command_interface_.get_value(); }
 
 protected:
   CommandInterface & command_interface_;

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -23,22 +23,20 @@
 
 namespace hardware_interface
 {
-
 class LoanedStateInterface
 {
 public:
-  using Deleter = std::function<void (void)>;
+  using Deleter = std::function<void(void)>;
 
   explicit LoanedStateInterface(StateInterface & state_interface)
   : LoanedStateInterface(state_interface, nullptr)
-  {}
+  {
+  }
 
-  LoanedStateInterface(
-    StateInterface & state_interface,
-    Deleter && deleter)
-  : state_interface_(state_interface),
-    deleter_(std::forward<Deleter>(deleter))
-  {}
+  LoanedStateInterface(StateInterface & state_interface, Deleter && deleter)
+  : state_interface_(state_interface), deleter_(std::forward<Deleter>(deleter))
+  {
+  }
 
   LoanedStateInterface(const LoanedStateInterface & other) = delete;
 
@@ -46,30 +44,19 @@ public:
 
   virtual ~LoanedStateInterface()
   {
-    if (deleter_) {
+    if (deleter_)
+    {
       deleter_();
     }
   }
 
-  const std::string & get_name() const
-  {
-    return state_interface_.get_name();
-  }
+  const std::string & get_name() const { return state_interface_.get_name(); }
 
-  const std::string & get_interface_name() const
-  {
-    return state_interface_.get_interface_name();
-  }
+  const std::string & get_interface_name() const { return state_interface_.get_interface_name(); }
 
-  const std::string get_full_name() const
-  {
-    return state_interface_.get_full_name();
-  }
+  const std::string get_full_name() const { return state_interface_.get_full_name(); }
 
-  double get_value() const
-  {
-    return state_interface_.get_value();
-  }
+  double get_value() const { return state_interface_.get_value(); }
 
 protected:
   StateInterface & state_interface_;

--- a/hardware_interface/include/hardware_interface/macros.hpp
+++ b/hardware_interface/include/hardware_interface/macros.hpp
@@ -24,22 +24,23 @@
 #define __PRETTY_FUNCTION__ __FUNCTION__
 #endif
 
-#define THROW_ON_NULLPTR(pointer) \
-  static_assert( \
-    rcpputils::is_pointer<typename std::remove_reference<decltype(pointer)>::type>::value, \
-    #pointer " has to be a pointer"); \
-  if (!pointer) { \
-    throw std::runtime_error( \
-            std::string(__PRETTY_FUNCTION__) + " failed. "#pointer " is null."); \
-  } \
+#define THROW_ON_NULLPTR(pointer)                                                                  \
+  static_assert(                                                                                   \
+    rcpputils::is_pointer<typename std::remove_reference<decltype(pointer)>::type>::value,         \
+    #pointer " has to be a pointer");                                                              \
+  if (!pointer)                                                                                    \
+  {                                                                                                \
+    throw std::runtime_error(std::string(__PRETTY_FUNCTION__) + " failed. " #pointer " is null."); \
+  }
 
-#define THROW_ON_NOT_NULLPTR(pointer) \
-  static_assert( \
+#define THROW_ON_NOT_NULLPTR(pointer)                                                      \
+  static_assert(                                                                           \
     rcpputils::is_pointer<typename std::remove_reference<decltype(pointer)>::type>::value, \
-    #pointer " has to be a pointer"); \
-  if (pointer) { \
-    throw std::runtime_error( \
-            std::string(__PRETTY_FUNCTION__) + " failed. "#pointer " would leak memory"); \
-  } \
+    #pointer " has to be a pointer");                                                      \
+  if (pointer)                                                                             \
+  {                                                                                        \
+    throw std::runtime_error(                                                              \
+      std::string(__PRETTY_FUNCTION__) + " failed. " #pointer " would leak memory");       \
+  }
 
 #endif  // HARDWARE_INTERFACE__MACROS_HPP_

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -21,9 +21,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
-#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_status_values.hpp"
 
 namespace hardware_interface
@@ -52,8 +52,7 @@ public:
    * \param[in] validate_interfaces boolean argument indicating whether the exported
    * interfaces ought to be validated. Defaults to true.
    */
-  explicit ResourceManager(
-    const std::string & urdf, bool validate_interfaces = true);
+  explicit ResourceManager(const std::string & urdf, bool validate_interfaces = true);
 
   ResourceManager(const ResourceManager &) = delete;
 

--- a/hardware_interface/include/hardware_interface/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/sensor.hpp
@@ -28,7 +28,6 @@
 
 namespace hardware_interface
 {
-
 class SensorInterface;
 
 class Sensor final

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -27,7 +27,6 @@
 
 namespace hardware_interface
 {
-
 /**
   * Virtual Class to implement when integrating a stand-alone sensor into ros2_control.
   * The typical examples are Force-Torque Sensor (FTS), Interial Measurement Unit (IMU).
@@ -37,8 +36,7 @@ class SensorInterface
 public:
   SensorInterface() = default;
 
-  virtual
-  ~SensorInterface() = default;
+  virtual ~SensorInterface() = default;
 
   /// Configuration of the sensor from data parsed from the robot's URDF.
   /**
@@ -46,8 +44,7 @@ public:
    * \return return_type::OK if required data are provided and can be parsed,
    * return_type::ERROR otherwise.
    */
-  virtual
-  return_type configure(const HardwareInfo & sensor_info) = 0;
+  virtual return_type configure(const HardwareInfo & sensor_info) = 0;
 
   /// Exports all state interfaces for this sensor.
   /**
@@ -58,36 +55,31 @@ public:
    *
    * \return std::vector<StateInterface> vector of state interfaces
    */
-  virtual
-  std::vector<StateInterface> export_state_interfaces() = 0;
+  virtual std::vector<StateInterface> export_state_interfaces() = 0;
 
   /// Start exchange data with the hardware.
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type start() = 0;
+  virtual return_type start() = 0;
 
   /// Stop exchange data with the hardware.
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type stop() = 0;
+  virtual return_type stop() = 0;
 
   /// Get name of the sensor hardware.
   /**
    * \return name.
    */
-  virtual
-  std::string get_name() const = 0;
+  virtual std::string get_name() const = 0;
 
   /// Get current state of the sensor hardware.
   /**
    * \return current status.
    */
-  virtual
-  status get_status() const = 0;
+  virtual status get_status() const = 0;
 
   /// Read the current state values from the sensor.
   /**
@@ -97,8 +89,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual
-  return_type read() = 0;
+  virtual return_type read() = 0;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -28,7 +28,6 @@
 
 namespace hardware_interface
 {
-
 class SystemInterface;
 
 class System final

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -27,7 +27,6 @@
 
 namespace hardware_interface
 {
-
 /// Virtual Class to implement when integrating a complex system into ros2_control.
 /**
 * The common examples for these types of hardware are multi-joint systems with or without sensors
@@ -38,8 +37,7 @@ class SystemInterface
 public:
   SystemInterface() = default;
 
-  virtual
-  ~SystemInterface() = default;
+  virtual ~SystemInterface() = default;
 
   /// Configuration of the system from data parsed from the robot's URDF.
   /**
@@ -47,8 +45,7 @@ public:
    * \return return_type::OK if required data are provided and can be parsed,
    * return_type::ERROR otherwise.
    */
-  virtual
-  return_type configure(const HardwareInfo & system_info) = 0;
+  virtual return_type configure(const HardwareInfo & system_info) = 0;
 
   /// Exports all state interfaces for this system.
   /**
@@ -60,8 +57,7 @@ public:
    *
    * \return vector of state interfaces
    */
-  virtual
-  std::vector<StateInterface> export_state_interfaces() = 0;
+  virtual std::vector<StateInterface> export_state_interfaces() = 0;
 
   /// Exports all command interfaces for this system.
   /**
@@ -72,8 +68,7 @@ public:
    *
    * \return vector of command interfaces
    */
-  virtual
-  std::vector<CommandInterface> export_command_interfaces() = 0;
+  virtual std::vector<CommandInterface> export_command_interfaces() = 0;
 
   /// Prepare for a new command interface switch.
   /**
@@ -88,8 +83,7 @@ public:
    * \return return_type::OK if the new command interface combination can be prepared,
    * or if the interface key is not relevant to this system. Returns return_type::ERROR otherwise.
    */
-  virtual
-  return_type prepare_command_mode_switch(
+  virtual return_type prepare_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
   {
@@ -108,8 +102,7 @@ public:
    * \return return_type::OK if the new command interface combination can be switched to,
    * or if the interface key is not relevant to this system. Returns return_type::ERROR otherwise.
    */
-  virtual
-  return_type perform_command_mode_switch(
+  virtual return_type perform_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
   {
@@ -120,29 +113,25 @@ public:
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type start() = 0;
+  virtual return_type start() = 0;
 
   /// Stop exchange data with the hardware.
   /**
    * \return return_type:OK if everything worked as expected, return_type::ERROR otherwise.
    */
-  virtual
-  return_type stop() = 0;
+  virtual return_type stop() = 0;
 
   /// Get name of the system hardware.
   /**
    * \return name.
    */
-  virtual
-  std::string get_name() const = 0;
+  virtual std::string get_name() const = 0;
 
   /// Get current state of the system hardware.
   /**
    * \return current status.
    */
-  virtual
-  status get_status() const = 0;
+  virtual status get_status() const = 0;
 
   /// Read the current state values from the actuators and sensors within the system.
   /**
@@ -152,8 +141,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual
-  return_type read() = 0;
+  virtual return_type read() = 0;
 
   /// Write the current command values to the actuator within the system.
   /**
@@ -162,8 +150,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual
-  return_type write() = 0;
+  virtual return_type write() = 0;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/visibility_control.h
+++ b/hardware_interface/include/hardware_interface/visibility_control.h
@@ -19,31 +19,31 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define HARDWARE_INTERFACE_EXPORT __attribute__ ((dllexport))
-    #define HARDWARE_INTERFACE_IMPORT __attribute__ ((dllimport))
-  #else
-    #define HARDWARE_INTERFACE_EXPORT __declspec(dllexport)
-    #define HARDWARE_INTERFACE_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef HARDWARE_INTERFACE_BUILDING_DLL
-    #define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_EXPORT
-  #else
-    #define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_IMPORT
-  #endif
-  #define HARDWARE_INTERFACE_PUBLIC_TYPE HARDWARE_INTERFACE_PUBLIC
-  #define HARDWARE_INTERFACE_LOCAL
+#ifdef __GNUC__
+#define HARDWARE_INTERFACE_EXPORT __attribute__((dllexport))
+#define HARDWARE_INTERFACE_IMPORT __attribute__((dllimport))
 #else
-  #define HARDWARE_INTERFACE_EXPORT __attribute__ ((visibility("default")))
-  #define HARDWARE_INTERFACE_IMPORT
-  #if __GNUC__ >= 4
-    #define HARDWARE_INTERFACE_PUBLIC __attribute__ ((visibility("default")))
-    #define HARDWARE_INTERFACE_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define HARDWARE_INTERFACE_PUBLIC
-    #define HARDWARE_INTERFACE_LOCAL
-  #endif
-  #define HARDWARE_INTERFACE_PUBLIC_TYPE
+#define HARDWARE_INTERFACE_EXPORT __declspec(dllexport)
+#define HARDWARE_INTERFACE_IMPORT __declspec(dllimport)
+#endif
+#ifdef HARDWARE_INTERFACE_BUILDING_DLL
+#define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_EXPORT
+#else
+#define HARDWARE_INTERFACE_PUBLIC HARDWARE_INTERFACE_IMPORT
+#endif
+#define HARDWARE_INTERFACE_PUBLIC_TYPE HARDWARE_INTERFACE_PUBLIC
+#define HARDWARE_INTERFACE_LOCAL
+#else
+#define HARDWARE_INTERFACE_EXPORT __attribute__((visibility("default")))
+#define HARDWARE_INTERFACE_IMPORT
+#if __GNUC__ >= 4
+#define HARDWARE_INTERFACE_PUBLIC __attribute__((visibility("default")))
+#define HARDWARE_INTERFACE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define HARDWARE_INTERFACE_PUBLIC
+#define HARDWARE_INTERFACE_LOCAL
+#endif
+#define HARDWARE_INTERFACE_PUBLIC_TYPE
 #endif
 
 #endif  // HARDWARE_INTERFACE__VISIBILITY_CONTROL_H_

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -28,10 +28,7 @@
 
 namespace hardware_interface
 {
-
-Actuator::Actuator(std::unique_ptr<ActuatorInterface> impl)
-: impl_(std::move(impl))
-{}
+Actuator::Actuator(std::unique_ptr<ActuatorInterface> impl) : impl_(std::move(impl)) {}
 
 return_type Actuator::configure(const HardwareInfo & actuator_info)
 {
@@ -64,34 +61,16 @@ return_type Actuator::perform_command_mode_switch(
   return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
 }
 
-return_type Actuator::start()
-{
-  return impl_->start();
-}
+return_type Actuator::start() { return impl_->start(); }
 
-return_type Actuator::stop()
-{
-  return impl_->stop();
-}
+return_type Actuator::stop() { return impl_->stop(); }
 
-std::string Actuator::get_name() const
-{
-  return impl_->get_name();
-}
+std::string Actuator::get_name() const { return impl_->get_name(); }
 
-status Actuator::get_status() const
-{
-  return impl_->get_status();
-}
+status Actuator::get_status() const { return impl_->get_status(); }
 
-return_type Actuator::read()
-{
-  return impl_->read();
-}
+return_type Actuator::read() { return impl_->read(); }
 
-return_type Actuator::write()
-{
-  return impl_->write();
-}
+return_type Actuator::write() { return impl_->write(); }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include <tinyxml2.h>
+#include <regex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <regex>
 
-#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/hardware_info.hpp"
 
 namespace
 {
@@ -49,7 +49,6 @@ constexpr const auto kOffsetAttribute = "offset";
 
 namespace hardware_interface
 {
-
 namespace detail
 {
 /// Gets value of the text between tags.
@@ -63,7 +62,8 @@ std::string get_text_for_element(
   const tinyxml2::XMLElement * element_it, const std::string & tag_name)
 {
   const auto get_text_output = element_it->GetText();
-  if (!get_text_output) {
+  if (!get_text_output)
+  {
     throw std::runtime_error("text not specified in the " + tag_name + " tag");
   }
   return get_text_output;
@@ -80,15 +80,14 @@ std::string get_text_for_element(
  * \throws std::runtime_error if attribute is not found
  */
 std::string get_attribute_value(
-  const tinyxml2::XMLElement * element_it,
-  const char * attribute_name,
-  std::string tag_name)
+  const tinyxml2::XMLElement * element_it, const char * attribute_name, std::string tag_name)
 {
   const tinyxml2::XMLAttribute * attr;
   attr = element_it->FindAttribute(attribute_name);
-  if (!attr) {
+  if (!attr)
+  {
     throw std::runtime_error(
-            "no attribute " + std::string(attribute_name) + " in " + tag_name + " tag");
+      "no attribute " + std::string(attribute_name) + " in " + tag_name + " tag");
   }
   return element_it->Attribute(attribute_name);
 }
@@ -104,9 +103,7 @@ std::string get_attribute_value(
  * \throws std::runtime_error if attribute is not found
  */
 std::string get_attribute_value(
-  const tinyxml2::XMLElement * element_it,
-  const char * attribute_name,
-  const char * tag_name)
+  const tinyxml2::XMLElement * element_it, const char * attribute_name, const char * tag_name)
 {
   return get_attribute_value(element_it, attribute_name, std::string(tag_name));
 }
@@ -121,16 +118,17 @@ std::string get_attribute_value(
  * \return attribute value or default
  */
 double get_parameter_value_or(
-  const tinyxml2::XMLElement * params_it,
-  const char * parameter_name,
-  const double default_value)
+  const tinyxml2::XMLElement * params_it, const char * parameter_name, const double default_value)
 {
-  while (params_it) {
+  while (params_it)
+  {
     // Fill the map with parameters
     const auto tag_name = params_it->Name();
-    if (strcmp(tag_name, parameter_name) == 0) {
+    if (strcmp(tag_name, parameter_name) == 0)
+    {
       const auto tag_text = params_it->GetText();
-      if (!tag_text) {
+      if (!tag_text)
+      {
         throw std::runtime_error("text not specified in the " + std::string(tag_name) + " tag");
       }
       return std::stod(tag_text);
@@ -150,12 +148,12 @@ double get_parameter_value_or(
  * \return The size.
  * \throws std::runtime_error if not given a positive non-zero integer as value.
  */
-std::size_t parse_size_attribute(
-  const tinyxml2::XMLElement * elem)
+std::size_t parse_size_attribute(const tinyxml2::XMLElement * elem)
 {
   const tinyxml2::XMLAttribute * attr = elem->FindAttribute(kSizeAttribute);
 
-  if (!attr) {
+  if (!attr)
+  {
     return 1;
   }
 
@@ -163,12 +161,15 @@ std::size_t parse_size_attribute(
   // Regex used to check for non-zero positive int
   std::string s = attr->Value();
   std::regex int_re("[1-9][0-9]*");
-  if (std::regex_match(s, int_re)) {
+  if (std::regex_match(s, int_re))
+  {
     size = std::stoi(s);
-  } else {
+  }
+  else
+  {
     throw std::runtime_error(
-            "Could not parse size tag in \"" + std::string(elem->Name()) + "\"." +
-            "Got \"" + s + "\", but expected a non-zero positive integer.");
+      "Could not parse size tag in \"" + std::string(elem->Name()) + "\"." + "Got \"" + s +
+      "\", but expected a non-zero positive integer.");
   }
 
   return size;
@@ -182,14 +183,16 @@ std::size_t parse_size_attribute(
  * \param[in] elem XMLElement that has the data_type attribute.
  * \return string specifying the data type.
  */
-std::string parse_data_type_attribute(
-  const tinyxml2::XMLElement * elem)
+std::string parse_data_type_attribute(const tinyxml2::XMLElement * elem)
 {
   const tinyxml2::XMLAttribute * attr = elem->FindAttribute(kDataTypeAttribute);
   std::string data_type;
-  if (!attr) {
+  if (!attr)
+  {
     data_type = "double";
-  } else {
+  }
+  else
+  {
     data_type = attr->Value();
   }
 
@@ -208,10 +211,12 @@ std::unordered_map<std::string, std::string> parse_parameters_from_xml(
   std::unordered_map<std::string, std::string> parameters;
   const tinyxml2::XMLAttribute * attr;
 
-  while (params_it) {
+  while (params_it)
+  {
     // Fill the map with parameters
     attr = params_it->FindAttribute(kNameAttribute);
-    if (!attr) {
+    if (!attr)
+    {
       throw std::runtime_error("no parameter name attribute set in param tag");
     }
     const std::string parameter_name = params_it->Attribute(kNameAttribute);
@@ -235,20 +240,21 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
 {
   hardware_interface::InterfaceInfo interface;
 
-  const std::string interface_name = get_attribute_value(
-    interfaces_it, kNameAttribute, interfaces_it->Name());
+  const std::string interface_name =
+    get_attribute_value(interfaces_it, kNameAttribute, interfaces_it->Name());
   interface.name = interface_name;
 
   // Optional min/max attributes
   std::unordered_map<std::string, std::string> interface_params =
     parse_parameters_from_xml(interfaces_it->FirstChildElement(kParamTag));
-  auto interface_param =
-    interface_params.find(kMinTag);
-  if (interface_param != interface_params.end()) {
+  auto interface_param = interface_params.find(kMinTag);
+  if (interface_param != interface_params.end())
+  {
     interface.min = interface_param->second;
   }
   interface_param = interface_params.find(kMaxTag);
-  if (interface_param != interface_params.end()) {
+  if (interface_param != interface_params.end())
+  {
     interface.max = interface_param->second;
   }
 
@@ -276,21 +282,24 @@ ComponentInfo parse_component_from_xml(const tinyxml2::XMLElement * component_it
 
   // Parse all command interfaces
   const auto * command_interfaces_it = component_it->FirstChildElement(kCommandInterfaceTag);
-  while (command_interfaces_it) {
+  while (command_interfaces_it)
+  {
     component.command_interfaces.push_back(parse_interfaces_from_xml(command_interfaces_it));
     command_interfaces_it = command_interfaces_it->NextSiblingElement(kCommandInterfaceTag);
   }
 
   // Parse state interfaces
   const auto * state_interfaces_it = component_it->FirstChildElement(kStateInterfaceTag);
-  while (state_interfaces_it) {
+  while (state_interfaces_it)
+  {
     component.state_interfaces.push_back(parse_interfaces_from_xml(state_interfaces_it));
     state_interfaces_it = state_interfaces_it->NextSiblingElement(kStateInterfaceTag);
   }
 
   // Parse parameters
   const auto * params_it = component_it->FirstChildElement(kParamTag);
-  if (params_it) {
+  if (params_it)
+  {
     component.parameters = parse_parameters_from_xml(params_it);
   }
 
@@ -306,8 +315,7 @@ ComponentInfo parse_component_from_xml(const tinyxml2::XMLElement * component_it
  * info should befound
  * \throws std::runtime_error if a required component attribute or tag is not found.
  */
-ComponentInfo parse_complex_component_from_xml(
-  const tinyxml2::XMLElement * component_it)
+ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * component_it)
 {
   ComponentInfo component;
 
@@ -317,7 +325,8 @@ ComponentInfo parse_complex_component_from_xml(
 
   // Parse all command interfaces
   const auto * command_interfaces_it = component_it->FirstChildElement(kCommandInterfaceTag);
-  while (command_interfaces_it) {
+  while (command_interfaces_it)
+  {
     component.command_interfaces.push_back(parse_interfaces_from_xml(command_interfaces_it));
     component.command_interfaces.back().data_type =
       parse_data_type_attribute(command_interfaces_it);
@@ -327,7 +336,8 @@ ComponentInfo parse_complex_component_from_xml(
 
   // Parse state interfaces
   const auto * state_interfaces_it = component_it->FirstChildElement(kStateInterfaceTag);
-  while (state_interfaces_it) {
+  while (state_interfaces_it)
+  {
     component.state_interfaces.push_back(parse_interfaces_from_xml(state_interfaces_it));
     component.state_interfaces.back().data_type = parse_data_type_attribute(state_interfaces_it);
     component.state_interfaces.back().size = parse_size_attribute(state_interfaces_it);
@@ -336,7 +346,8 @@ ComponentInfo parse_complex_component_from_xml(
 
   // Parse parameters
   const auto * params_it = component_it->FirstChildElement(kParamTag);
-  if (params_it) {
+  if (params_it)
+  {
     component.parameters = parse_parameters_from_xml(params_it);
   }
 
@@ -348,8 +359,8 @@ JointInfo parse_transmission_joint_from_xml(const tinyxml2::XMLElement * element
   JointInfo joint_info;
   joint_info.name = get_attribute_value(element_it, kNameAttribute, element_it->Name());
   joint_info.role = get_attribute_value(element_it, kRoleAttribute, element_it->Name());
-  joint_info.mechanical_reduction = get_parameter_value_or(
-    element_it->FirstChildElement(), kReductionAttribute, 0.0);
+  joint_info.mechanical_reduction =
+    get_parameter_value_or(element_it->FirstChildElement(), kReductionAttribute, 0.0);
   joint_info.offset =
     get_parameter_value_or(element_it->FirstChildElement(), kOffsetAttribute, 0.0);
   return joint_info;
@@ -360,8 +371,8 @@ ActuatorInfo parse_transmission_actuator_from_xml(const tinyxml2::XMLElement * e
   ActuatorInfo actuator_info;
   actuator_info.name = get_attribute_value(element_it, kNameAttribute, element_it->Name());
   actuator_info.role = get_attribute_value(element_it, kRoleAttribute, element_it->Name());
-  actuator_info.offset = get_parameter_value_or(
-    element_it->FirstChildElement(), kOffsetAttribute, 0.0);
+  actuator_info.offset =
+    get_parameter_value_or(element_it->FirstChildElement(), kOffsetAttribute, 0.0);
   return actuator_info;
 }
 
@@ -382,21 +393,24 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
 
   // Parse joints
   const auto * joint_it = transmission_it->FirstChildElement(kJointTag);
-  while (joint_it) {
+  while (joint_it)
+  {
     transmission.joints.push_back(parse_transmission_joint_from_xml(joint_it));
     joint_it = joint_it->NextSiblingElement(kJointTag);
   }
 
   // Parse actuators
   const auto * actuator_it = transmission_it->FirstChildElement(kActuatorTag);
-  while (actuator_it) {
+  while (actuator_it)
+  {
     transmission.actuators.push_back(parse_transmission_actuator_from_xml(actuator_it));
     actuator_it = actuator_it->NextSiblingElement(kActuatorTag);
   }
 
   // Parse parameters
   const auto * params_it = transmission_it->FirstChildElement(kParamTag);
-  if (params_it) {
+  if (params_it)
+  {
     transmission.parameters = parse_parameters_from_xml(params_it);
   }
 
@@ -410,40 +424,43 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
  */
 void auto_fill_transmission_interfaces(HardwareInfo & hardware)
 {
-  for (auto & transmission : hardware.transmissions) {
+  for (auto & transmission : hardware.transmissions)
+  {
     // fill joint interfaces for actuator from joints declared for this component
-    for (auto & joint : transmission.joints) {
+    for (auto & joint : transmission.joints)
+    {
       auto found_it = std::find_if(
-        hardware.joints.cbegin(), hardware.joints.cend(), [&joint](const auto & joint_info) {
-          return joint.name == joint_info.name;
-        });
+        hardware.joints.cbegin(), hardware.joints.cend(),
+        [&joint](const auto & joint_info) { return joint.name == joint_info.name; });
 
-      if (found_it == hardware.joints.cend()) {
+      if (found_it == hardware.joints.cend())
+      {
         throw std::runtime_error(
-                "Error while parsing '" + hardware.name + "'. Transmission '" +
-                transmission.name + "' declared joint '" +
-                joint.name + "' is not available in component '" + hardware.name + "'.");
+          "Error while parsing '" + hardware.name + "'. Transmission '" + transmission.name +
+          "' declared joint '" + joint.name + "' is not available in component '" + hardware.name +
+          "'.");
       }
 
       //  copy interface names from their definitions in the component
       std::transform(
-        found_it->command_interfaces.cbegin(),
-        found_it->command_interfaces.cend(), std::back_inserter(joint.interfaces),
-        [](const auto & interface) {return interface.name;});
+        found_it->command_interfaces.cbegin(), found_it->command_interfaces.cend(),
+        std::back_inserter(joint.interfaces),
+        [](const auto & interface) { return interface.name; });
     }
 
     // we parsed an actuator component, here we fill in more details
-    if (hardware.type == kActuatorTag) {
-      if (transmission.joints.size() != 1) {
+    if (hardware.type == kActuatorTag)
+    {
+      if (transmission.joints.size() != 1)
+      {
         throw std::runtime_error(
-                "Error while parsing '" + hardware.name +
-                "'. There should be exactly one joint defined in this component but found " +
-                std::to_string(transmission.joints.size()));
+          "Error while parsing '" + hardware.name +
+          "'. There should be exactly one joint defined in this component but found " +
+          std::to_string(transmission.joints.size()));
       }
 
       transmission.actuators.push_back(
-        ActuatorInfo{"actuator1",
-          transmission.joints[0].interfaces, "actuator1", 0.0});
+        ActuatorInfo{"actuator1", transmission.joints[0].interfaces, "actuator1", 0.0});
     }
   }
 }
@@ -464,25 +481,37 @@ HardwareInfo parse_resource_from_xml(const tinyxml2::XMLElement * ros2_control_i
   // Parse everything under ros2_control tag
   hardware.hardware_class_type = "";
   const auto * ros2_control_child_it = ros2_control_it->FirstChildElement();
-  while (ros2_control_child_it) {
-    if (!std::string(kHardwareTag).compare(ros2_control_child_it->Name())) {
+  while (ros2_control_child_it)
+  {
+    if (!std::string(kHardwareTag).compare(ros2_control_child_it->Name()))
+    {
       const auto * type_it = ros2_control_child_it->FirstChildElement(kClassTypeTag);
-      hardware.hardware_class_type = get_text_for_element(
-        type_it, std::string("hardware ") + kClassTypeTag);
+      hardware.hardware_class_type =
+        get_text_for_element(type_it, std::string("hardware ") + kClassTypeTag);
       const auto * params_it = ros2_control_child_it->FirstChildElement(kParamTag);
-      if (params_it) {
+      if (params_it)
+      {
         hardware.hardware_parameters = parse_parameters_from_xml(params_it);
       }
-    } else if (!std::string(kJointTag).compare(ros2_control_child_it->Name())) {
-      hardware.joints.push_back(parse_component_from_xml(ros2_control_child_it) );
-    } else if (!std::string(kSensorTag).compare(ros2_control_child_it->Name())) {
-      hardware.sensors.push_back(parse_component_from_xml(ros2_control_child_it) );
-    } else if (!std::string(kGPIOTag).compare(ros2_control_child_it->Name())) {
-      hardware.gpios.push_back(
-        parse_complex_component_from_xml(ros2_control_child_it));
-    } else if (!std::string(kTransmissionTag).compare(ros2_control_child_it->Name())) {
-      hardware.transmissions.push_back(parse_transmission_from_xml(ros2_control_child_it) );
-    } else {
+    }
+    else if (!std::string(kJointTag).compare(ros2_control_child_it->Name()))
+    {
+      hardware.joints.push_back(parse_component_from_xml(ros2_control_child_it));
+    }
+    else if (!std::string(kSensorTag).compare(ros2_control_child_it->Name()))
+    {
+      hardware.sensors.push_back(parse_component_from_xml(ros2_control_child_it));
+    }
+    else if (!std::string(kGPIOTag).compare(ros2_control_child_it->Name()))
+    {
+      hardware.gpios.push_back(parse_complex_component_from_xml(ros2_control_child_it));
+    }
+    else if (!std::string(kTransmissionTag).compare(ros2_control_child_it->Name()))
+    {
+      hardware.transmissions.push_back(parse_transmission_from_xml(ros2_control_child_it));
+    }
+    else
+    {
       throw std::runtime_error("invalid tag name " + std::string(ros2_control_child_it->Name()));
     }
     ros2_control_child_it = ros2_control_child_it->NextSiblingElement();
@@ -498,31 +527,37 @@ HardwareInfo parse_resource_from_xml(const tinyxml2::XMLElement * ros2_control_i
 std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & urdf)
 {
   // Check if everything OK with URDF string
-  if (urdf.empty()) {
+  if (urdf.empty())
+  {
     throw std::runtime_error("empty URDF passed to robot");
   }
   tinyxml2::XMLDocument doc;
-  if (!doc.Parse(urdf.c_str()) && doc.Error()) {
+  if (!doc.Parse(urdf.c_str()) && doc.Error())
+  {
     throw std::runtime_error("invalid URDF passed in to robot parser");
   }
-  if (doc.Error()) {
+  if (doc.Error())
+  {
     throw std::runtime_error("invalid URDF passed in to robot parser");
   }
 
   // Find robot tag
   const tinyxml2::XMLElement * robot_it = doc.RootElement();
 
-  if (std::string(kRobotTag).compare(robot_it->Name())) {
+  if (std::string(kRobotTag).compare(robot_it->Name()))
+  {
     throw std::runtime_error("the robot tag is not root element in URDF");
   }
 
   const tinyxml2::XMLElement * ros2_control_it = robot_it->FirstChildElement(kROS2ControlTag);
-  if (!ros2_control_it) {
+  if (!ros2_control_it)
+  {
     throw std::runtime_error("no " + std::string(kROS2ControlTag) + " tag");
   }
 
   std::vector<HardwareInfo> hardware_info;
-  while (ros2_control_it) {
+  while (ros2_control_it)
+  {
     hardware_info.push_back(detail::parse_resource_from_xml(ros2_control_it));
     ros2_control_it = ros2_control_it->NextSiblingElement(kROS2ControlTag);
   }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -34,29 +34,25 @@
 
 namespace hardware_interface
 {
-
 class ResourceStorage
 {
   static constexpr const char * pkg_name = "hardware_interface";
 
-  static constexpr const char * actuator_interface_name =
-    "hardware_interface::ActuatorInterface";
-  static constexpr const char * sensor_interface_name =
-    "hardware_interface::SensorInterface";
-  static constexpr const char * system_interface_name =
-    "hardware_interface::SystemInterface";
+  static constexpr const char * actuator_interface_name = "hardware_interface::ActuatorInterface";
+  static constexpr const char * sensor_interface_name = "hardware_interface::SensorInterface";
+  static constexpr const char * system_interface_name = "hardware_interface::SystemInterface";
 
 public:
   ResourceStorage()
   : actuator_loader_(pkg_name, actuator_interface_name),
     sensor_loader_(pkg_name, sensor_interface_name),
     system_loader_(pkg_name, system_interface_name)
-  {}
+  {
+  }
 
-  template<class HardwareT, class HardwareInterfaceT>
+  template <class HardwareT, class HardwareInterfaceT>
   void initialize_hardware(
-    const HardwareInfo & hardware_info,
-    pluginlib::ClassLoader<HardwareInterfaceT> & loader,
+    const HardwareInfo & hardware_info, pluginlib::ClassLoader<HardwareInterfaceT> & loader,
     std::vector<HardwareT> & container)
   {
     // hardware_class_type has to match class name in plugin xml description
@@ -70,29 +66,27 @@ public:
       std::make_pair(container.back().get_name(), container.back().get_status()));
   }
 
-  template<class HardwareT>
+  template <class HardwareT>
   void import_state_interfaces(HardwareT & hardware)
   {
     auto interfaces = hardware.export_state_interfaces();
-    for (auto i = 0u; i < interfaces.size(); ++i) {
+    for (auto i = 0u; i < interfaces.size(); ++i)
+    {
       auto key = interfaces[i].get_name() + "/" + interfaces[i].get_interface_name();
-      state_interface_map_.emplace(
-        std::make_pair(key, std::move(interfaces[i])));
+      state_interface_map_.emplace(std::make_pair(key, std::move(interfaces[i])));
     }
   }
 
-  template<class HardwareT>
+  template <class HardwareT>
   void import_command_interfaces(
-    HardwareT & hardware,
-    std::unordered_map<std::string, bool> & claimed_command_interface_map)
+    HardwareT & hardware, std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     auto interfaces = hardware.export_command_interfaces();
-    for (auto i = 0u; i < interfaces.size(); ++i) {
+    for (auto i = 0u; i < interfaces.size(); ++i)
+    {
       auto key = interfaces[i].get_name() + "/" + interfaces[i].get_interface_name();
-      command_interface_map_.emplace(
-        std::make_pair(key, std::move(interfaces[i])));
-      claimed_command_interface_map.emplace(
-        std::make_pair(key, false));
+      command_interface_map_.emplace(std::make_pair(key, std::move(interfaces[i])));
+      claimed_command_interface_map.emplace(std::make_pair(key, false));
     }
   }
 
@@ -100,9 +94,9 @@ public:
     const HardwareInfo & hardware_info,
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
-    initialize_hardware<Actuator, ActuatorInterface>(
-      hardware_info, actuator_loader_, actuators_);
-    if (return_type::OK != actuators_.back().configure(hardware_info)) {
+    initialize_hardware<Actuator, ActuatorInterface>(hardware_info, actuator_loader_, actuators_);
+    if (return_type::OK != actuators_.back().configure(hardware_info))
+    {
       throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
     }
     import_state_interfaces(actuators_.back());
@@ -111,9 +105,9 @@ public:
 
   void initialize_sensor(const HardwareInfo & hardware_info)
   {
-    initialize_hardware<Sensor, SensorInterface>(
-      hardware_info, sensor_loader_, sensors_);
-    if (return_type::OK != sensors_.back().configure(hardware_info)) {
+    initialize_hardware<Sensor, SensorInterface>(hardware_info, sensor_loader_, sensors_);
+    if (return_type::OK != sensors_.back().configure(hardware_info))
+    {
       throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
     }
     import_state_interfaces(sensors_.back());
@@ -123,9 +117,9 @@ public:
     const HardwareInfo & hardware_info,
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
-    initialize_hardware<System, SystemInterface>(
-      hardware_info, system_loader_, systems_);
-    if (return_type::OK != systems_.back().configure(hardware_info)) {
+    initialize_hardware<System, SystemInterface>(hardware_info, system_loader_, systems_);
+    if (return_type::OK != systems_.back().configure(hardware_info))
+    {
       throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
     }
     import_state_interfaces(systems_.back());
@@ -147,9 +141,7 @@ public:
   std::map<std::string, CommandInterface> command_interface_map_;
 };
 
-ResourceManager::ResourceManager()
-: resource_storage_(std::make_unique<ResourceStorage>())
-{}
+ResourceManager::ResourceManager() : resource_storage_(std::make_unique<ResourceStorage>()) {}
 
 ResourceManager::~ResourceManager() = default;
 
@@ -166,20 +158,25 @@ void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfac
   const std::string actuator_type = "actuator";
 
   const auto hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf);
-  for (const auto & hardware : hardware_info) {
-    if (hardware.type == actuator_type) {
+  for (const auto & hardware : hardware_info)
+  {
+    if (hardware.type == actuator_type)
+    {
       resource_storage_->initialize_actuator(hardware, claimed_command_interface_map_);
     }
-    if (hardware.type == sensor_type) {
+    if (hardware.type == sensor_type)
+    {
       resource_storage_->initialize_sensor(hardware);
     }
-    if (hardware.type == system_type) {
+    if (hardware.type == system_type)
+    {
       resource_storage_->initialize_system(hardware, claimed_command_interface_map_);
     }
   }
 
   // throw on missing state and command interfaces, not specified keys are being ignored
-  if (validate_interfaces) {
+  if (validate_interfaces)
+  {
     validate_storage(hardware_info);
   }
 }
@@ -192,9 +189,9 @@ void ResourceManager::release_command_interface(const std::string & key)
 
 LoanedStateInterface ResourceManager::claim_state_interface(const std::string & key)
 {
-  if (!state_interface_exists(key)) {
-    throw std::runtime_error(
-            std::string("State interface with key '") + key + "' does not exist");
+  if (!state_interface_exists(key))
+  {
+    throw std::runtime_error(std::string("State interface with key '") + key + "' does not exist");
   }
 
   return LoanedStateInterface(resource_storage_->state_interface_map_.at(key));
@@ -203,7 +200,8 @@ LoanedStateInterface ResourceManager::claim_state_interface(const std::string & 
 std::vector<std::string> ResourceManager::state_interface_keys() const
 {
   std::vector<std::string> keys;
-  for (const auto & item : resource_storage_->state_interface_map_) {
+  for (const auto & item : resource_storage_->state_interface_map_)
+  {
     keys.push_back(std::get<0>(item));
   }
   return keys;
@@ -217,7 +215,8 @@ bool ResourceManager::state_interface_exists(const std::string & key) const
 
 bool ResourceManager::command_interface_is_claimed(const std::string & key) const
 {
-  if (!command_interface_exists(key)) {
+  if (!command_interface_exists(key))
+  {
     return false;
   }
 
@@ -227,15 +226,16 @@ bool ResourceManager::command_interface_is_claimed(const std::string & key) cons
 
 LoanedCommandInterface ResourceManager::claim_command_interface(const std::string & key)
 {
-  if (!command_interface_exists(key)) {
-    throw std::runtime_error(
-            std::string("Command interface with '") + key + "' does not exist");
+  if (!command_interface_exists(key))
+  {
+    throw std::runtime_error(std::string("Command interface with '") + key + "' does not exist");
   }
 
   std::lock_guard<decltype(resource_lock_)> lg(resource_lock_);
-  if (command_interface_is_claimed(key)) {
+  if (command_interface_is_claimed(key))
+  {
     throw std::runtime_error(
-            std::string("Command interface with '") + key + "' is already claimed");
+      std::string("Command interface with '") + key + "' is already claimed");
   }
 
   claimed_command_interface_map_[key] = true;
@@ -247,7 +247,8 @@ LoanedCommandInterface ResourceManager::claim_command_interface(const std::strin
 std::vector<std::string> ResourceManager::command_interface_keys() const
 {
   std::vector<std::string> keys;
-  for (const auto & item : resource_storage_->command_interface_map_) {
+  for (const auto & item : resource_storage_->command_interface_map_)
+  {
     keys.push_back(std::get<0>(item));
   }
   return keys;
@@ -261,8 +262,7 @@ bool ResourceManager::command_interface_exists(const std::string & key) const
 
 void ResourceManager::import_component(std::unique_ptr<ActuatorInterface> actuator)
 {
-  resource_storage_->actuators_.emplace_back(
-    Actuator(std::move(actuator)));
+  resource_storage_->actuators_.emplace_back(Actuator(std::move(actuator)));
   resource_storage_->import_state_interfaces(resource_storage_->actuators_.back());
   resource_storage_->import_command_interfaces(
     resource_storage_->actuators_.back(), claimed_command_interface_map_);
@@ -299,13 +299,16 @@ size_t ResourceManager::system_components_size() const
 
 std::unordered_map<std::string, status> ResourceManager::get_components_status()
 {
-  for (auto & component : resource_storage_->actuators_) {
+  for (auto & component : resource_storage_->actuators_)
+  {
     resource_storage_->hardware_status_map_[component.get_name()] = component.get_status();
   }
-  for (auto & component : resource_storage_->sensors_) {
+  for (auto & component : resource_storage_->sensors_)
+  {
     resource_storage_->hardware_status_map_[component.get_name()] = component.get_status();
   }
-  for (auto & component : resource_storage_->systems_) {
+  for (auto & component : resource_storage_->systems_)
+  {
     resource_storage_->hardware_status_map_[component.get_name()] = component.get_status();
   }
 
@@ -318,12 +321,14 @@ std::string interfaces_to_string(
 {
   std::stringstream ss;
   ss << "Start interfaces: " << std::endl << "[" << std::endl;
-  for (const auto & start_if : start_interfaces) {
+  for (const auto & start_if : start_interfaces)
+  {
     ss << "  " << start_if << std::endl;
   }
   ss << "]" << std::endl;
   ss << "Stop interfaces: " << std::endl << "[" << std::endl;
-  for (const auto & stop_if : stop_interfaces) {
+  for (const auto & stop_if : stop_interfaces)
+  {
     ss << "  " << stop_if << std::endl;
   }
   ss << "]" << std::endl;
@@ -334,29 +339,25 @@ bool ResourceManager::prepare_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
   const std::vector<std::string> & stop_interfaces)
 {
-  for (auto & component : resource_storage_->actuators_) {
-    if (return_type::OK !=
-      component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
+  for (auto & component : resource_storage_->actuators_)
+  {
+    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
     {
       RCUTILS_LOG_ERROR_NAMED(
-        "resource_manager",
-        "Component '%s' did not accept new command resource combination: \n %s",
-        component.get_name().c_str(), interfaces_to_string(
-          start_interfaces,
-          stop_interfaces).c_str());
+        "resource_manager", "Component '%s' did not accept new command resource combination: \n %s",
+        component.get_name().c_str(),
+        interfaces_to_string(start_interfaces, stop_interfaces).c_str());
       return false;
     }
   }
-  for (auto & component : resource_storage_->systems_) {
-    if (return_type::OK !=
-      component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
+  for (auto & component : resource_storage_->systems_)
+  {
+    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
     {
       RCUTILS_LOG_ERROR_NAMED(
-        "resource_manager",
-        "Component '%s' did not accept new command resource combination: \n %s",
-        component.get_name().c_str(), interfaces_to_string(
-          start_interfaces,
-          stop_interfaces).c_str());
+        "resource_manager", "Component '%s' did not accept new command resource combination: \n %s",
+        component.get_name().c_str(),
+        interfaces_to_string(start_interfaces, stop_interfaces).c_str());
       return false;
     }
   }
@@ -367,24 +368,22 @@ bool ResourceManager::perform_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
   const std::vector<std::string> & stop_interfaces)
 {
-  for (auto & component : resource_storage_->actuators_) {
-    if (return_type::OK !=
-      component.perform_command_mode_switch(start_interfaces, stop_interfaces))
+  for (auto & component : resource_storage_->actuators_)
+  {
+    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces))
     {
       RCUTILS_LOG_ERROR_NAMED(
-        "resource_manager",
-        "Component '%s' could not perform switch",
+        "resource_manager", "Component '%s' could not perform switch",
         component.get_name().c_str());
       return false;
     }
   }
-  for (auto & component : resource_storage_->systems_) {
-    if (return_type::OK !=
-      component.perform_command_mode_switch(start_interfaces, stop_interfaces))
+  for (auto & component : resource_storage_->systems_)
+  {
+    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces))
     {
       RCUTILS_LOG_ERROR_NAMED(
-        "resource_manager",
-        "Component '%s' could not perform switch",
+        "resource_manager", "Component '%s' could not perform switch",
         component.get_name().c_str());
       return false;
     }
@@ -394,49 +393,60 @@ bool ResourceManager::perform_command_mode_switch(
 
 void ResourceManager::start_components()
 {
-  for (auto & component : resource_storage_->actuators_) {
+  for (auto & component : resource_storage_->actuators_)
+  {
     component.start();
   }
-  for (auto & component : resource_storage_->sensors_) {
+  for (auto & component : resource_storage_->sensors_)
+  {
     component.start();
   }
-  for (auto & component : resource_storage_->systems_) {
+  for (auto & component : resource_storage_->systems_)
+  {
     component.start();
   }
 }
 
 void ResourceManager::stop_components()
 {
-  for (auto & component : resource_storage_->actuators_) {
+  for (auto & component : resource_storage_->actuators_)
+  {
     component.stop();
   }
-  for (auto & component : resource_storage_->sensors_) {
+  for (auto & component : resource_storage_->sensors_)
+  {
     component.stop();
   }
-  for (auto & component : resource_storage_->systems_) {
+  for (auto & component : resource_storage_->systems_)
+  {
     component.stop();
   }
 }
 
 void ResourceManager::read()
 {
-  for (auto & component : resource_storage_->actuators_) {
+  for (auto & component : resource_storage_->actuators_)
+  {
     component.read();
   }
-  for (auto & component : resource_storage_->sensors_) {
+  for (auto & component : resource_storage_->sensors_)
+  {
     component.read();
   }
-  for (auto & component : resource_storage_->systems_) {
+  for (auto & component : resource_storage_->systems_)
+  {
     component.read();
   }
 }
 
 void ResourceManager::write()
 {
-  for (auto & component : resource_storage_->actuators_) {
+  for (auto & component : resource_storage_->actuators_)
+  {
     component.write();
   }
-  for (auto & component : resource_storage_->systems_) {
+  for (auto & component : resource_storage_->systems_)
+  {
     component.write();
   }
 }
@@ -447,36 +457,48 @@ void ResourceManager::validate_storage(
   std::vector<std::string> missing_state_keys = {};
   std::vector<std::string> missing_command_keys = {};
 
-  for (const auto & hardware : hardware_info) {
-    for (const auto & joint : hardware.joints) {
-      for (const auto & state_interface : joint.state_interfaces) {
-        if (!state_interface_exists(joint.name + "/" + state_interface.name)) {
+  for (const auto & hardware : hardware_info)
+  {
+    for (const auto & joint : hardware.joints)
+    {
+      for (const auto & state_interface : joint.state_interfaces)
+      {
+        if (!state_interface_exists(joint.name + "/" + state_interface.name))
+        {
           missing_state_keys.emplace_back(joint.name + "/" + state_interface.name);
         }
       }
-      for (const auto & command_interface : joint.command_interfaces) {
-        if (!command_interface_exists(joint.name + "/" + command_interface.name)) {
+      for (const auto & command_interface : joint.command_interfaces)
+      {
+        if (!command_interface_exists(joint.name + "/" + command_interface.name))
+        {
           missing_command_keys.emplace_back(joint.name + "/" + command_interface.name);
         }
       }
     }
-    for (const auto & sensor : hardware.sensors) {
-      for (const auto & state_interface : sensor.state_interfaces) {
-        if (!state_interface_exists(sensor.name + "/" + state_interface.name)) {
+    for (const auto & sensor : hardware.sensors)
+    {
+      for (const auto & state_interface : sensor.state_interfaces)
+      {
+        if (!state_interface_exists(sensor.name + "/" + state_interface.name))
+        {
           missing_state_keys.emplace_back(sensor.name + "/" + state_interface.name);
         }
       }
     }
   }
 
-  if (!missing_state_keys.empty() || !missing_command_keys.empty()) {
+  if (!missing_state_keys.empty() || !missing_command_keys.empty())
+  {
     std::string err_msg = "Wrong state or command interface configuration.\n";
     err_msg += "missing state interfaces:\n";
-    for (const auto & missing_key : missing_state_keys) {
+    for (const auto & missing_key : missing_state_keys)
+    {
       err_msg += "' " + missing_key + " '" + "\t";
     }
     err_msg += "\nmissing command interfaces:\n";
-    for (const auto & missing_key : missing_command_keys) {
+    for (const auto & missing_key : missing_command_keys)
+    {
       err_msg += "' " + missing_key + " '" + "\t";
     }
 

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -27,10 +27,7 @@
 
 namespace hardware_interface
 {
-
-Sensor::Sensor(std::unique_ptr<SensorInterface> impl)
-: impl_(std::move(impl))
-{}
+Sensor::Sensor(std::unique_ptr<SensorInterface> impl) : impl_(std::move(impl)) {}
 
 return_type Sensor::configure(const HardwareInfo & sensor_info)
 {
@@ -42,29 +39,14 @@ std::vector<StateInterface> Sensor::export_state_interfaces()
   return impl_->export_state_interfaces();
 }
 
-return_type Sensor::start()
-{
-  return impl_->start();
-}
+return_type Sensor::start() { return impl_->start(); }
 
-return_type Sensor::stop()
-{
-  return impl_->stop();
-}
+return_type Sensor::stop() { return impl_->stop(); }
 
-std::string Sensor::get_name() const
-{
-  return impl_->get_name();
-}
+std::string Sensor::get_name() const { return impl_->get_name(); }
 
-status Sensor::get_status() const
-{
-  return impl_->get_status();
-}
+status Sensor::get_status() const { return impl_->get_status(); }
 
-return_type Sensor::read()
-{
-  return impl_->read();
-}
+return_type Sensor::read() { return impl_->read(); }
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -27,10 +27,7 @@
 
 namespace hardware_interface
 {
-
-System::System(std::unique_ptr<SystemInterface> impl)
-: impl_(std::move(impl))
-{}
+System::System(std::unique_ptr<SystemInterface> impl) : impl_(std::move(impl)) {}
 
 return_type System::configure(const HardwareInfo & system_info)
 {
@@ -61,34 +58,16 @@ return_type System::perform_command_mode_switch(
   return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
 }
 
-return_type System::start()
-{
-  return impl_->start();
-}
+return_type System::start() { return impl_->start(); }
 
-return_type System::stop()
-{
-  return impl_->stop();
-}
+return_type System::stop() { return impl_->stop(); }
 
-std::string System::get_name() const
-{
-  return impl_->get_name();
-}
+std::string System::get_name() const { return impl_->get_name(); }
 
-status System::get_status() const
-{
-  return impl_->get_status();
-}
+status System::get_status() const { return impl_->get_status(); }
 
-return_type System::read()
-{
-  return impl_->read();
-}
+return_type System::read() { return impl_->read(); }
 
-return_type System::write()
-{
-  return impl_->write();
-}
+return_type System::write() { return impl_->write(); }
 
 }  // namespace hardware_interface

--- a/hardware_interface/test/fake_components/test_generic_system.cpp
+++ b/hardware_interface/test/fake_components/test_generic_system.cpp
@@ -23,8 +23,8 @@
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "hardware_interface/resource_manager.hpp"
-#include "ros2_control_test_assets/descriptions.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
 
 class TestGenericSystem : public ::testing::Test
 {
@@ -270,18 +270,18 @@ protected:
   std::string hardware_system_2dof_standard_interfaces_with_offset_;
 };
 
-TEST_F(TestGenericSystem, load_generic_system_2dof) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head + hardware_system_2dof_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, load_generic_system_2dof)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_ +
+              ros2_control_test_assets::urdf_tail;
   ASSERT_NO_THROW(hardware_interface::ResourceManager rm(urdf));
 }
 
 // Test inspired by hardware_interface/test_resource_manager.cpp
-TEST_F(TestGenericSystem, generic_system_2dof_symetric_interfaces) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head + hardware_system_2dof_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_symetric_interfaces)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_ +
+              ros2_control_test_assets::urdf_tail;
   hardware_interface::ResourceManager rm(urdf);
 
   // Check interfaces
@@ -307,10 +307,10 @@ TEST_F(TestGenericSystem, generic_system_2dof_symetric_interfaces) {
 }
 
 // Test inspired by hardware_interface/test_resource_manager.cpp
-TEST_F(TestGenericSystem, generic_system_2dof_asymetric_interfaces) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head + hardware_system_2dof_asymetric_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_asymetric_interfaces)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_asymetric_ +
+              ros2_control_test_assets::urdf_tail;
   hardware_interface::ResourceManager rm(urdf);
 
   // Check interfaces
@@ -344,8 +344,8 @@ TEST_F(TestGenericSystem, generic_system_2dof_asymetric_interfaces) {
   ASSERT_ANY_THROW(rm.claim_command_interface("joint1/acceleration"));
   ASSERT_ANY_THROW(rm.claim_command_interface("joint2/position"));
   ASSERT_ANY_THROW(rm.claim_command_interface("joint2/position"));
-  hardware_interface::LoanedCommandInterface j2a_c = rm.claim_command_interface(
-    "joint2/acceleration");
+  hardware_interface::LoanedCommandInterface j2a_c =
+    rm.claim_command_interface("joint2/acceleration");
 
   ASSERT_EQ(0.0, j1v_s.get_value());
   ASSERT_EQ(0.7854, j2p_s.get_value());
@@ -445,20 +445,18 @@ void generic_system_functional_test(std::string urdf, double offset = 0)
   EXPECT_EQ(status_map["GenericSystem2dof"], hardware_interface::status::STOPPED);
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_functionality) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_standard_interfaces_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_functionality)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_standard_interfaces_ +
+              ros2_control_test_assets::urdf_tail;
 
   generic_system_functional_test(urdf);
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_other_interfaces) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_other_interface_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_other_interfaces)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_with_other_interface_ +
+              ros2_control_test_assets::urdf_tail;
   hardware_interface::ResourceManager rm(urdf);
 
   // Check interfaces
@@ -536,12 +534,10 @@ TEST_F(TestGenericSystem, generic_system_2dof_other_interfaces) {
   ASSERT_EQ(0.99, vo_c.get_value());
 }
 
-
-TEST_F(TestGenericSystem, generic_system_2dof_sensor) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_sensor_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_sensor)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_with_sensor_ +
+              ros2_control_test_assets::urdf_tail;
   hardware_interface::ResourceManager rm(urdf);
 
   // Check interfaces
@@ -756,20 +752,19 @@ void test_generic_system_with_fake_sensor_commands(std::string urdf)
   ASSERT_EQ(4.44, sty_c.get_value());
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_sensor_fake_command_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_with_sensor_fake_command_ +
+              ros2_control_test_assets::urdf_tail;
 
   test_generic_system_with_fake_sensor_commands(urdf);
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command_True) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_sensor_fake_command_True_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_sensor_fake_command_True)
+{
+  auto urdf = ros2_control_test_assets::urdf_head +
+              hardware_system_2dof_with_sensor_fake_command_True_ +
+              ros2_control_test_assets::urdf_tail;
 
   test_generic_system_with_fake_sensor_commands(urdf);
 }
@@ -838,20 +833,19 @@ void test_generic_system_with_mimic_joint(std::string urdf)
   ASSERT_EQ(0.05, j1v_c.get_value());
 }
 
-TEST_F(TestGenericSystem, hardware_system_2dof_with_mimic_joint) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_with_mimic_joint_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, hardware_system_2dof_with_mimic_joint)
+{
+  auto urdf = ros2_control_test_assets::urdf_head + hardware_system_2dof_with_mimic_joint_ +
+              ros2_control_test_assets::urdf_tail;
 
   test_generic_system_with_mimic_joint(urdf);
 }
 
-TEST_F(TestGenericSystem, generic_system_2dof_functionality_with_offset) {
-  auto urdf =
-    ros2_control_test_assets::urdf_head +
-    hardware_system_2dof_standard_interfaces_with_offset_ +
-    ros2_control_test_assets::urdf_tail;
+TEST_F(TestGenericSystem, generic_system_2dof_functionality_with_offset)
+{
+  auto urdf = ros2_control_test_assets::urdf_head +
+              hardware_system_2dof_standard_interfaces_with_offset_ +
+              ros2_control_test_assets::urdf_tail;
 
   generic_system_functional_test(urdf, -3);
 }

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -22,11 +22,11 @@
 
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/actuator_interface.hpp"
-#include "hardware_interface/sensor_interface.hpp"
-#include "hardware_interface/sensor.hpp"
-#include "hardware_interface/system_interface.hpp"
-#include "hardware_interface/system.hpp"
 #include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/sensor.hpp"
+#include "hardware_interface/sensor_interface.hpp"
+#include "hardware_interface/system.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/hardware_interface_status_values.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
@@ -35,7 +35,6 @@ using namespace ::testing;  // NOLINT
 
 namespace test_components
 {
-
 class DummyActuator : public hardware_interface::ActuatorInterface
 {
   hardware_interface::return_type configure(
@@ -49,12 +48,10 @@ class DummyActuator : public hardware_interface::ActuatorInterface
   {
     // We can read a position and a velocity
     std::vector<hardware_interface::StateInterface> state_interfaces;
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint1", hardware_interface::HW_IF_POSITION, &position_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint1", hardware_interface::HW_IF_POSITION, &position_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_));
 
     return state_interfaces;
   }
@@ -63,27 +60,17 @@ class DummyActuator : public hardware_interface::ActuatorInterface
   {
     // We can command in velocity
     std::vector<hardware_interface::CommandInterface> command_interfaces;
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_));
 
     return command_interfaces;
   }
 
-  hardware_interface::return_type start() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type start() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type stop() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type stop() override { return hardware_interface::return_type::OK; }
 
-  std::string get_name() const override
-  {
-    return "DummyActuator";
-  }
+  std::string get_name() const override { return "DummyActuator"; }
 
   hardware_interface::status get_status() const override
   {
@@ -129,20 +116,11 @@ class DummySensor : public hardware_interface::SensorInterface
     return state_interfaces;
   }
 
-  hardware_interface::return_type start() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type start() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type stop() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type stop() override { return hardware_interface::return_type::OK; }
 
-  std::string get_name() const override
-  {
-    return "DummySensor";
-  }
+  std::string get_name() const override { return "DummySensor"; }
 
   hardware_interface::status get_status() const override
   {
@@ -172,24 +150,18 @@ class DummySystem : public hardware_interface::SystemInterface
   {
     // We can read a position and a velocity
     std::vector<hardware_interface::StateInterface> state_interfaces;
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint1", hardware_interface::HW_IF_POSITION, &position_state_[0]));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_[0]));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint2", hardware_interface::HW_IF_POSITION, &position_state_[1]));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_state_[1]));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint3", hardware_interface::HW_IF_POSITION, &position_state_[2]));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_state_[2]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint1", hardware_interface::HW_IF_POSITION, &position_state_[0]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_state_[0]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint2", hardware_interface::HW_IF_POSITION, &position_state_[1]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_state_[1]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint3", hardware_interface::HW_IF_POSITION, &position_state_[2]));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_state_[2]));
 
     return state_interfaces;
   }
@@ -198,33 +170,21 @@ class DummySystem : public hardware_interface::SystemInterface
   {
     // We can command in velocity
     std::vector<hardware_interface::CommandInterface> command_interfaces;
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_[0]));
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_command_[1]));
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_command_[2]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      "joint1", hardware_interface::HW_IF_VELOCITY, &velocity_command_[0]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      "joint2", hardware_interface::HW_IF_VELOCITY, &velocity_command_[1]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      "joint3", hardware_interface::HW_IF_VELOCITY, &velocity_command_[2]));
 
     return command_interfaces;
   }
 
-  hardware_interface::return_type start() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type start() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type stop() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type stop() override { return hardware_interface::return_type::OK; }
 
-  std::string get_name() const override
-  {
-    return "DummySystem";
-  }
+  std::string get_name() const override { return "DummySystem"; }
 
   hardware_interface::status get_status() const override
   {
@@ -239,7 +199,8 @@ class DummySystem : public hardware_interface::SystemInterface
 
   hardware_interface::return_type write() override
   {
-    for (auto i = 0; i < 3; ++i) {
+    for (auto i = 0; i < 3; ++i)
+    {
       position_state_[i] += velocity_command_[0];
       velocity_state_[i] = velocity_command_[0];
     }
@@ -262,45 +223,27 @@ class DummySystemPreparePerform : public hardware_interface::SystemInterface
     return hardware_interface::return_type::OK;
   }
 
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() override
-  {
-    return {};
-  }
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override { return {}; }
 
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     return {};
   }
 
-  hardware_interface::return_type start() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type start() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type stop() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type stop() override { return hardware_interface::return_type::OK; }
 
-  std::string get_name() const override
-  {
-    return "DummySystemPreparePerform";
-  }
+  std::string get_name() const override { return "DummySystemPreparePerform"; }
 
   hardware_interface::status get_status() const override
   {
     return hardware_interface::status::UNKNOWN;
   }
 
-  hardware_interface::return_type read() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type read() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type write() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type write() override { return hardware_interface::return_type::OK; }
 
   // Custom prepare/perform functions
   hardware_interface::return_type prepare_command_mode_switch(
@@ -308,10 +251,12 @@ class DummySystemPreparePerform : public hardware_interface::SystemInterface
     const std::vector<std::string> & stop_interfaces) override
   {
     // Criteria to test against
-    if (start_interfaces.size() != 1) {
+    if (start_interfaces.size() != 1)
+    {
       return hardware_interface::return_type::ERROR;
     }
-    if (stop_interfaces.size() != 2) {
+    if (stop_interfaces.size() != 2)
+    {
       return hardware_interface::return_type::ERROR;
     }
     return hardware_interface::return_type::OK;
@@ -322,10 +267,12 @@ class DummySystemPreparePerform : public hardware_interface::SystemInterface
     const std::vector<std::string> & stop_interfaces) override
   {
     // Criteria to test against
-    if (start_interfaces.size() != 1) {
+    if (start_interfaces.size() != 1)
+    {
       return hardware_interface::return_type::ERROR;
     }
-    if (stop_interfaces.size() != 2) {
+    if (stop_interfaces.size() != 2)
+    {
       return hardware_interface::return_type::ERROR;
     }
     return hardware_interface::return_type::OK;
@@ -336,8 +283,7 @@ class DummySystemPreparePerform : public hardware_interface::SystemInterface
 
 TEST(TestComponentInterfaces, dummy_actuator)
 {
-  hardware_interface::Actuator actuator_hw(
-    std::make_unique<test_components::DummyActuator>());
+  hardware_interface::Actuator actuator_hw(std::make_unique<test_components::DummyActuator>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, actuator_hw.configure(mock_hw_info));
@@ -357,27 +303,25 @@ TEST(TestComponentInterfaces, dummy_actuator)
   command_interfaces[0].set_value(1.0);  // velocity
   ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.write());
 
-  for (auto step = 1u; step <= 10; ++step) {
+  for (auto step = 1u; step <= 10; ++step)
+  {
     ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.read());
 
     ASSERT_EQ(step, state_interfaces[0].get_value());  // position value
-    ASSERT_EQ(1u, state_interfaces[1].get_value());  // velocity
+    ASSERT_EQ(1u, state_interfaces[1].get_value());    // velocity
 
     ASSERT_EQ(hardware_interface::return_type::OK, actuator_hw.write());
   }
 
   EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    actuator_hw.prepare_command_mode_switch({""}, {""}));
+    hardware_interface::return_type::OK, actuator_hw.prepare_command_mode_switch({""}, {""}));
   EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    actuator_hw.perform_command_mode_switch({""}, {""}));
+    hardware_interface::return_type::OK, actuator_hw.perform_command_mode_switch({""}, {""}));
 }
 
 TEST(TestComponentInterfaces, dummy_sensor)
 {
-  hardware_interface::Sensor sensor_hw(
-    std::make_unique<test_components::DummySensor>());
+  hardware_interface::Sensor sensor_hw(std::make_unique<test_components::DummySensor>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, sensor_hw.configure(mock_hw_info));
@@ -391,8 +335,7 @@ TEST(TestComponentInterfaces, dummy_sensor)
 
 TEST(TestComponentInterfaces, dummy_system)
 {
-  hardware_interface::System system_hw(
-    std::make_unique<test_components::DummySystem>());
+  hardware_interface::System system_hw(std::make_unique<test_components::DummySystem>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
   EXPECT_EQ(hardware_interface::return_type::OK, system_hw.configure(mock_hw_info));
@@ -426,25 +369,22 @@ TEST(TestComponentInterfaces, dummy_system)
   command_interfaces[2].set_value(1.0);  // velocity
   ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write());
 
-  for (auto step = 1u; step <= 10; ++step) {
+  for (auto step = 1u; step <= 10; ++step)
+  {
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read());
 
     ASSERT_EQ(step, state_interfaces[0].get_value());  // position value
-    ASSERT_EQ(1u, state_interfaces[1].get_value());  // velocity
+    ASSERT_EQ(1u, state_interfaces[1].get_value());    // velocity
     ASSERT_EQ(step, state_interfaces[2].get_value());  // position value
-    ASSERT_EQ(1u, state_interfaces[3].get_value());  // velocity
+    ASSERT_EQ(1u, state_interfaces[3].get_value());    // velocity
     ASSERT_EQ(step, state_interfaces[4].get_value());  // position value
-    ASSERT_EQ(1u, state_interfaces[5].get_value());  // velocity
+    ASSERT_EQ(1u, state_interfaces[5].get_value());    // velocity
 
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write());
   }
 
-  EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    system_hw.prepare_command_mode_switch({}, {}));
-  EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    system_hw.perform_command_mode_switch({}, {}));
+  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch({}, {}));
+  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.perform_command_mode_switch({}, {}));
 }
 
 TEST(TestComponentInterfaces, dummy_command_mode_system)
@@ -465,11 +405,9 @@ TEST(TestComponentInterfaces, dummy_command_mode_system)
     hardware_interface::return_type::ERROR,
     system_hw.perform_command_mode_switch(one_key, one_key));
   EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    system_hw.prepare_command_mode_switch(one_key, two_keys));
+    hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch(one_key, two_keys));
   EXPECT_EQ(
-    hardware_interface::return_type::OK,
-    system_hw.perform_command_mode_switch(one_key, two_keys));
+    hardware_interface::return_type::OK, system_hw.perform_command_mode_switch(one_key, two_keys));
   EXPECT_EQ(
     hardware_interface::return_type::ERROR,
     system_hw.prepare_command_mode_switch(two_keys, one_key));

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -17,23 +17,21 @@
 
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "ros2_control_test_assets/descriptions.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
 
 using namespace ::testing;  // NOLINT
 
 class TestComponentParser : public Test
 {
 protected:
-  void SetUp() override
-  {
-  }
+  void SetUp() override {}
 };
 
-using hardware_interface::parse_control_resources_from_urdf;
+using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
-using hardware_interface::HW_IF_EFFORT;
+using hardware_interface::parse_control_resources_from_urdf;
 
 TEST_F(TestComponentParser, empty_string_throws_error)
 {
@@ -195,8 +193,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_sens
   EXPECT_EQ(hardware_info.name, "RRBotSystemWithSensor");
   EXPECT_EQ(hardware_info.type, "system");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/RRBotSystemWithSensorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/RRBotSystemWithSensorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_write_for_sec"), "2");
 
@@ -281,8 +278,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.name, "RRBotModularJoint1");
   EXPECT_EQ(hardware_info.type, "actuator");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/PositionActuatorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/PositionActuatorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_write_for_sec"), "1.23");
 
@@ -295,8 +291,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.name, "RRBotModularJoint2");
   EXPECT_EQ(hardware_info.type, "actuator");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/PositionActuatorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/PositionActuatorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_read_for_sec"), "3");
 
@@ -318,8 +313,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.name, "RRBotModularJoint1");
   EXPECT_EQ(hardware_info.type, "actuator");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/VelocityActuatorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/VelocityActuatorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_write_for_sec"), "1.23");
 
@@ -335,8 +329,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   ASSERT_THAT(hardware_info.transmissions[0].joints, SizeIs(1));
   EXPECT_THAT(hardware_info.transmissions[0].joints[0].name, "joint1");
   EXPECT_THAT(
-    hardware_info.transmissions[0].joints[0].mechanical_reduction,
-    DoubleNear(1024.0 / M_PI, 0.01));
+    hardware_info.transmissions[0].joints[0].mechanical_reduction, DoubleNear(1024.0 / M_PI, 0.01));
   ASSERT_THAT(hardware_info.transmissions[0].actuators, SizeIs(1));
   EXPECT_THAT(hardware_info.transmissions[0].actuators[0].name, "actuator1");
 
@@ -345,8 +338,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   EXPECT_EQ(hardware_info.name, "RRBotModularJoint2");
   EXPECT_EQ(hardware_info.type, "actuator");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/VelocityActuatorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/VelocityActuatorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_read_for_sec"), "3");
 
@@ -362,9 +354,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
 
   EXPECT_EQ(hardware_info.name, "RRBotModularPositionSensorJoint1");
   EXPECT_EQ(hardware_info.type, "sensor");
-  EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/PositionSensorHardware");
+  EXPECT_EQ(hardware_info.hardware_class_type, "ros2_control_demo_hardware/PositionSensorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(1));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_read_for_sec"), "2");
 
@@ -375,7 +365,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_modular_robot
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, IsEmpty());
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(1));
   EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
-
 
   hardware_info = control_hardware.at(3);
 
@@ -407,8 +396,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_tr
   EXPECT_EQ(hardware_info.name, "RRBotModularWrist");
   EXPECT_EQ(hardware_info.type, "system");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/ActuatorHardwareMultiDOF");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/ActuatorHardwareMultiDOF");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_write_for_sec"), "1.23");
 
@@ -440,10 +428,9 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_tr
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_sensor_only)
 {
-  std::string urdf_to_test =
-    std::string(ros2_control_test_assets::urdf_head) +
-    ros2_control_test_assets::valid_urdf_ros2_control_sensor_only +
-    ros2_control_test_assets::urdf_tail;
+  std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
+                             ros2_control_test_assets::valid_urdf_ros2_control_sensor_only +
+                             ros2_control_test_assets::urdf_tail;
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
   ASSERT_THAT(control_hardware, SizeIs(1));
   auto hardware_info = control_hardware.at(0);
@@ -470,10 +457,9 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_sensor_only)
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_only)
 {
-  std::string urdf_to_test =
-    std::string(ros2_control_test_assets::urdf_head) +
-    ros2_control_test_assets::valid_urdf_ros2_control_actuator_only +
-    ros2_control_test_assets::urdf_tail;
+  std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
+                             ros2_control_test_assets::valid_urdf_ros2_control_actuator_only +
+                             ros2_control_test_assets::urdf_tail;
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
   ASSERT_THAT(control_hardware, SizeIs(1));
   auto hardware_info = control_hardware.at(0);
@@ -481,8 +467,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_actuator_only)
   EXPECT_EQ(hardware_info.name, "ActuatorModularJoint1");
   EXPECT_EQ(hardware_info.type, "actuator");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/VelocityActuatorHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/VelocityActuatorHardware");
   ASSERT_THAT(hardware_info.hardware_parameters, SizeIs(2));
   EXPECT_EQ(hardware_info.hardware_parameters.at("example_param_write_for_sec"), "1.13");
 
@@ -530,8 +515,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_gpio
   EXPECT_EQ(hardware_info.name, "RRBotSystemWithGPIO");
   EXPECT_EQ(hardware_info.type, "system");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/RRBotSystemWithGPIOHardware");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/RRBotSystemWithGPIOHardware");
 
   ASSERT_THAT(hardware_info.joints, SizeIs(2));
 
@@ -574,8 +558,7 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_d
   EXPECT_EQ(hardware_info.name, "RRBotSystemWithSizeAndDataType");
   EXPECT_EQ(hardware_info.type, "system");
   EXPECT_EQ(
-    hardware_info.hardware_class_type,
-    "ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType");
+    hardware_info.hardware_class_type, "ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType");
 
   ASSERT_THAT(hardware_info.joints, SizeIs(1));
 
@@ -609,19 +592,17 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_d
 
 TEST_F(TestComponentParser, negative_size_throws_error)
 {
-  std::string urdf_to_test =
-    std::string(ros2_control_test_assets::urdf_head) +
-    ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size +
-    ros2_control_test_assets::urdf_tail;
+  std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
+                             ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size +
+                             ros2_control_test_assets::urdf_tail;
   ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
 }
 
 TEST_F(TestComponentParser, noninteger_size_throws_error)
 {
-  std::string urdf_to_test =
-    std::string(ros2_control_test_assets::urdf_head) +
-    ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size2 +
-    ros2_control_test_assets::urdf_tail;
+  std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
+                             ros2_control_test_assets::invalid_urdf2_ros2_control_illegal_size2 +
+                             ros2_control_test_assets::urdf_tail;
   ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
 }
 

--- a/hardware_interface/test/test_components/test_actuator.cpp
+++ b/hardware_interface/test/test_components/test_actuator.cpp
@@ -15,8 +15,8 @@
 #include <memory>
 #include <vector>
 
-#include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/base_interface.hpp"
 
 using hardware_interface::ActuatorInterface;
 using hardware_interface::BaseInterface;
@@ -29,7 +29,8 @@ class TestActuator : public BaseInterface<ActuatorInterface>
 {
   return_type configure(const hardware_interface::HardwareInfo & info) override
   {
-    if (configure_default(info) != return_type::OK) {
+    if (configure_default(info) != return_type::OK)
+    {
       return return_type::ERROR;
     }
 
@@ -50,21 +51,12 @@ class TestActuator : public BaseInterface<ActuatorInterface>
   std::vector<StateInterface> export_state_interfaces() override
   {
     std::vector<StateInterface> state_interfaces;
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[0].name, info_.joints[0].state_interfaces[0].name, &position_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[0].name, info_.joints[0].state_interfaces[1].name, &velocity_state_));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        info_.joints[0].name,
-        info_.joints[0].state_interfaces[0].name,
-        &position_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        info_.joints[0].name,
-        info_.joints[0].state_interfaces[1].name,
-        &velocity_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        info_.joints[0].name,
-        "some_unlisted_interface",
-        nullptr));
+      hardware_interface::StateInterface(info_.joints[0].name, "some_unlisted_interface", nullptr));
 
     return state_interfaces;
   }
@@ -72,11 +64,8 @@ class TestActuator : public BaseInterface<ActuatorInterface>
   std::vector<CommandInterface> export_command_interfaces() override
   {
     std::vector<CommandInterface> command_interfaces;
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        info_.joints[0].name,
-        info_.joints[0].command_interfaces[0].name,
-        &velocity_command_));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[0].name, info_.joints[0].command_interfaces[0].name, &velocity_command_));
 
     return command_interfaces;
   }
@@ -93,15 +82,9 @@ class TestActuator : public BaseInterface<ActuatorInterface>
     return return_type::OK;
   }
 
-  return_type read() override
-  {
-    return return_type::OK;
-  }
+  return_type read() override { return return_type::OK; }
 
-  return_type write() override
-  {
-    return return_type::OK;
-  }
+  return_type write() override { return return_type::OK; }
 
 private:
   double position_state_ = 0.0;

--- a/hardware_interface/test/test_components/test_sensor.cpp
+++ b/hardware_interface/test/test_components/test_sensor.cpp
@@ -28,11 +28,13 @@ class TestSensor : public BaseInterface<SensorInterface>
 {
   return_type configure(const hardware_interface::HardwareInfo & info) override
   {
-    if (configure_default(info) != return_type::OK) {
+    if (configure_default(info) != return_type::OK)
+    {
       return return_type::ERROR;
     }
     // can only give feedback state for velocity
-    if (info_.sensors[0].state_interfaces.size() != 1) {
+    if (info_.sensors[0].state_interfaces.size() != 1)
+    {
       return return_type::ERROR;
     }
     return return_type::OK;
@@ -41,11 +43,8 @@ class TestSensor : public BaseInterface<SensorInterface>
   std::vector<StateInterface> export_state_interfaces() override
   {
     std::vector<StateInterface> state_interfaces;
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        info_.sensors[0].name,
-        info_.sensors[0].state_interfaces[0].name,
-        &velocity_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.sensors[0].name, info_.sensors[0].state_interfaces[0].name, &velocity_state_));
 
     return state_interfaces;
   }
@@ -62,10 +61,7 @@ class TestSensor : public BaseInterface<SensorInterface>
     return return_type::OK;
   }
 
-  return_type read() override
-  {
-    return return_type::OK;
-  }
+  return_type read() override { return return_type::OK; }
 
 private:
   double velocity_state_ = 0.0;

--- a/hardware_interface/test/test_components/test_system.cpp
+++ b/hardware_interface/test/test_components/test_system.cpp
@@ -32,17 +32,14 @@ class TestSystem : public BaseInterface<SystemInterface>
   std::vector<StateInterface> export_state_interfaces() override
   {
     std::vector<StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i) {
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name,
-          hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
+    for (auto i = 0u; i < info_.joints.size(); ++i)
+    {
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
     }
 
     return state_interfaces;
@@ -51,10 +48,10 @@ class TestSystem : public BaseInterface<SystemInterface>
   std::vector<CommandInterface> export_command_interfaces() override
   {
     std::vector<CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i) {
-      command_interfaces.emplace_back(
-        hardware_interface::CommandInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
+    for (auto i = 0u; i < info_.joints.size(); ++i)
+    {
+      command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
     }
 
     return command_interfaces;
@@ -72,15 +69,9 @@ class TestSystem : public BaseInterface<SystemInterface>
     return return_type::OK;
   }
 
-  return_type read() override
-  {
-    return return_type::OK;
-  }
+  return_type read() override { return return_type::OK; }
 
-  return_type write() override
-  {
-    return return_type::OK;
-  }
+  return_type write() override { return return_type::OK; }
 
 private:
   std::array<double, 2> velocity_command_ = {0.0, 0.0};

--- a/hardware_interface/test/test_hardware_components/test_force_torque_sensor.cpp
+++ b/hardware_interface/test/test_hardware_components/test_force_torque_sensor.cpp
@@ -20,27 +20,32 @@
 #include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/sensor_interface.hpp"
 
-using hardware_interface::status;
-using hardware_interface::return_type;
-using hardware_interface::StateInterface;
 using hardware_interface::BaseInterface;
+using hardware_interface::return_type;
 using hardware_interface::SensorInterface;
+using hardware_interface::StateInterface;
+using hardware_interface::status;
 
 namespace test_hardware_components
 {
-
 class TestForceTorqueSensor : public BaseInterface<SensorInterface>
 {
   return_type configure(const hardware_interface::HardwareInfo & sensor_info) override
   {
-    if (configure_default(sensor_info) != return_type::OK) {
+    if (configure_default(sensor_info) != return_type::OK)
+    {
       return return_type::ERROR;
     }
 
     const auto & state_interfaces = info_.sensors[0].state_interfaces;
-    if (state_interfaces.size() != 6) {return return_type::ERROR;}
-    for (const auto & ft_key : {"fx", "fy", "fz", "tx", "ty", "tz"}) {
-      if (std::find_if(
+    if (state_interfaces.size() != 6)
+    {
+      return return_type::ERROR;
+    }
+    for (const auto & ft_key : {"fx", "fy", "fz", "tx", "ty", "tz"})
+    {
+      if (
+        std::find_if(
           state_interfaces.begin(), state_interfaces.end(), [&ft_key](const auto & interface_info) {
             return interface_info.name == ft_key;
           }) == state_interfaces.end())
@@ -59,48 +64,24 @@ class TestForceTorqueSensor : public BaseInterface<SensorInterface>
 
     const auto & sensor_name = info_.sensors[0].name;
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "fx",
-        &values_.fx));
+      hardware_interface::StateInterface(sensor_name, "fx", &values_.fx));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "fy",
-        &values_.fy));
+      hardware_interface::StateInterface(sensor_name, "fy", &values_.fy));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "fz",
-        &values_.fz));
+      hardware_interface::StateInterface(sensor_name, "fz", &values_.fz));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "tx",
-        &values_.tx));
+      hardware_interface::StateInterface(sensor_name, "tx", &values_.tx));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "ty",
-        &values_.ty));
+      hardware_interface::StateInterface(sensor_name, "ty", &values_.ty));
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        sensor_name,
-        "tz",
-        &values_.tz));
+      hardware_interface::StateInterface(sensor_name, "tz", &values_.tz));
 
     return state_interfaces;
   }
 
-  return_type start() override
-  {
-    return return_type::OK;
-  }
+  return_type start() override { return return_type::OK; }
 
-  return_type stop() override
-  {
-    return return_type::OK;
-  }
+  return_type stop() override { return return_type::OK; }
 
   return_type read() override
   {

--- a/hardware_interface/test/test_hardware_components/test_single_joint_actuator.cpp
+++ b/hardware_interface/test/test_hardware_components/test_single_joint_actuator.cpp
@@ -15,41 +15,53 @@
 #include <memory>
 #include <vector>
 
-#include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
-using hardware_interface::status;
-using hardware_interface::return_type;
-using hardware_interface::StateInterface;
-using hardware_interface::CommandInterface;
 using hardware_interface::ActuatorInterface;
 using hardware_interface::BaseInterface;
+using hardware_interface::CommandInterface;
+using hardware_interface::return_type;
+using hardware_interface::StateInterface;
+using hardware_interface::status;
 
 namespace test_hardware_components
 {
-
 class TestSingleJointActuator : public BaseInterface<ActuatorInterface>
 {
   return_type configure(const hardware_interface::HardwareInfo & actuator_info) override
   {
-    if (configure_default(actuator_info) != return_type::OK) {
+    if (configure_default(actuator_info) != return_type::OK)
+    {
       return return_type::ERROR;
     }
 
     // can only control one joint
-    if (info_.joints.size() != 1) {return return_type::ERROR;}
+    if (info_.joints.size() != 1)
+    {
+      return return_type::ERROR;
+    }
     // can only control in position
     const auto & command_interfaces = info_.joints[0].command_interfaces;
-    if (command_interfaces.size() != 1) {return return_type::ERROR;}
-    if (command_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+    if (command_interfaces.size() != 1)
+    {
+      return return_type::ERROR;
+    }
+    if (command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
       return return_type::ERROR;
     }
     // can only give feedback state for position and velocity
     const auto & state_interfaces = info_.joints[0].state_interfaces;
-    if (state_interfaces.size() < 1) {return return_type::ERROR;}
-    for (const auto & state_interface : state_interfaces) {
-      if ((state_interface.name != hardware_interface::HW_IF_POSITION) &&
+    if (state_interfaces.size() < 1)
+    {
+      return return_type::ERROR;
+    }
+    for (const auto & state_interface : state_interfaces)
+    {
+      if (
+        (state_interface.name != hardware_interface::HW_IF_POSITION) &&
         (state_interface.name != hardware_interface::HW_IF_VELOCITY))
       {
         return return_type::ERROR;
@@ -64,16 +76,10 @@ class TestSingleJointActuator : public BaseInterface<ActuatorInterface>
     std::vector<StateInterface> state_interfaces;
 
     const auto & joint_name = info_.joints[0].name;
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        joint_name,
-        hardware_interface::HW_IF_POSITION,
-        &position_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        joint_name,
-        hardware_interface::HW_IF_VELOCITY,
-        &velocity_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      joint_name, hardware_interface::HW_IF_POSITION, &position_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      joint_name, hardware_interface::HW_IF_VELOCITY, &velocity_state_));
 
     return state_interfaces;
   }
@@ -83,29 +89,17 @@ class TestSingleJointActuator : public BaseInterface<ActuatorInterface>
     std::vector<CommandInterface> command_interfaces;
 
     const auto & joint_name = info_.joints[0].name;
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        joint_name,
-        hardware_interface::HW_IF_POSITION,
-        &position_command_));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      joint_name, hardware_interface::HW_IF_POSITION, &position_command_));
 
     return command_interfaces;
   }
 
-  return_type start() override
-  {
-    return return_type::OK;
-  }
+  return_type start() override { return return_type::OK; }
 
-  return_type stop() override
-  {
-    return return_type::OK;
-  }
+  return_type stop() override { return return_type::OK; }
 
-  return_type read() override
-  {
-    return return_type::OK;
-  }
+  return_type read() override { return return_type::OK; }
 
   return_type write() override
   {

--- a/hardware_interface/test/test_hardware_components/test_system_with_command_modes.cpp
+++ b/hardware_interface/test/test_hardware_components/test_system_with_command_modes.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <vector>
 #include <array>
 #include <string>
+#include <vector>
 
 #include "hardware_interface/base_interface.hpp"
 #include "hardware_interface/system_interface.hpp"
@@ -22,26 +22,35 @@
 
 namespace test_hardware_components
 {
-
-class TestSystemCommandModes : public
-  hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+class TestSystemCommandModes
+: public hardware_interface::BaseInterface<hardware_interface::SystemInterface>
 {
 public:
-  hardware_interface::return_type configure(const hardware_interface::HardwareInfo & system_info)
-  override
+  hardware_interface::return_type configure(
+    const hardware_interface::HardwareInfo & system_info) override
   {
-    if (configure_default(system_info) != hardware_interface::return_type::OK) {
+    if (configure_default(system_info) != hardware_interface::return_type::OK)
+    {
       return hardware_interface::return_type::ERROR;
     }
 
     // Can only control two joints
-    if (info_.joints.size() != 2) {return hardware_interface::return_type::ERROR;}
-    for (const hardware_interface::ComponentInfo & joint : info_.joints) {
+    if (info_.joints.size() != 2)
+    {
+      return hardware_interface::return_type::ERROR;
+    }
+    for (const hardware_interface::ComponentInfo & joint : info_.joints)
+    {
       // Can control in position or velocity
       const auto & command_interfaces = joint.command_interfaces;
-      if (command_interfaces.size() != 2) {return hardware_interface::return_type::ERROR;}
-      for (const auto & command_interface : command_interfaces) {
-        if (command_interface.name != hardware_interface::HW_IF_POSITION &&
+      if (command_interfaces.size() != 2)
+      {
+        return hardware_interface::return_type::ERROR;
+      }
+      for (const auto & command_interface : command_interfaces)
+      {
+        if (
+          command_interface.name != hardware_interface::HW_IF_POSITION &&
           command_interface.name != hardware_interface::HW_IF_VELOCITY)
         {
           return hardware_interface::return_type::ERROR;
@@ -49,9 +58,14 @@ public:
       }
       // Can give feedback state for position, velocity, and acceleration
       const auto & state_interfaces = joint.state_interfaces;
-      if (state_interfaces.size() != 2) {return hardware_interface::return_type::ERROR;}
-      for (const auto & state_interface : state_interfaces) {
-        if (state_interface.name != hardware_interface::HW_IF_POSITION &&
+      if (state_interfaces.size() != 2)
+      {
+        return hardware_interface::return_type::ERROR;
+      }
+      for (const auto & state_interface : state_interfaces)
+      {
+        if (
+          state_interface.name != hardware_interface::HW_IF_POSITION &&
           state_interface.name != hardware_interface::HW_IF_VELOCITY)
         {
           return hardware_interface::return_type::ERROR;
@@ -66,17 +80,14 @@ public:
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     std::vector<hardware_interface::StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); i++) {
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name,
-          hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
+    for (auto i = 0u; i < info_.joints.size(); i++)
+    {
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
     }
 
     return state_interfaces;
@@ -85,13 +96,12 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     std::vector<hardware_interface::CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); i++) {
-      command_interfaces.emplace_back(
-        hardware_interface::CommandInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
-      command_interfaces.emplace_back(
-        hardware_interface::CommandInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
+    for (auto i = 0u; i < info_.joints.size(); i++)
+    {
+      command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
+      command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
     }
 
     return command_interfaces;
@@ -109,15 +119,9 @@ public:
     return hardware_interface::return_type::OK;
   }
 
-  hardware_interface::return_type read() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type read() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type write() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type write() override { return hardware_interface::return_type::OK; }
 
   hardware_interface::return_type prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
@@ -126,31 +130,40 @@ public:
     // Starting interfaces
     start_modes_.clear();
     stop_modes_.clear();
-    for (const auto & key : start_interfaces) {
-      for (auto i = 0u; i < info_.joints.size(); i++) {
-        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION) {
+    for (const auto & key : start_interfaces)
+    {
+      for (auto i = 0u; i < info_.joints.size(); i++)
+      {
+        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION)
+        {
           start_modes_.push_back(hardware_interface::HW_IF_POSITION);
         }
-        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY) {
+        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY)
+        {
           start_modes_.push_back(hardware_interface::HW_IF_VELOCITY);
         }
       }
     }
     // Example Criteria 1 - Starting: All interfaces must be given a new mode at the same time
-    if (start_modes_.size() != 0 && start_modes_.size() != info_.joints.size()) {
+    if (start_modes_.size() != 0 && start_modes_.size() != info_.joints.size())
+    {
       return hardware_interface::return_type::ERROR;
     }
 
     // Stopping interfaces
-    for (const auto & key : stop_interfaces) {
-      for (auto i = 0u; i < info_.joints.size(); i++) {
-        if (key.find(info_.joints[i].name) != std::string::npos) {
+    for (const auto & key : stop_interfaces)
+    {
+      for (auto i = 0u; i < info_.joints.size(); i++)
+      {
+        if (key.find(info_.joints[i].name) != std::string::npos)
+        {
           stop_modes_.push_back(true);
         }
       }
     }
     // Example Criteria 2 - Stopping: All joints must have the same command mode
-    if (stop_modes_.size() != 0 && stop_modes_.size() != 2 && stop_modes_[0] != stop_modes_[1]) {
+    if (stop_modes_.size() != 0 && stop_modes_.size() != 2 && stop_modes_[0] != stop_modes_[1])
+    {
       return hardware_interface::return_type::ERROR;
     }
     return hardware_interface::return_type::OK;
@@ -164,7 +177,8 @@ public:
     // Fail if given an empty list.
     // This should never occur in a real system as the same start_interfaces list is sent to both
     // prepare and perform, and an error should be handled in prepare.
-    if (start_interfaces.size() == 0) {
+    if (start_interfaces.size() == 0)
+    {
       return hardware_interface::return_type::ERROR;
     }
     return hardware_interface::return_type::OK;
@@ -185,5 +199,4 @@ private:
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-  test_hardware_components::TestSystemCommandModes,
-  hardware_interface::SystemInterface)
+  test_hardware_components::TestSystemCommandModes, hardware_interface::SystemInterface)

--- a/hardware_interface/test/test_hardware_components/test_two_joint_system.cpp
+++ b/hardware_interface/test/test_hardware_components/test_two_joint_system.cpp
@@ -20,37 +20,49 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 
-using hardware_interface::status;
+using hardware_interface::BaseInterface;
+using hardware_interface::CommandInterface;
 using hardware_interface::return_type;
 using hardware_interface::StateInterface;
-using hardware_interface::CommandInterface;
-using hardware_interface::BaseInterface;
+using hardware_interface::status;
 using hardware_interface::SystemInterface;
 
 namespace test_hardware_components
 {
-
 class TestTwoJointSystem : public BaseInterface<SystemInterface>
 {
   return_type configure(const hardware_interface::HardwareInfo & system_info) override
   {
-    if (configure_default(system_info) != return_type::OK) {
+    if (configure_default(system_info) != return_type::OK)
+    {
       return return_type::ERROR;
     }
 
     // can only control two joint
-    if (info_.joints.size() != 2) {return return_type::ERROR;}
-    for (const auto & joint : info_.joints) {
+    if (info_.joints.size() != 2)
+    {
+      return return_type::ERROR;
+    }
+    for (const auto & joint : info_.joints)
+    {
       // can only control in position
       const auto & command_interfaces = joint.command_interfaces;
-      if (command_interfaces.size() != 1) {return return_type::ERROR;}
-      if (command_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+      if (command_interfaces.size() != 1)
+      {
+        return return_type::ERROR;
+      }
+      if (command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+      {
         return return_type::ERROR;
       }
       // can only give feedback state for position and velocity
       const auto & state_interfaces = joint.state_interfaces;
-      if (state_interfaces.size() != 1) {return return_type::ERROR;}
-      if (state_interfaces[0].name != hardware_interface::HW_IF_POSITION) {
+      if (state_interfaces.size() != 1)
+      {
+        return return_type::ERROR;
+      }
+      if (state_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+      {
         return return_type::ERROR;
       }
     }
@@ -62,10 +74,10 @@ class TestTwoJointSystem : public BaseInterface<SystemInterface>
   std::vector<StateInterface> export_state_interfaces() override
   {
     std::vector<StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i) {
-      state_interfaces.emplace_back(
-        hardware_interface::StateInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+    for (auto i = 0u; i < info_.joints.size(); ++i)
+    {
+      state_interfaces.emplace_back(hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
     }
 
     return state_interfaces;
@@ -74,34 +86,22 @@ class TestTwoJointSystem : public BaseInterface<SystemInterface>
   std::vector<CommandInterface> export_command_interfaces() override
   {
     std::vector<CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i) {
-      command_interfaces.emplace_back(
-        hardware_interface::CommandInterface(
-          info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
+    for (auto i = 0u; i < info_.joints.size(); ++i)
+    {
+      command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
     }
 
     return command_interfaces;
   }
 
-  return_type start() override
-  {
-    return return_type::OK;
-  }
+  return_type start() override { return return_type::OK; }
 
-  return_type stop() override
-  {
-    return return_type::OK;
-  }
+  return_type stop() override { return return_type::OK; }
 
-  return_type read() override
-  {
-    return return_type::OK;
-  }
+  return_type read() override { return return_type::OK; }
 
-  return_type write() override
-  {
-    return return_type::OK;
-  }
+  return_type write() override { return return_type::OK; }
 
 private:
   std::array<double, 2> position_command_ = {0.0, 0.0};

--- a/hardware_interface/test/test_macros.cpp
+++ b/hardware_interface/test/test_macros.cpp
@@ -21,16 +21,15 @@
 class TestMacros : public ::testing::Test
 {
 protected:
-  static void SetUpTestCase()
-  {
-  }
+  static void SetUpTestCase() {}
 };
 
 class A
 {
 };
 
-TEST_F(TestMacros, throw_on_null) {
+TEST_F(TestMacros, throw_on_null)
+{
   int * i_ptr = nullptr;
   // cppcheck-suppress unknownMacro
   EXPECT_ANY_THROW(THROW_ON_NULLPTR(i_ptr));
@@ -39,7 +38,8 @@ TEST_F(TestMacros, throw_on_null) {
   EXPECT_ANY_THROW(THROW_ON_NULLPTR(a_ptr));
 
   std::vector<int *> vec_ptr(7);
-  for (auto ptr : vec_ptr) {
+  for (auto ptr : vec_ptr)
+  {
     EXPECT_ANY_THROW(THROW_ON_NULLPTR(ptr));
   }
 
@@ -53,7 +53,8 @@ TEST_F(TestMacros, throw_on_null) {
   */
 }
 
-TEST_F(TestMacros, throw_on_not_null) {
+TEST_F(TestMacros, throw_on_not_null)
+{
   int * i_ptr = new int();
   EXPECT_ANY_THROW(THROW_ON_NOT_NULLPTR(i_ptr));
 
@@ -61,7 +62,8 @@ TEST_F(TestMacros, throw_on_not_null) {
   EXPECT_ANY_THROW(THROW_ON_NOT_NULLPTR(a_ptr));
 
   std::vector<int *> vec_ptr;
-  for (auto i : {0, 1, 2}) {
+  for (auto i : {0, 1, 2})
+  {
     vec_ptr.push_back(i_ptr);
     EXPECT_ANY_THROW(THROW_ON_NOT_NULLPTR(vec_ptr[i]));
   }

--- a/hardware_interface/test/test_resource_manager.cpp
+++ b/hardware_interface/test/test_resource_manager.cpp
@@ -17,8 +17,8 @@
 #include <algorithm>
 #include <memory>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/resource_manager.hpp"
@@ -27,30 +27,30 @@
 class TestResourceManager : public ::testing::Test
 {
 public:
-  static void SetUpTestCase()
-  {
-  }
+  static void SetUpTestCase() {}
 
-  void SetUp()
-  {
-  }
+  void SetUp() {}
 };
 
-TEST_F(TestResourceManager, initialization_empty) {
+TEST_F(TestResourceManager, initialization_empty)
+{
   ASSERT_ANY_THROW(hardware_interface::ResourceManager rm(""));
 }
 
-TEST_F(TestResourceManager, initialization_with_urdf) {
+TEST_F(TestResourceManager, initialization_with_urdf)
+{
   ASSERT_NO_THROW(
     hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf));
 }
 
-TEST_F(TestResourceManager, post_initialization_with_urdf) {
+TEST_F(TestResourceManager, post_initialization_with_urdf)
+{
   hardware_interface::ResourceManager rm;
   ASSERT_NO_THROW(rm.load_urdf(ros2_control_test_assets::minimal_robot_urdf));
 }
 
-TEST_F(TestResourceManager, initialization_with_urdf_manual_validation) {
+TEST_F(TestResourceManager, initialization_with_urdf_manual_validation)
+{
   // we validate the results manually
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf, false);
 
@@ -73,38 +73,45 @@ TEST_F(TestResourceManager, initialization_with_urdf_manual_validation) {
   EXPECT_TRUE(rm.command_interface_exists("joint3/velocity"));
 }
 
-TEST_F(TestResourceManager, initialization_with_wrong_urdf) {
+TEST_F(TestResourceManager, initialization_with_wrong_urdf)
+{
   // missing state keys
   {
     EXPECT_THROW(
       hardware_interface::ResourceManager rm(
-        ros2_control_test_assets::minimal_robot_missing_state_keys_urdf), std::exception);
+        ros2_control_test_assets::minimal_robot_missing_state_keys_urdf),
+      std::exception);
   }
   // missing command keys
   {
     EXPECT_THROW(
       hardware_interface::ResourceManager rm(
-        ros2_control_test_assets::minimal_robot_missing_command_keys_urdf), std::exception);
+        ros2_control_test_assets::minimal_robot_missing_command_keys_urdf),
+      std::exception);
   }
 }
 
-TEST_F(TestResourceManager, initialization_with_urdf_unclaimed) {
+TEST_F(TestResourceManager, initialization_with_urdf_unclaimed)
+{
   // we validate the results manually
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   auto command_interface_keys = rm.command_interface_keys();
-  for (const auto & key : command_interface_keys) {
+  for (const auto & key : command_interface_keys)
+  {
     EXPECT_FALSE(rm.command_interface_is_claimed(key));
   }
   // state interfaces don't have to be locked, hence any arbitrary key
   // should return false.
   auto state_interface_keys = rm.state_interface_keys();
-  for (const auto & key : state_interface_keys) {
+  for (const auto & key : state_interface_keys)
+  {
     EXPECT_FALSE(rm.command_interface_is_claimed(key));
   }
 }
 
-TEST_F(TestResourceManager, resource_status) {
+TEST_F(TestResourceManager, resource_status)
+{
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   std::unordered_map<std::string, hardware_interface::status> status_map;
@@ -115,7 +122,8 @@ TEST_F(TestResourceManager, resource_status) {
   EXPECT_EQ(status_map["TestSystemHardware"], hardware_interface::status::CONFIGURED);
 }
 
-TEST_F(TestResourceManager, starting_and_stopping_resources) {
+TEST_F(TestResourceManager, starting_and_stopping_resources)
+{
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   std::unordered_map<std::string, hardware_interface::status> status_map;
@@ -133,7 +141,8 @@ TEST_F(TestResourceManager, starting_and_stopping_resources) {
   EXPECT_EQ(status_map["TestSystemHardware"], hardware_interface::status::STOPPED);
 }
 
-TEST_F(TestResourceManager, resource_claiming) {
+TEST_F(TestResourceManager, resource_claiming)
+{
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf);
 
   const auto key = "joint1/position";
@@ -150,8 +159,8 @@ TEST_F(TestResourceManager, resource_claiming) {
 
   // command interfaces can only be claimed once
   for (const auto & key :
-    {"joint1/position", "joint1/position", "joint1/position", "joint2/velocity",
-      "joint3/velocity"})
+       {"joint1/position", "joint1/position", "joint1/position", "joint2/velocity",
+        "joint3/velocity"})
   {
     {
       auto interface = rm.claim_command_interface(key);
@@ -165,8 +174,8 @@ TEST_F(TestResourceManager, resource_claiming) {
 
   // state interfaces can be claimed multiple times
   for (const auto & key :
-    {"joint1/position", "joint1/velocity", "sensor1/velocity", "joint2/position",
-      "joint3/position"})
+       {"joint1/position", "joint1/velocity", "sensor1/velocity", "joint2/position",
+        "joint3/position"})
   {
     {
       auto interface = rm.claim_state_interface(key);
@@ -178,14 +187,17 @@ TEST_F(TestResourceManager, resource_claiming) {
 
   std::vector<hardware_interface::LoanedCommandInterface> interfaces;
   const auto interface_names = {"joint1/position", "joint2/velocity", "joint3/velocity"};
-  for (const auto & key : interface_names) {
+  for (const auto & key : interface_names)
+  {
     interfaces.emplace_back(rm.claim_command_interface(key));
   }
-  for (const auto & key : interface_names) {
+  for (const auto & key : interface_names)
+  {
     EXPECT_TRUE(rm.command_interface_is_claimed(key));
   }
   interfaces.clear();
-  for (const auto & key : interface_names) {
+  for (const auto & key : interface_names)
+  {
     EXPECT_FALSE(rm.command_interface_is_claimed(key));
   }
 }
@@ -201,8 +213,7 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
   {
     std::vector<hardware_interface::StateInterface> state_interfaces;
     state_interfaces.emplace_back(
-      hardware_interface::StateInterface(
-        "external_joint", "external_state_interface", nullptr));
+      hardware_interface::StateInterface("external_joint", "external_state_interface", nullptr));
 
     return state_interfaces;
   }
@@ -210,45 +221,30 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     std::vector<hardware_interface::CommandInterface> command_interfaces;
-    command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(
-        "external_joint", "external_command_interface", nullptr));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      "external_joint", "external_command_interface", nullptr));
 
     return command_interfaces;
   }
 
-  hardware_interface::return_type start() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type start() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type stop() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type stop() override { return hardware_interface::return_type::OK; }
 
-  std::string get_name() const override
-  {
-    return "ExternalComponent";
-  }
+  std::string get_name() const override { return "ExternalComponent"; }
 
   hardware_interface::status get_status() const override
   {
     return hardware_interface::status::UNKNOWN;
   }
 
-  hardware_interface::return_type read() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type read() override { return hardware_interface::return_type::OK; }
 
-  hardware_interface::return_type write() override
-  {
-    return hardware_interface::return_type::OK;
-  }
+  hardware_interface::return_type write() override { return hardware_interface::return_type::OK; }
 };
 
-TEST_F(TestResourceManager, post_initialization_add_components) {
+TEST_F(TestResourceManager, post_initialization_add_components)
+{
   // we validate the results manually
   hardware_interface::ResourceManager rm(ros2_control_test_assets::minimal_robot_urdf, false);
 
@@ -299,7 +295,8 @@ const auto hardware_resources_command_modes =
   </ros2_control>
 )";
 const auto command_mode_urdf = std::string(ros2_control_test_assets::urdf_head) +
-  std::string(hardware_resources_command_modes) + std::string(ros2_control_test_assets::urdf_tail);
+                               std::string(hardware_resources_command_modes) +
+                               std::string(ros2_control_test_assets::urdf_tail);
 
 TEST_F(TestResourceManager, custom_prepare_perform_switch)
 {

--- a/joint_limits_interface/CMakeLists.txt
+++ b/joint_limits_interface/CMakeLists.txt
@@ -11,6 +11,10 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
 
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(joint_limits_interface_test test/joint_limits_interface_test.cpp)

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits.hpp
@@ -19,7 +19,6 @@
 
 namespace joint_limits_interface
 {
-
 struct JointLimits
 {
   JointLimits()
@@ -35,7 +34,8 @@ struct JointLimits
     has_jerk_limits(false),
     has_effort_limits(false),
     angle_wraparound(false)
-  {}
+  {
+  }
 
   double min_position;
   double max_position;
@@ -54,12 +54,7 @@ struct JointLimits
 
 struct SoftJointLimits
 {
-  SoftJointLimits()
-  : min_position(0.0),
-    max_position(0.0),
-    k_position(0.0),
-    k_velocity(0.0)
-  {}
+  SoftJointLimits() : min_position(0.0), max_position(0.0), k_position(0.0), k_velocity(0.0) {}
 
   double min_position;
   double max_position;

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface.hpp
@@ -29,16 +29,14 @@
 #include <cassert>
 #include <cmath>
 #include <limits>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "joint_limits_interface/joint_limits.hpp"
 #include "joint_limits_interface/joint_limits_interface_exception.hpp"
 
-
 namespace joint_limits_interface
 {
-
 /**
  * The base class of limit handles for enforcing position, velocity, and effort limits of
  * an effort-controlled joint.
@@ -52,11 +50,11 @@ public:
     jposh_(hardware_interface::HW_IF_POSITION),
     jvelh_(hardware_interface::HW_IF_VELOCITY),
     jcmdh_("position_command")
-  {}
+  {
+  }
 
   JointLimitHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
   : jposh_(jposh),
     jvelh_(hardware_interface::HW_IF_VELOCITY),
@@ -64,28 +62,26 @@ public:
     limits_(limits),
     prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0)
-  {}
+  {
+  }
 
   JointLimitHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jvelh,
-    const hardware_interface::JointHandle & jcmdh,
-    const JointLimits & limits)
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jvelh,
+    const hardware_interface::JointHandle & jcmdh, const JointLimits & limits)
   : jposh_(jposh),
     jvelh_(jvelh),
     jcmdh_(jcmdh),
     limits_(limits),
     prev_pos_(std::numeric_limits<double>::quiet_NaN()),
     prev_vel_(0.0)
-  {}
+  {
+  }
 
   /// \return Joint name.
   std::string get_name() const
   {
-    return jposh_ ? jposh_.get_name() :
-           jvelh_ ? jvelh_.get_name() :
-           jcmdh_ ? jcmdh_.get_name() :
-           std::string();
+    return jposh_ ? jposh_.get_name()
+                  : jvelh_ ? jvelh_.get_name() : jcmdh_ ? jcmdh_.get_name() : std::string();
   }
 
   /// Sub-class implementation of limit enforcing policy.
@@ -117,12 +113,9 @@ protected:
   {
     // if we have a handle to a velocity state we can directly return state velocity
     // otherwise we will estimate velocity from previous position (command or state)
-    return jvelh_ ?
-           jvelh_.get_value() :
-           (jposh_.get_value() - prev_pos_) / period.seconds();
+    return jvelh_ ? jvelh_.get_value() : (jposh_.get_value() - prev_pos_) / period.seconds();
   }
 };
-
 
 /** The base class of limit handles for enforcing position, velocity, and effort limits of
  * an effort-controlled joint that has soft-limits.
@@ -133,28 +126,23 @@ public:
   JointSoftLimitsHandle() {}
 
   JointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
-    const JointLimits & limits,
-    const SoftJointLimits & soft_limits)
-  : JointLimitHandle(jposh, jcmdh, limits),
-    soft_limits_(soft_limits)
-  {}
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
+    const JointLimits & limits, const SoftJointLimits & soft_limits)
+  : JointLimitHandle(jposh, jcmdh, limits), soft_limits_(soft_limits)
+  {
+  }
 
   JointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jvelh,
-    const hardware_interface::JointHandle & jcmdh,
-    const JointLimits & limits,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jvelh,
+    const hardware_interface::JointHandle & jcmdh, const JointLimits & limits,
     const SoftJointLimits & soft_limits)
-  : JointLimitHandle(jposh, jvelh, jcmdh, limits),
-    soft_limits_(soft_limits)
-  {}
+  : JointLimitHandle(jposh, jvelh, jcmdh, limits), soft_limits_(soft_limits)
+  {
+  }
 
 protected:
   joint_limits_interface::SoftJointLimits soft_limits_;
 };
-
 
 /** A handle used to enforce position and velocity limits of a position-controlled joint that does not have
     soft limits. */
@@ -164,39 +152,45 @@ public:
   PositionJointSaturationHandle() {}
 
   PositionJointSaturationHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
     const JointLimits & limits)
   : JointLimitHandle(jposh, jcmdh, limits)
   {
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       min_pos_limit_ = limits_.min_position;
       max_pos_limit_ = limits_.max_position;
-    } else {
+    }
+    else
+    {
       min_pos_limit_ = -std::numeric_limits<double>::max();
       max_pos_limit_ = std::numeric_limits<double>::max();
     }
   }
 
-/// Enforce position and velocity limits for a joint that is not subject to soft limits.
-/**
+  /// Enforce position and velocity limits for a joint that is not subject to soft limits.
+  /**
  * \param[in] period Control period.
  */
   void enforce_limits(const rclcpp::Duration & period)
   {
-    if (std::isnan(prev_pos_)) {
+    if (std::isnan(prev_pos_))
+    {
       prev_pos_ = jposh_.get_value();
     }
 
     double min_pos, max_pos;
-    if (limits_.has_velocity_limits) {
+    if (limits_.has_velocity_limits)
+    {
       // enforce velocity limits
       // set constraints on where the position can be based on the
       // max velocity times seconds since last update
       const double delta_pos = limits_.max_velocity * period.seconds();
       min_pos = std::max(prev_pos_ - delta_pos, min_pos_limit_);
       max_pos = std::min(prev_pos_ + delta_pos, max_pos_limit_);
-    } else {
+    }
+    else
+    {
       // no velocity limit, so position is simply limited to set extents (our imposed soft limits)
       min_pos = min_pos_limit_;
       max_pos = max_pos_limit_;
@@ -246,20 +240,19 @@ private:
 class PositionJointSoftLimitsHandle : public JointSoftLimitsHandle
 {
 public:
-  PositionJointSoftLimitsHandle()
-  {}
+  PositionJointSoftLimitsHandle() {}
 
   PositionJointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
   : JointSoftLimitsHandle(jposh, jcmdh, limits, soft_limits)
   {
-    if (!limits.has_velocity_limits) {
+    if (!limits.has_velocity_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no velocity limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no velocity limits specification.");
     }
   }
 
@@ -274,7 +267,8 @@ public:
     assert(period.seconds() > 0.0);
 
     // Current position
-    if (std::isnan(prev_pos_)) {
+    if (std::isnan(prev_pos_))
+    {
       // Happens only once at initialization
       prev_pos_ = jposh_.get_value();
     }
@@ -284,18 +278,19 @@ public:
     double soft_min_vel;
     double soft_max_vel;
 
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       // Velocity bounds depend on the velocity limit and the proximity to the position limit
       soft_min_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.min_position),
-        -limits_.max_velocity,
+        -soft_limits_.k_position * (pos - soft_limits_.min_position), -limits_.max_velocity,
         limits_.max_velocity);
 
       soft_max_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.max_position),
-        -limits_.max_velocity,
+        -soft_limits_.k_position * (pos - soft_limits_.max_position), -limits_.max_velocity,
         limits_.max_velocity);
-    } else {
+    }
+    else
+    {
       // No position limits, eg. continuous joints
       soft_min_vel = -limits_.max_velocity;
       soft_max_vel = limits_.max_velocity;
@@ -306,7 +301,8 @@ public:
     double pos_low = pos + soft_min_vel * dt;
     double pos_high = pos + soft_max_vel * dt;
 
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       // This extra measure safeguards against pathological cases, like when the soft limit lies
       // beyond the hard limit
       pos_low = std::max(pos_low, limits_.min_position);
@@ -314,10 +310,7 @@ public:
     }
 
     // Saturate position command according to bounds
-    const double pos_cmd = rcppmath::clamp(
-      jcmdh_.get_value(),
-      pos_low,
-      pos_high);
+    const double pos_cmd = rcppmath::clamp(jcmdh_.get_value(), pos_low, pos_high);
     jcmdh_.set_value(pos_cmd);
 
     // Cache variables
@@ -337,30 +330,30 @@ public:
   EffortJointSaturationHandle() {}
 
   EffortJointSaturationHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jvelh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jvelh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
   : JointLimitHandle(jposh, jvelh, jcmdh, limits)
   {
-    if (!limits.has_velocity_limits) {
+    if (!limits.has_velocity_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no velocity limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no velocity limits specification.");
     }
-    if (!limits.has_effort_limits) {
+    if (!limits.has_effort_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no efforts limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no efforts limits specification.");
     }
   }
 
   EffortJointSaturationHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : EffortJointSaturationHandle(jposh,
-      hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits)
+  : EffortJointSaturationHandle(
+      jposh, hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits)
   {
   }
 
@@ -375,19 +368,26 @@ public:
     double min_eff = -limits_.max_effort;
     double max_eff = limits_.max_effort;
 
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       const double pos = jposh_.get_value();
-      if (pos < limits_.min_position) {
+      if (pos < limits_.min_position)
+      {
         min_eff = 0.0;
-      } else if (pos > limits_.max_position) {
+      }
+      else if (pos > limits_.max_position)
+      {
         max_eff = 0.0;
       }
     }
 
     const double vel = get_velocity(period);
-    if (vel < -limits_.max_velocity) {
+    if (vel < -limits_.max_velocity)
+    {
       min_eff = 0.0;
-    } else if (vel > limits_.max_velocity) {
+    }
+    else if (vel > limits_.max_velocity)
+    {
       max_eff = 0.0;
     }
 
@@ -404,33 +404,33 @@ public:
   EffortJointSoftLimitsHandle() {}
 
   EffortJointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jvelh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jvelh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
   : JointSoftLimitsHandle(jposh, jvelh, jcmdh, limits, soft_limits)
   {
-    if (!limits.has_velocity_limits) {
+    if (!limits.has_velocity_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no velocity limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no velocity limits specification.");
     }
-    if (!limits.has_effort_limits) {
+    if (!limits.has_effort_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no effort limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no effort limits specification.");
     }
   }
 
   EffortJointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jcmdh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
-  : EffortJointSoftLimitsHandle(jposh,
-      hardware_interface::JointHandle(
-        hardware_interface::HW_IF_VELOCITY), jcmdh, limits, soft_limits)
+  : EffortJointSoftLimitsHandle(
+      jposh, hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits,
+      soft_limits)
   {
   }
 
@@ -451,18 +451,19 @@ public:
     double soft_min_vel;
     double soft_max_vel;
 
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       // Velocity bounds depend on the velocity limit and the proximity to the position limit
       soft_min_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.min_position),
-        -limits_.max_velocity,
+        -soft_limits_.k_position * (pos - soft_limits_.min_position), -limits_.max_velocity,
         limits_.max_velocity);
 
       soft_max_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.max_position),
-        -limits_.max_velocity,
+        -soft_limits_.k_position * (pos - soft_limits_.max_position), -limits_.max_velocity,
         limits_.max_velocity);
-    } else {
+    }
+    else
+    {
       // No position limits, eg. continuous joints
       soft_min_vel = -limits_.max_velocity;
       soft_max_vel = limits_.max_velocity;
@@ -470,24 +471,16 @@ public:
 
     // Effort bounds depend on the velocity and effort bounds
     const double soft_min_eff = rcppmath::clamp(
-      -soft_limits_.k_velocity * (vel - soft_min_vel),
-      -limits_.max_effort,
-      limits_.max_effort);
+      -soft_limits_.k_velocity * (vel - soft_min_vel), -limits_.max_effort, limits_.max_effort);
 
     const double soft_max_eff = rcppmath::clamp(
-      -soft_limits_.k_velocity * (vel - soft_max_vel),
-      -limits_.max_effort,
-      limits_.max_effort);
+      -soft_limits_.k_velocity * (vel - soft_max_vel), -limits_.max_effort, limits_.max_effort);
 
     // Saturate effort command according to bounds
-    const double eff_cmd = rcppmath::clamp(
-      jcmdh_.get_value(),
-      soft_min_eff,
-      soft_max_eff);
+    const double eff_cmd = rcppmath::clamp(jcmdh_.get_value(), soft_min_eff, soft_max_eff);
     jcmdh_.set_value(eff_cmd);
   }
 };
-
 
 /// A handle used to enforce velocity and acceleration limits of a velocity-controlled joint.
 class VelocityJointSaturationHandle : public JointLimitHandle
@@ -499,26 +492,29 @@ public:
     const hardware_interface::JointHandle & jvelh,  // currently unused
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle(hardware_interface::JointHandle(
-        hardware_interface::HW_IF_POSITION), jvelh, jcmdh, limits)
+  : JointLimitHandle(
+      hardware_interface::JointHandle(hardware_interface::HW_IF_POSITION), jvelh, jcmdh, limits)
   {
-    if (!limits.has_velocity_limits) {
+    if (!limits.has_velocity_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no velocity limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no velocity limits specification.");
     }
   }
 
   VelocityJointSaturationHandle(
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits)
-  : JointLimitHandle(hardware_interface::JointHandle(hardware_interface::HW_IF_POSITION),
+  : JointLimitHandle(
+      hardware_interface::JointHandle(hardware_interface::HW_IF_POSITION),
       hardware_interface::JointHandle(hardware_interface::HW_IF_VELOCITY), jcmdh, limits)
   {
-    if (!limits.has_velocity_limits) {
+    if (!limits.has_velocity_limits)
+    {
       throw joint_limits_interface::JointLimitsInterfaceException(
-              "Cannot enforce limits for joint '" + get_name() +
-              "'. It has no velocity limits specification.");
+        "Cannot enforce limits for joint '" + get_name() +
+        "'. It has no velocity limits specification.");
     }
   }
 
@@ -532,22 +528,22 @@ public:
     double vel_low;
     double vel_high;
 
-    if (limits_.has_acceleration_limits) {
+    if (limits_.has_acceleration_limits)
+    {
       assert(period.seconds() > 0.0);
       const double dt = period.seconds();
 
       vel_low = std::max(prev_vel_ - limits_.max_acceleration * dt, -limits_.max_velocity);
       vel_high = std::min(prev_vel_ + limits_.max_acceleration * dt, limits_.max_velocity);
-    } else {
+    }
+    else
+    {
       vel_low = -limits_.max_velocity;
       vel_high = limits_.max_velocity;
     }
 
     // Saturate velocity command according to limits
-    const double vel_cmd = rcppmath::clamp(
-      jcmdh_.get_value(),
-      vel_low,
-      vel_high);
+    const double vel_cmd = rcppmath::clamp(jcmdh_.get_value(), vel_low, vel_high);
     jcmdh_.set_value(vel_cmd);
 
     // Cache variables
@@ -565,16 +561,18 @@ public:
   VelocityJointSoftLimitsHandle() {}
 
   VelocityJointSoftLimitsHandle(
-    const hardware_interface::JointHandle & jposh,
-    const hardware_interface::JointHandle & jvelh,
+    const hardware_interface::JointHandle & jposh, const hardware_interface::JointHandle & jvelh,
     const hardware_interface::JointHandle & jcmdh,
     const joint_limits_interface::JointLimits & limits,
     const joint_limits_interface::SoftJointLimits & soft_limits)
   : JointSoftLimitsHandle(jposh, jvelh, jcmdh, limits, soft_limits)
   {
-    if (limits.has_velocity_limits) {
+    if (limits.has_velocity_limits)
+    {
       max_vel_limit_ = limits.max_velocity;
-    } else {
+    }
+    else
+    {
       max_vel_limit_ = std::numeric_limits<double>::max();
     }
   }
@@ -588,21 +586,25 @@ public:
   void enforce_limits(const rclcpp::Duration & period)
   {
     double min_vel, max_vel;
-    if (limits_.has_position_limits) {
+    if (limits_.has_position_limits)
+    {
       // Velocity bounds depend on the velocity limit and the proximity to the position limit.
       const double pos = jposh_.get_value();
       min_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.min_position),
-        -max_vel_limit_, max_vel_limit_);
+        -soft_limits_.k_position * (pos - soft_limits_.min_position), -max_vel_limit_,
+        max_vel_limit_);
       max_vel = rcppmath::clamp(
-        -soft_limits_.k_position * (pos - soft_limits_.max_position),
-        -max_vel_limit_, max_vel_limit_);
-    } else {
+        -soft_limits_.k_position * (pos - soft_limits_.max_position), -max_vel_limit_,
+        max_vel_limit_);
+    }
+    else
+    {
       min_vel = -max_vel_limit_;
       max_vel = max_vel_limit_;
     }
 
-    if (limits_.has_acceleration_limits) {
+    if (limits_.has_acceleration_limits)
+    {
       const double vel = get_velocity(period);
       const double delta_t = period.seconds();
       min_vel = std::max(vel - limits_.max_acceleration * delta_t, min_vel);

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_interface_exception.hpp
@@ -19,18 +19,13 @@
 
 namespace joint_limits_interface
 {
-
 /// An exception related to a \ref JointLimitsInterface
 class JointLimitsInterfaceException : public std::exception
 {
 public:
-  explicit JointLimitsInterfaceException(const std::string & message)
-  : msg(message) {}
+  explicit JointLimitsInterfaceException(const std::string & message) : msg(message) {}
 
-  const char * what() const noexcept override
-  {
-    return msg.c_str();
-  }
+  const char * what() const noexcept override { return msg.c_str(); }
 
 private:
   std::string msg;

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_rosparam.hpp
@@ -25,7 +25,6 @@
 
 namespace joint_limits_interface
 {
-
 /// Populate a JointLimits instance from the ROS parameter server.
 /**
  * It is assumed that the following parameter structure is followed on the provided NodeHandle. Unspecified parameters
@@ -60,12 +59,13 @@ namespace joint_limits_interface
  * \return True if a limits specification is found (ie. the \p joint_limits/joint_name parameter exists in \p node), false otherwise.
  */
 inline bool getJointLimits(
-  const std::string & joint_name, const rclcpp::Node::SharedPtr & node,
-  JointLimits & limits)
+  const std::string & joint_name, const rclcpp::Node::SharedPtr & node, JointLimits & limits)
 {
   const std::string param_base_name = "joint_limits." + joint_name;
-  try {
-    if (!node->has_parameter(param_base_name + ".has_position_limits") &&
+  try
+  {
+    if (
+      !node->has_parameter(param_base_name + ".has_position_limits") &&
       !node->has_parameter(param_base_name + ".min_position") &&
       !node->has_parameter(param_base_name + ".max_position") &&
       !node->has_parameter(param_base_name + ".has_velocity_limits") &&
@@ -88,23 +88,27 @@ inline bool getJointLimits(
         node->get_logger(),
         "No joint limits specification found for joint '%s' in the parameter server "
         "(node: %s param name: %s).",
-        joint_name.c_str(),
-        node->get_name(),
-        param_base_name.c_str());
+        joint_name.c_str(), node->get_name(), param_base_name.c_str());
       return false;
     }
-  } catch (const std::exception & ex) {
+  }
+  catch (const std::exception & ex)
+  {
     RCLCPP_ERROR(node->get_logger(), "%s", ex.what());
     return false;
   }
 
   // Position limits
   bool has_position_limits = false;
-  if (node->get_parameter(param_base_name + ".has_position_limits", has_position_limits)) {
-    if (!has_position_limits) {limits.has_position_limits = false;}
+  if (node->get_parameter(param_base_name + ".has_position_limits", has_position_limits))
+  {
+    if (!has_position_limits)
+    {
+      limits.has_position_limits = false;
+    }
     double min_pos, max_pos;
-    if (has_position_limits &&
-      node->get_parameter(param_base_name + ".min_position", min_pos) &&
+    if (
+      has_position_limits && node->get_parameter(param_base_name + ".min_position", min_pos) &&
       node->get_parameter(param_base_name + ".max_position", max_pos))
     {
       limits.has_position_limits = true;
@@ -113,7 +117,8 @@ inline bool getJointLimits(
     }
 
     bool angle_wraparound;
-    if (!has_position_limits &&
+    if (
+      !has_position_limits &&
       node->get_parameter(param_base_name + ".angle_wraparound", angle_wraparound))
     {
       limits.angle_wraparound = angle_wraparound;
@@ -122,10 +127,15 @@ inline bool getJointLimits(
 
   // Velocity limits
   bool has_velocity_limits = false;
-  if (node->get_parameter(param_base_name + ".has_velocity_limits", has_velocity_limits)) {
-    if (!has_velocity_limits) {limits.has_velocity_limits = false;}
+  if (node->get_parameter(param_base_name + ".has_velocity_limits", has_velocity_limits))
+  {
+    if (!has_velocity_limits)
+    {
+      limits.has_velocity_limits = false;
+    }
     double max_vel;
-    if (has_velocity_limits && node->get_parameter(param_base_name + ".max_velocity", max_vel)) {
+    if (has_velocity_limits && node->get_parameter(param_base_name + ".max_velocity", max_vel))
+    {
       limits.has_velocity_limits = true;
       limits.max_velocity = max_vel;
     }
@@ -133,10 +143,15 @@ inline bool getJointLimits(
 
   // Acceleration limits
   bool has_acceleration_limits = false;
-  if (node->get_parameter(param_base_name + ".has_acceleration_limits", has_acceleration_limits)) {
-    if (!has_acceleration_limits) {limits.has_acceleration_limits = false;}
+  if (node->get_parameter(param_base_name + ".has_acceleration_limits", has_acceleration_limits))
+  {
+    if (!has_acceleration_limits)
+    {
+      limits.has_acceleration_limits = false;
+    }
     double max_acc;
-    if (has_acceleration_limits &&
+    if (
+      has_acceleration_limits &&
       node->get_parameter(param_base_name + ".max_acceleration", max_acc))
     {
       limits.has_acceleration_limits = true;
@@ -146,10 +161,15 @@ inline bool getJointLimits(
 
   // Jerk limits
   bool has_jerk_limits = false;
-  if (node->get_parameter(param_base_name + ".has_jerk_limits", has_jerk_limits)) {
-    if (!has_jerk_limits) {limits.has_jerk_limits = false;}
+  if (node->get_parameter(param_base_name + ".has_jerk_limits", has_jerk_limits))
+  {
+    if (!has_jerk_limits)
+    {
+      limits.has_jerk_limits = false;
+    }
     double max_jerk;
-    if (has_jerk_limits && node->get_parameter(param_base_name + ".max_jerk", max_jerk)) {
+    if (has_jerk_limits && node->get_parameter(param_base_name + ".max_jerk", max_jerk))
+    {
       limits.has_jerk_limits = true;
       limits.max_jerk = max_jerk;
     }
@@ -157,10 +177,15 @@ inline bool getJointLimits(
 
   // Effort limits
   bool has_effort_limits = false;
-  if (node->get_parameter(param_base_name + ".has_effort_limits", has_effort_limits)) {
-    if (!has_effort_limits) {limits.has_effort_limits = false;}
+  if (node->get_parameter(param_base_name + ".has_effort_limits", has_effort_limits))
+  {
+    if (!has_effort_limits)
+    {
+      limits.has_effort_limits = false;
+    }
     double max_effort;
-    if (has_effort_limits && node->get_parameter(param_base_name + ".max_effort", max_effort)) {
+    if (has_effort_limits && node->get_parameter(param_base_name + ".max_effort", max_effort))
+    {
       limits.has_effort_limits = true;
       limits.max_effort = max_effort;
     }
@@ -196,8 +221,10 @@ inline bool getSoftJointLimits(
   SoftJointLimits & soft_limits)
 {
   const std::string param_base_name = "joint_limits." + joint_name;
-  try {
-    if (!node->has_parameter(param_base_name + ".has_soft_limits") &&
+  try
+  {
+    if (
+      !node->has_parameter(param_base_name + ".has_soft_limits") &&
       !node->has_parameter(param_base_name + ".k_velocity") &&
       !node->has_parameter(param_base_name + ".k_position") &&
       !node->has_parameter(param_base_name + ".soft_lower_limit") &&
@@ -207,21 +234,22 @@ inline bool getSoftJointLimits(
         node->get_logger(),
         "No soft joint limits specification found for joint '%s' in the parameter server "
         "(node: %s param name: %s).",
-        joint_name.c_str(),
-        node->get_name(),
-        param_base_name.c_str());
+        joint_name.c_str(), node->get_name(), param_base_name.c_str());
       return false;
     }
-  } catch (const std::exception & ex) {
+  }
+  catch (const std::exception & ex)
+  {
     RCLCPP_ERROR(node->get_logger(), "%s", ex.what());
     return false;
   }
 
   // Override soft limits if complete specification is found
   bool has_soft_limits;
-  if (node->get_parameter(param_base_name + ".has_soft_limits", has_soft_limits)) {
-    if (has_soft_limits &&
-      node->has_parameter(param_base_name + ".k_position") &&
+  if (node->get_parameter(param_base_name + ".has_soft_limits", has_soft_limits))
+  {
+    if (
+      has_soft_limits && node->has_parameter(param_base_name + ".k_position") &&
       node->has_parameter(param_base_name + ".k_velocity") &&
       node->has_parameter(param_base_name + ".soft_lower_limit") &&
       node->has_parameter(param_base_name + ".soft_upper_limit"))

--- a/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.hpp
+++ b/joint_limits_interface/include/joint_limits_interface/joint_limits_urdf.hpp
@@ -17,14 +17,13 @@
 #ifndef JOINT_LIMITS_INTERFACE__JOINT_LIMITS_URDF_HPP_
 #define JOINT_LIMITS_INTERFACE__JOINT_LIMITS_URDF_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <urdf_model/joint.h>
 #include <urdf/urdfdom_compatibility.h>
+#include <urdf_model/joint.h>
 #include <joint_limits_interface/joint_limits.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace joint_limits_interface
 {
-
 /**
  * Populate a JointLimits instance from URDF joint data.
  * \param[in] urdf_joint URDF joint.
@@ -34,18 +33,21 @@ namespace joint_limits_interface
  */
 inline bool getJointLimits(urdf::JointConstSharedPtr urdf_joint, JointLimits & limits)
 {
-  if (!urdf_joint || !urdf_joint->limits) {
+  if (!urdf_joint || !urdf_joint->limits)
+  {
     return false;
   }
 
-  limits.has_position_limits = urdf_joint->type == urdf::Joint::REVOLUTE ||
-    urdf_joint->type == urdf::Joint::PRISMATIC;
-  if (limits.has_position_limits) {
+  limits.has_position_limits =
+    urdf_joint->type == urdf::Joint::REVOLUTE || urdf_joint->type == urdf::Joint::PRISMATIC;
+  if (limits.has_position_limits)
+  {
     limits.min_position = urdf_joint->limits->lower;
     limits.max_position = urdf_joint->limits->upper;
   }
 
-  if (!limits.has_position_limits && urdf_joint->type == urdf::Joint::CONTINUOUS) {
+  if (!limits.has_position_limits && urdf_joint->type == urdf::Joint::CONTINUOUS)
+  {
     limits.angle_wraparound = true;
   }
 
@@ -68,7 +70,8 @@ inline bool getJointLimits(urdf::JointConstSharedPtr urdf_joint, JointLimits & l
  */
 inline bool getSoftJointLimits(urdf::JointConstSharedPtr urdf_joint, SoftJointLimits & soft_limits)
 {
-  if (!urdf_joint || !urdf_joint->safety) {
+  if (!urdf_joint || !urdf_joint->safety)
+  {
     return false;
   }
 

--- a/joint_limits_interface/test/joint_limits_interface_test.cpp
+++ b/joint_limits_interface/test/joint_limits_interface_test.cpp
@@ -24,9 +24,8 @@
 
 #include <rcppmath/clamp.hpp>
 
-#include <string>
 #include <memory>
-
+#include <string>
 
 // Floating-point value comparison threshold
 const double EPS = 1e-12;
@@ -56,12 +55,14 @@ TEST(SaturateTest, Saturate)
   EXPECT_NEAR(max, rcppmath::clamp(val, min, max), EPS);
 }
 
-
 class JointLimitsTest
 {
 public:
   JointLimitsTest()
-  : pos(0.0), vel(0.0), eff(0.0), cmd(0.0),
+  : pos(0.0),
+    vel(0.0),
+    eff(0.0),
+    cmd(0.0),
     name("joint_name"),
     period(0, 100000000),
     cmd_handle(hardware_interface::JointHandle(name, "position_command", &cmd)),
@@ -96,7 +97,9 @@ protected:
   joint_limits_interface::SoftJointLimits soft_limits;
 };
 
-class JointLimitsHandleTest : public JointLimitsTest, public ::testing::Test {};
+class JointLimitsHandleTest : public JointLimitsTest, public ::testing::Test
+{
+};
 
 TEST_F(JointLimitsHandleTest, HandleConstruction)
 {
@@ -104,16 +107,18 @@ TEST_F(JointLimitsHandleTest, HandleConstruction)
     joint_limits_interface::JointLimits limits_bad;
     EXPECT_THROW(
       joint_limits_interface::PositionJointSoftLimitsHandle(
-        pos_handle, cmd_handle,
-        limits_bad, soft_limits),
+        pos_handle, cmd_handle, limits_bad, soft_limits),
       joint_limits_interface::JointLimitsInterfaceException);
 
     // Print error messages. Requires manual output inspection, but exception message should be
     // descriptive
-    try {
+    try
+    {
       joint_limits_interface::PositionJointSoftLimitsHandle(
         pos_handle, cmd_handle, limits_bad, soft_limits);
-    } catch (const joint_limits_interface::JointLimitsInterfaceException & e) {
+    }
+    catch (const joint_limits_interface::JointLimitsInterfaceException & e)
+    {
       RCLCPP_ERROR(rclcpp::get_logger("joint_limits_interface_test"), "%s", e.what());
     }
   }
@@ -123,15 +128,18 @@ TEST_F(JointLimitsHandleTest, HandleConstruction)
     limits_bad.has_effort_limits = true;
     EXPECT_THROW(
       joint_limits_interface::EffortJointSoftLimitsHandle(
-        pos_handle, cmd_handle, limits_bad,
-        soft_limits), joint_limits_interface::JointLimitsInterfaceException);
+        pos_handle, cmd_handle, limits_bad, soft_limits),
+      joint_limits_interface::JointLimitsInterfaceException);
 
     // Print error messages. Requires manual output inspection,
     // but exception message should be descriptive
-    try {
+    try
+    {
       joint_limits_interface::EffortJointSoftLimitsHandle(
         pos_handle, cmd_handle, limits_bad, soft_limits);
-    } catch (const joint_limits_interface::JointLimitsInterfaceException & e) {
+    }
+    catch (const joint_limits_interface::JointLimitsInterfaceException & e)
+    {
       RCLCPP_ERROR(rclcpp::get_logger("joint_limits_interface_test"), "%s", e.what());
     }
   }
@@ -141,15 +149,18 @@ TEST_F(JointLimitsHandleTest, HandleConstruction)
     limits_bad.has_velocity_limits = true;
     EXPECT_THROW(
       joint_limits_interface::EffortJointSoftLimitsHandle(
-        pos_handle, cmd_handle, limits_bad,
-        soft_limits), joint_limits_interface::JointLimitsInterfaceException);
+        pos_handle, cmd_handle, limits_bad, soft_limits),
+      joint_limits_interface::JointLimitsInterfaceException);
 
     // Print error messages. Requires manual output inspection, but exception message should
     // be descriptive
-    try {
+    try
+    {
       joint_limits_interface::EffortJointSoftLimitsHandle(
         pos_handle, cmd_handle, limits_bad, soft_limits);
-    } catch (const joint_limits_interface::JointLimitsInterfaceException & e) {
+    }
+    catch (const joint_limits_interface::JointLimitsInterfaceException & e)
+    {
       RCLCPP_ERROR(rclcpp::get_logger("joint_limits_interface_test"), "%s", e.what());
     }
   }
@@ -157,31 +168,32 @@ TEST_F(JointLimitsHandleTest, HandleConstruction)
   {
     joint_limits_interface::JointLimits limits_bad;
     EXPECT_THROW(
-      joint_limits_interface::VelocityJointSaturationHandle(
-        pos_handle, cmd_handle,
-        limits_bad), joint_limits_interface::JointLimitsInterfaceException);
+      joint_limits_interface::VelocityJointSaturationHandle(pos_handle, cmd_handle, limits_bad),
+      joint_limits_interface::JointLimitsInterfaceException);
 
     // Print error messages. Requires manual output inspection, but exception message should
     // be descriptive
-    try {
+    try
+    {
       joint_limits_interface::VelocityJointSaturationHandle(pos_handle, cmd_handle, limits_bad);
-    } catch (const joint_limits_interface::JointLimitsInterfaceException & e) {
+    }
+    catch (const joint_limits_interface::JointLimitsInterfaceException & e)
+    {
       RCLCPP_ERROR(rclcpp::get_logger("joint_limits_interface_test"), "%s", e.what());
     }
   }
 
+  EXPECT_NO_THROW(joint_limits_interface::PositionJointSoftLimitsHandle(
+    pos_handle, cmd_handle, limits, soft_limits));
+  EXPECT_NO_THROW(joint_limits_interface::EffortJointSoftLimitsHandle(
+    pos_handle, cmd_handle, limits, soft_limits));
   EXPECT_NO_THROW(
-    joint_limits_interface::PositionJointSoftLimitsHandle(
-      pos_handle, cmd_handle, limits, soft_limits));
-  EXPECT_NO_THROW(
-    joint_limits_interface::EffortJointSoftLimitsHandle(
-      pos_handle, cmd_handle, limits, soft_limits));
-  EXPECT_NO_THROW(
-    joint_limits_interface::VelocityJointSaturationHandle(
-      pos_handle, cmd_handle, limits));
+    joint_limits_interface::VelocityJointSaturationHandle(pos_handle, cmd_handle, limits));
 }
 
-class PositionJointSoftLimitsHandleTest : public JointLimitsTest, public ::testing::Test {};
+class PositionJointSoftLimitsHandleTest : public JointLimitsTest, public ::testing::Test
+{
+};
 
 TEST_F(PositionJointSoftLimitsHandleTest, EnforceVelocityBounds)
 {
@@ -335,10 +347,10 @@ TEST_F(PositionJointSoftLimitsHandleTest, EnforcePositionBounds)
 TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
 {
   // Safety limits are past the hard limits
-  soft_limits.min_position = limits.min_position *
-    (1.0 - 0.5 * limits.min_position / std::abs(limits.min_position));
-  soft_limits.max_position = limits.max_position *
-    (1.0 + 0.5 * limits.max_position / std::abs(limits.max_position));
+  soft_limits.min_position =
+    limits.min_position * (1.0 - 0.5 * limits.min_position / std::abs(limits.min_position));
+  soft_limits.max_position =
+    limits.max_position * (1.0 + 0.5 * limits.max_position / std::abs(limits.max_position));
 
   // Current position == higher hard limit
   {
@@ -369,7 +381,9 @@ TEST_F(PositionJointSoftLimitsHandleTest, PathologicalSoftBounds)
   }
 }
 
-class VelocityJointSaturationHandleTest : public JointLimitsTest, public ::testing::Test {};
+class VelocityJointSaturationHandleTest : public JointLimitsTest, public ::testing::Test
+{
+};
 
 TEST_F(VelocityJointSaturationHandleTest, EnforceVelocityBounds)
 {
@@ -487,21 +501,21 @@ class JointLimitsInterfaceTest : public JointLimitsTest, public ::testing::Test
 public:
   JointLimitsInterfaceTest()
   : JointLimitsTest(),
-    pos2(0.0), vel2(0.0), eff2(0.0), cmd2(0.0),
+    pos2(0.0),
+    vel2(0.0),
+    eff2(0.0),
+    cmd2(0.0),
     name2("joint2_name"),
-    cmd2_handle(std::make_shared<hardware_interface::JointHandle>(
-        name2, "position_command",
-        &cmd2)),
+    cmd2_handle(
+      std::make_shared<hardware_interface::JointHandle>(name2, "position_command", &cmd2)),
     pos2_handle(std::make_shared<hardware_interface::JointHandle>(
-        name2,
-        hardware_interface::HW_IF_POSITION, &pos2)),
+      name2, hardware_interface::HW_IF_POSITION, &pos2)),
     vel2_handle(std::make_shared<hardware_interface::JointHandle>(
-        name2,
-        hardware_interface::HW_IF_VELOCITY, &vel2)),
+      name2, hardware_interface::HW_IF_VELOCITY, &vel2)),
     eff2_handle(std::make_shared<hardware_interface::JointHandle>(
-        name2,
-        hardware_interface::HW_IF_EFFORT, &eff2))
-  {}
+      name2, hardware_interface::HW_IF_EFFORT, &eff2))
+  {
+  }
 
 protected:
   double pos2, vel2, eff2, cmd2;

--- a/joint_limits_interface/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits_interface/test/joint_limits_rosparam_test.cpp
@@ -28,8 +28,8 @@ protected:
   void SetUp()
   {
     rclcpp::NodeOptions node_options;
-    node_options.allow_undeclared_parameters(true)
-    .automatically_declare_parameters_from_overrides(true);
+    node_options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(
+      true);
 
     node_ = rclcpp::Node::make_shared("JointLimitsRosparamTestNode", node_options);
   }

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -16,6 +16,10 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -19,7 +19,6 @@
 
 namespace ros2_control_test_assets
 {
-
 // 1. Industrial Robots with only one interface
 const auto valid_urdf_ros2_control_system_one_interface =
   R"(
@@ -450,7 +449,6 @@ const auto invalid_urdf_ros2_control_parameter_missing_name =
     </joint>
   </ros2_control>
 )";
-
 
 const auto invalid_urdf_ros2_control_component_class_type_empty =
   R"(

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -22,7 +22,6 @@
 
 namespace ros2_control_test_assets
 {
-
 const auto urdf_head =
   R"(
 <?xml version="1.0" encoding="utf-8"?>
@@ -253,14 +252,16 @@ const auto hardware_resources_missing_command_keys =
   </ros2_control>
 )";
 
-const auto minimal_robot_urdf = std::string(urdf_head) + std::string(hardware_resources) +
+const auto minimal_robot_urdf =
+  std::string(urdf_head) + std::string(hardware_resources) + std::string(urdf_tail);
+
+const auto minimal_robot_missing_state_keys_urdf =
+  std::string(urdf_head) + std::string(hardware_resources_missing_state_keys) +
   std::string(urdf_tail);
 
-const auto minimal_robot_missing_state_keys_urdf = std::string(urdf_head) +
-  std::string(hardware_resources_missing_state_keys) + std::string(urdf_tail);
-
-const auto minimal_robot_missing_command_keys_urdf = std::string(urdf_head) +
-  std::string(hardware_resources_missing_command_keys) + std::string(urdf_tail);
+const auto minimal_robot_missing_command_keys_urdf =
+  std::string(urdf_head) + std::string(hardware_resources_missing_command_keys) +
+  std::string(urdf_tail);
 }  // namespace ros2_control_test_assets
 
 #endif  // ROS2_CONTROL_TEST_ASSETS__DESCRIPTIONS_HPP_

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -22,6 +22,10 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+  )
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gmock(

--- a/transmission_interface/include/transmission_interface/accessor.hpp
+++ b/transmission_interface/include/transmission_interface/accessor.hpp
@@ -22,48 +22,47 @@
 
 namespace transmission_interface
 {
-
-template<typename T>
+template <typename T>
 std::string to_string(const std::vector<T> & list)
 {
   std::stringstream ss;
   ss << "[";
-  for (const auto & elem : list) {
+  for (const auto & elem : list)
+  {
     ss << elem << ", ";
   }
 
-  if (!list.empty()) {
+  if (!list.empty())
+  {
     ss.seekp(-2, std::ios_base::end);  // remove last ", "
   }
   ss << "]";
   return ss.str();
 }
 
-template<class T>
+template <class T>
 std::vector<std::string> get_names(const std::vector<T> & handles)
 {
   std::set<std::string> names;
   std::transform(
-    handles.cbegin(), handles.cend(),
-    std::inserter(names, names.end()),
-    [](const auto & handle) {return handle.get_name();});
+    handles.cbegin(), handles.cend(), std::inserter(names, names.end()),
+    [](const auto & handle) { return handle.get_name(); });
   return std::vector<std::string>(names.begin(), names.end());
 }
 
-template<typename T>
+template <typename T>
 std::vector<T> get_ordered_handles(
-  const std::vector<T> & unordered_handles,
-  const std::vector<std::string> & names,
+  const std::vector<T> & unordered_handles, const std::vector<std::string> & names,
   const std::string & interface_type)
 {
   std::vector<T> result;
-  for (const auto & name : names) {
+  for (const auto & name : names)
+  {
     std::copy_if(
-      unordered_handles.cbegin(), unordered_handles.cend(),
-      std::back_inserter(result), [&](const auto & handle) {
-        return (handle.get_name() == name) &&
-        (handle.get_interface_name() == interface_type) &&
-        handle;
+      unordered_handles.cbegin(), unordered_handles.cend(), std::back_inserter(result),
+      [&](const auto & handle) {
+        return (handle.get_name() == name) && (handle.get_interface_name() == interface_type) &&
+               handle;
       });
   }
   return result;

--- a/transmission_interface/include/transmission_interface/differential_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/differential_transmission.hpp
@@ -27,7 +27,6 @@
 
 namespace transmission_interface
 {
-
 /// Implementation of a differential transmission.
 /**
  *
@@ -112,8 +111,7 @@ public:
    * \pre Nonzero actuator and joint reduction values.
    */
   DifferentialTransmission(
-    const std::vector<double> & actuator_reduction,
-    const std::vector<double> & joint_reduction,
+    const std::vector<double> & actuator_reduction, const std::vector<double> & joint_reduction,
     const std::vector<double> & joint_offset = {0.0, 0.0});
 
   /**
@@ -139,12 +137,12 @@ public:
    */
   void joint_to_actuator() override;
 
-  std::size_t num_actuators() const override {return 2;}
-  std::size_t num_joints()    const override {return 2;}
+  std::size_t num_actuators() const override { return 2; }
+  std::size_t num_joints() const override { return 2; }
 
-  const std::vector<double> & get_actuator_reduction() const {return actuator_reduction_;}
-  const std::vector<double> & get_joint_reduction()    const {return joint_reduction_;}
-  const std::vector<double> & get_joint_offset()       const {return joint_offset_;}
+  const std::vector<double> & get_actuator_reduction() const { return actuator_reduction_; }
+  const std::vector<double> & get_joint_reduction() const { return joint_reduction_; }
+  const std::vector<double> & get_joint_offset() const { return joint_offset_; }
 
   /// Get human-friendly report of handles
   std::string get_handles_info() const;
@@ -164,23 +162,21 @@ protected:
 };
 
 inline DifferentialTransmission::DifferentialTransmission(
-  const std::vector<double> & actuator_reduction,
-  const std::vector<double> & joint_reduction,
+  const std::vector<double> & actuator_reduction, const std::vector<double> & joint_reduction,
   const std::vector<double> & joint_offset)
 : actuator_reduction_(actuator_reduction),
   joint_reduction_(joint_reduction),
   joint_offset_(joint_offset)
 {
-  if (num_actuators() != actuator_reduction_.size() ||
-    num_joints() != joint_reduction_.size() ||
+  if (
+    num_actuators() != actuator_reduction_.size() || num_joints() != joint_reduction_.size() ||
     num_joints() != joint_offset_.size())
   {
     throw Exception("Reduction and offset vectors must have size 2.");
   }
 
-  if (0.0 == actuator_reduction_[0] ||
-    0.0 == actuator_reduction_[1] ||
-    0.0 == joint_reduction_[0] ||
+  if (
+    0.0 == actuator_reduction_[0] || 0.0 == actuator_reduction_[1] || 0.0 == joint_reduction_[0] ||
     0.0 == joint_reduction_[1])
   {
     throw Exception("Transmission reduction ratios cannot be zero.");
@@ -191,58 +187,58 @@ void DifferentialTransmission::configure(
   const std::vector<JointHandle> & joint_handles,
   const std::vector<ActuatorHandle> & actuator_handles)
 {
-  if (joint_handles.empty()) {
+  if (joint_handles.empty())
+  {
     throw Exception("No joint handles were passed in");
   }
 
-  if (actuator_handles.empty()) {
+  if (actuator_handles.empty())
+  {
     throw Exception("No actuator handles were passed in");
   }
 
   const auto joint_names = get_names(joint_handles);
-  if (joint_names.size() != 2) {
+  if (joint_names.size() != 2)
+  {
     throw Exception(
-            "There should be exactly two unique joint names but was given " +
-            to_string(joint_names));
+      "There should be exactly two unique joint names but was given " + to_string(joint_names));
   }
   const auto actuator_names = get_names(actuator_handles);
-  if (actuator_names.size() != 2) {
+  if (actuator_names.size() != 2)
+  {
     throw Exception(
-            "There should be exactly two unique actuator names but was given " +
-            to_string(actuator_names));
+      "There should be exactly two unique actuator names but was given " +
+      to_string(actuator_names));
   }
 
-  joint_position_ = get_ordered_handles(
-    joint_handles, joint_names,
-    hardware_interface::HW_IF_POSITION);
-  joint_velocity_ = get_ordered_handles(
-    joint_handles, joint_names,
-    hardware_interface::HW_IF_VELOCITY);
+  joint_position_ =
+    get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_POSITION);
+  joint_velocity_ =
+    get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_VELOCITY);
   joint_effort_ = get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_EFFORT);
 
-  if (joint_position_.size() != 2 && joint_velocity_.size() != 2 && joint_effort_.size() != 2) {
+  if (joint_position_.size() != 2 && joint_velocity_.size() != 2 && joint_effort_.size() != 2)
+  {
     throw Exception("Not enough valid or required joint handles were presented.");
   }
 
-  actuator_position_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_POSITION);
-  actuator_velocity_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_VELOCITY);
-  actuator_effort_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_EFFORT);
+  actuator_position_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_POSITION);
+  actuator_velocity_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_VELOCITY);
+  actuator_effort_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_EFFORT);
 
-  if (actuator_position_.size() != 2 && actuator_velocity_.size() != 2 &&
+  if (
+    actuator_position_.size() != 2 && actuator_velocity_.size() != 2 &&
     actuator_effort_.size() != 2)
   {
     throw Exception(
-            "Not enough valid or required actuator handles were presented. \n" +
-            get_handles_info() );
+      "Not enough valid or required actuator handles were presented. \n" + get_handles_info());
   }
 
-  if (joint_position_.size() != actuator_position_.size() &&
+  if (
+    joint_position_.size() != actuator_position_.size() &&
     joint_velocity_.size() != actuator_velocity_.size() &&
     joint_effort_.size() != actuator_effort_.size())
   {
@@ -257,41 +253,40 @@ inline void DifferentialTransmission::actuator_to_joint()
 
   auto & act_pos = actuator_position_;
   auto & joint_pos = joint_position_;
-  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints()) {
+  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints())
+  {
     assert(act_pos[0] && act_pos[1] && joint_pos[0] && joint_pos[1]);
 
     joint_pos[0].set_value(
-      (act_pos[0].get_value() / ar[0] + act_pos[1].get_value() / ar[1]) /
-      (2.0 * jr[0]) + joint_offset_[0]);
+      (act_pos[0].get_value() / ar[0] + act_pos[1].get_value() / ar[1]) / (2.0 * jr[0]) +
+      joint_offset_[0]);
     joint_pos[1].set_value(
-      (act_pos[0].get_value() / ar[0] - act_pos[1].get_value() / ar[1]) /
-      (2.0 * jr[1]) + joint_offset_[1]);
+      (act_pos[0].get_value() / ar[0] - act_pos[1].get_value() / ar[1]) / (2.0 * jr[1]) +
+      joint_offset_[1]);
   }
 
   auto & act_vel = actuator_velocity_;
   auto & joint_vel = joint_velocity_;
-  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints()) {
+  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints())
+  {
     assert(act_vel[0] && act_vel[1] && joint_vel[0] && joint_vel[1]);
 
     joint_vel[0].set_value(
-      (act_vel[0].get_value() / ar[0] + act_vel[1].get_value() / ar[1]) /
-      (2.0 * jr[0]));
+      (act_vel[0].get_value() / ar[0] + act_vel[1].get_value() / ar[1]) / (2.0 * jr[0]));
     joint_vel[1].set_value(
-      (act_vel[0].get_value() / ar[0] - act_vel[1].get_value() / ar[1]) /
-      (2.0 * jr[1]));
+      (act_vel[0].get_value() / ar[0] - act_vel[1].get_value() / ar[1]) / (2.0 * jr[1]));
   }
 
   auto & act_eff = actuator_effort_;
   auto & joint_eff = joint_effort_;
-  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints()) {
+  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints())
+  {
     assert(act_eff[0] && act_eff[1] && joint_eff[0] && joint_eff[1]);
 
     joint_eff[0].set_value(
-      jr[0] *
-      (act_eff[0].get_value() * ar[0] + act_eff[1].get_value() * ar[1]));
+      jr[0] * (act_eff[0].get_value() * ar[0] + act_eff[1].get_value() * ar[1]));
     joint_eff[1].set_value(
-      jr[1] *
-      (act_eff[0].get_value() * ar[0] - act_eff[1].get_value() * ar[1]));
+      jr[1] * (act_eff[0].get_value() * ar[0] - act_eff[1].get_value() * ar[1]));
   }
 }
 
@@ -302,56 +297,52 @@ inline void DifferentialTransmission::joint_to_actuator()
 
   auto & act_pos = actuator_position_;
   auto & joint_pos = joint_position_;
-  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints()) {
+  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints())
+  {
     assert(act_pos[0] && act_pos[1] && joint_pos[0] && joint_pos[1]);
 
-    double joints_offset_applied[2] = {joint_pos[0].get_value() - joint_offset_[0],
-      joint_pos[1].get_value() - joint_offset_[1]};
+    double joints_offset_applied[2] = {
+      joint_pos[0].get_value() - joint_offset_[0], joint_pos[1].get_value() - joint_offset_[1]};
     act_pos[0].set_value(
-      (joints_offset_applied[0] * jr[0] + joints_offset_applied[1] * jr[1]) *
-      ar[0]);
+      (joints_offset_applied[0] * jr[0] + joints_offset_applied[1] * jr[1]) * ar[0]);
     act_pos[1].set_value(
-      (joints_offset_applied[0] * jr[0] - joints_offset_applied[1] * jr[1]) *
-      ar[1]);
+      (joints_offset_applied[0] * jr[0] - joints_offset_applied[1] * jr[1]) * ar[1]);
   }
 
   auto & act_vel = actuator_velocity_;
   auto & joint_vel = joint_velocity_;
-  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints()) {
+  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints())
+  {
     assert(act_vel[0] && act_vel[1] && joint_vel[0] && joint_vel[1]);
 
     act_vel[0].set_value(
-      (joint_vel[0].get_value() * jr[0] + joint_vel[1].get_value() * jr[1]) *
-      ar[0]);
+      (joint_vel[0].get_value() * jr[0] + joint_vel[1].get_value() * jr[1]) * ar[0]);
     act_vel[1].set_value(
-      (joint_vel[0].get_value() * jr[0] - joint_vel[1].get_value() * jr[1]) *
-      ar[1]);
+      (joint_vel[0].get_value() * jr[0] - joint_vel[1].get_value() * jr[1]) * ar[1]);
   }
 
   auto & act_eff = actuator_effort_;
   auto & joint_eff = joint_effort_;
-  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints()) {
+  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints())
+  {
     assert(act_eff[0] && act_eff[1] && joint_eff[0] && joint_eff[1]);
 
     act_eff[0].set_value(
-      (joint_eff[0].get_value() / jr[0] + joint_eff[1].get_value() / jr[1]) /
-      (2.0 * ar[0]));
+      (joint_eff[0].get_value() / jr[0] + joint_eff[1].get_value() / jr[1]) / (2.0 * ar[0]));
     act_eff[1].set_value(
-      (joint_eff[0].get_value() / jr[0] - joint_eff[1].get_value() / jr[1]) /
-      (2.0 * ar[1]));
+      (joint_eff[0].get_value() / jr[0] - joint_eff[1].get_value() / jr[1]) / (2.0 * ar[1]));
   }
 }
 
 std::string DifferentialTransmission::get_handles_info() const
 {
   return std::string("Got the following handles:\n") +
-         "Joint position: " + to_string(get_names(joint_position_)) + ", Actuator position: " +
-         to_string(get_names(actuator_position_) ) + "\n" +
-         "Joint velocity: " + to_string(get_names(joint_velocity_)) + ", Actuator velocity: " +
-         to_string(get_names(actuator_velocity_) ) + "\n" +
-         "Joint effort: " + to_string(get_names(joint_effort_)) + ", Actuator effort: " + to_string(
-    get_names(
-      actuator_effort_));
+         "Joint position: " + to_string(get_names(joint_position_)) +
+         ", Actuator position: " + to_string(get_names(actuator_position_)) + "\n" +
+         "Joint velocity: " + to_string(get_names(joint_velocity_)) +
+         ", Actuator velocity: " + to_string(get_names(actuator_velocity_)) + "\n" +
+         "Joint effort: " + to_string(get_names(joint_effort_)) +
+         ", Actuator effort: " + to_string(get_names(actuator_effort_));
 }
 
 }  // namespace transmission_interface

--- a/transmission_interface/include/transmission_interface/exception.hpp
+++ b/transmission_interface/include/transmission_interface/exception.hpp
@@ -14,21 +14,16 @@
 #ifndef TRANSMISSION_INTERFACE__EXCEPTION_HPP_
 #define TRANSMISSION_INTERFACE__EXCEPTION_HPP_
 
-
 #include <exception>
 #include <string>
 
 namespace transmission_interface
 {
-
 class Exception : public std::exception
 {
 public:
-  explicit Exception(const std::string & message)
-  : msg(message)
-  {
-  }
-  const char * what() const noexcept override {return msg.c_str();}
+  explicit Exception(const std::string & message) : msg(message) {}
+  const char * what() const noexcept override { return msg.c_str(); }
 
 private:
   std::string msg;

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.hpp
@@ -27,7 +27,6 @@
 
 namespace transmission_interface
 {
-
 /// Implementation of a four-bar-linkage transmission.
 /**
 *
@@ -111,8 +110,7 @@ public:
    * \pre Nonzero actuator reduction values.
    */
   FourBarLinkageTransmission(
-    const std::vector<double> & actuator_reduction,
-    const std::vector<double> & joint_reduction,
+    const std::vector<double> & actuator_reduction, const std::vector<double> & joint_reduction,
     const std::vector<double> & joint_offset = std::vector<double>(2, 0.0));
 
   /**
@@ -138,12 +136,12 @@ public:
    */
   void joint_to_actuator() override;
 
-  std::size_t num_actuators() const override {return 2;}
-  std::size_t num_joints()    const override {return 2;}
+  std::size_t num_actuators() const override { return 2; }
+  std::size_t num_joints() const override { return 2; }
 
-  const std::vector<double> & get_actuator_reduction() const {return actuator_reduction_;}
-  const std::vector<double> & get_joint_reduction()    const {return joint_reduction_;}
-  const std::vector<double> & get_joint_offset()       const {return joint_offset_;}
+  const std::vector<double> & get_actuator_reduction() const { return actuator_reduction_; }
+  const std::vector<double> & get_joint_reduction() const { return joint_reduction_; }
+  const std::vector<double> & get_joint_offset() const { return joint_offset_; }
 
   /// Get human-friendly report of handles
   std::string get_handles_info() const;
@@ -163,22 +161,20 @@ protected:
 };
 
 inline FourBarLinkageTransmission::FourBarLinkageTransmission(
-  const std::vector<double> & actuator_reduction,
-  const std::vector<double> & joint_reduction,
+  const std::vector<double> & actuator_reduction, const std::vector<double> & joint_reduction,
   const std::vector<double> & joint_offset)
 : actuator_reduction_(actuator_reduction),
   joint_reduction_(joint_reduction),
   joint_offset_(joint_offset)
 {
-  if (num_actuators() != actuator_reduction_.size() ||
-    num_joints() != joint_reduction_.size() ||
+  if (
+    num_actuators() != actuator_reduction_.size() || num_joints() != joint_reduction_.size() ||
     num_joints() != joint_offset_.size())
   {
     throw Exception("Reduction and offset vectors must have size 2.");
   }
-  if (0.0 == actuator_reduction_[0] ||
-    0.0 == actuator_reduction_[1] ||
-    0.0 == joint_reduction_[0] ||
+  if (
+    0.0 == actuator_reduction_[0] || 0.0 == actuator_reduction_[1] || 0.0 == joint_reduction_[0] ||
     0.0 == joint_reduction_[1])
   {
     throw Exception("Transmission reduction ratios cannot be zero.");
@@ -189,58 +185,58 @@ void FourBarLinkageTransmission::configure(
   const std::vector<JointHandle> & joint_handles,
   const std::vector<ActuatorHandle> & actuator_handles)
 {
-  if (joint_handles.empty()) {
+  if (joint_handles.empty())
+  {
     throw Exception("No joint handles were passed in");
   }
 
-  if (actuator_handles.empty()) {
+  if (actuator_handles.empty())
+  {
     throw Exception("No actuator handles were passed in");
   }
 
   const auto joint_names = get_names(joint_handles);
-  if (joint_names.size() != 2) {
+  if (joint_names.size() != 2)
+  {
     throw Exception(
-            "There should be exactly two unique joint names but was given " +
-            to_string(joint_names));
+      "There should be exactly two unique joint names but was given " + to_string(joint_names));
   }
   const auto actuator_names = get_names(actuator_handles);
-  if (actuator_names.size() != 2) {
+  if (actuator_names.size() != 2)
+  {
     throw Exception(
-            "There should be exactly two unique actuator names but was given " +
-            to_string(actuator_names));
+      "There should be exactly two unique actuator names but was given " +
+      to_string(actuator_names));
   }
 
-  joint_position_ = get_ordered_handles(
-    joint_handles, joint_names,
-    hardware_interface::HW_IF_POSITION);
-  joint_velocity_ = get_ordered_handles(
-    joint_handles, joint_names,
-    hardware_interface::HW_IF_VELOCITY);
+  joint_position_ =
+    get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_POSITION);
+  joint_velocity_ =
+    get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_VELOCITY);
   joint_effort_ = get_ordered_handles(joint_handles, joint_names, hardware_interface::HW_IF_EFFORT);
 
-  if (joint_position_.size() != 2 && joint_velocity_.size() != 2 && joint_effort_.size() != 2) {
+  if (joint_position_.size() != 2 && joint_velocity_.size() != 2 && joint_effort_.size() != 2)
+  {
     throw Exception("Not enough valid or required joint handles were presented.");
   }
 
-  actuator_position_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_POSITION);
-  actuator_velocity_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_VELOCITY);
-  actuator_effort_ = get_ordered_handles(
-    actuator_handles, actuator_names,
-    hardware_interface::HW_IF_EFFORT);
+  actuator_position_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_POSITION);
+  actuator_velocity_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_VELOCITY);
+  actuator_effort_ =
+    get_ordered_handles(actuator_handles, actuator_names, hardware_interface::HW_IF_EFFORT);
 
-  if (actuator_position_.size() != 2 && actuator_velocity_.size() != 2 &&
+  if (
+    actuator_position_.size() != 2 && actuator_velocity_.size() != 2 &&
     actuator_effort_.size() != 2)
   {
     throw Exception(
-            "Not enough valid or required actuator handles were presented. \n" +
-            get_handles_info() );
+      "Not enough valid or required actuator handles were presented. \n" + get_handles_info());
   }
 
-  if (joint_position_.size() != actuator_position_.size() &&
+  if (
+    joint_position_.size() != actuator_position_.size() &&
     joint_velocity_.size() != actuator_velocity_.size() &&
     joint_effort_.size() != actuator_effort_.size())
   {
@@ -256,42 +252,40 @@ inline void FourBarLinkageTransmission::actuator_to_joint()
   // position
   auto & act_pos = actuator_position_;
   auto & joint_pos = joint_position_;
-  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints()) {
+  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints())
+  {
     assert(act_pos[0] && act_pos[1] && joint_pos[0] && joint_pos[1]);
 
-    joint_pos[0].set_value(
-      act_pos[0].get_value() / (jr[0] * ar[0]) + joint_offset_[0]);
+    joint_pos[0].set_value(act_pos[0].get_value() / (jr[0] * ar[0]) + joint_offset_[0]);
     joint_pos[1].set_value(
-      (act_pos[1].get_value() / ar[1] - act_pos[0].get_value() / (jr[0] * ar[0])) /
-      jr[1] + joint_offset_[1]);
+      (act_pos[1].get_value() / ar[1] - act_pos[0].get_value() / (jr[0] * ar[0])) / jr[1] +
+      joint_offset_[1]);
   }
 
   // velocity
   auto & act_vel = actuator_velocity_;
   auto & joint_vel = joint_velocity_;
-  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints()) {
+  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints())
+  {
     assert(act_vel[0] && act_vel[1] && joint_vel[0] && joint_vel[1]);
 
     joint_vel[0].set_value(act_vel[0].get_value() / (jr[0] * ar[0]));
     joint_vel[1].set_value(
-      (act_vel[1].get_value() / ar[1] - act_vel[0].get_value() /
-      (jr[0] * ar[0])) / jr[1]);
+      (act_vel[1].get_value() / ar[1] - act_vel[0].get_value() / (jr[0] * ar[0])) / jr[1]);
   }
-
 
   // effort
   auto & act_eff = actuator_effort_;
   auto & joint_eff = joint_effort_;
-  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints()) {
+  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints())
+  {
     assert(act_eff[0] && act_eff[1] && joint_eff[0] && joint_eff[1]);
 
     joint_eff[0].set_value(jr[0] * act_eff[0].get_value() * ar[0]);
     joint_eff[1].set_value(
-      jr[1] *
-      (act_eff[1].get_value() * ar[1] - act_eff[0].get_value() * ar[0] * jr[0] ));
+      jr[1] * (act_eff[1].get_value() * ar[1] - act_eff[0].get_value() * ar[0] * jr[0]));
   }
 }
-
 
 inline void FourBarLinkageTransmission::joint_to_actuator()
 {
@@ -301,11 +295,12 @@ inline void FourBarLinkageTransmission::joint_to_actuator()
   // position
   auto & act_pos = actuator_position_;
   auto & joint_pos = joint_position_;
-  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints()) {
+  if (act_pos.size() == num_actuators() && joint_pos.size() == num_joints())
+  {
     assert(act_pos[0] && act_pos[1] && joint_pos[0] && joint_pos[1]);
 
-    double joints_offset_applied[2] =
-    {joint_pos[0].get_value() - joint_offset_[0], joint_pos[1].get_value() - joint_offset_[1]};
+    double joints_offset_applied[2] = {
+      joint_pos[0].get_value() - joint_offset_[0], joint_pos[1].get_value() - joint_offset_[1]};
     act_pos[0].set_value(joints_offset_applied[0] * jr[0] * ar[0]);
     act_pos[1].set_value((joints_offset_applied[0] + joints_offset_applied[1] * jr[1]) * ar[1]);
   }
@@ -313,7 +308,8 @@ inline void FourBarLinkageTransmission::joint_to_actuator()
   // velocity
   auto & act_vel = actuator_velocity_;
   auto & joint_vel = joint_velocity_;
-  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints()) {
+  if (act_vel.size() == num_actuators() && joint_vel.size() == num_joints())
+  {
     assert(act_vel[0] && act_vel[1] && joint_vel[0] && joint_vel[1]);
 
     act_vel[0].set_value(joint_vel[0].get_value() * jr[0] * ar[0]);
@@ -323,7 +319,8 @@ inline void FourBarLinkageTransmission::joint_to_actuator()
   // effort
   auto & act_eff = actuator_effort_;
   auto & joint_eff = joint_effort_;
-  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints()) {
+  if (act_eff.size() == num_actuators() && joint_eff.size() == num_joints())
+  {
     assert(act_eff[0] && act_eff[1] && joint_eff[0] && joint_eff[1]);
 
     act_eff[0].set_value(joint_eff[0].get_value() / (ar[0] * jr[0]));
@@ -334,13 +331,12 @@ inline void FourBarLinkageTransmission::joint_to_actuator()
 std::string FourBarLinkageTransmission::get_handles_info() const
 {
   return std::string("Got the following handles:\n") +
-         "Joint position: " + to_string(get_names(joint_position_)) + ", Actuator position: " +
-         to_string(get_names(actuator_position_) ) + "\n" +
-         "Joint velocity: " + to_string(get_names(joint_velocity_)) + ", Actuator velocity: " +
-         to_string(get_names(actuator_velocity_) ) + "\n" +
-         "Joint effort: " + to_string(get_names(joint_effort_)) + ", Actuator effort: " + to_string(
-    get_names(
-      actuator_effort_));
+         "Joint position: " + to_string(get_names(joint_position_)) +
+         ", Actuator position: " + to_string(get_names(actuator_position_)) + "\n" +
+         "Joint velocity: " + to_string(get_names(joint_velocity_)) +
+         ", Actuator velocity: " + to_string(get_names(actuator_velocity_)) + "\n" +
+         "Joint effort: " + to_string(get_names(joint_effort_)) +
+         ", Actuator effort: " + to_string(get_names(actuator_effort_));
 }
 
 }  // namespace transmission_interface

--- a/transmission_interface/include/transmission_interface/simple_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/simple_transmission.hpp
@@ -21,12 +21,11 @@
 #include <vector>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "transmission_interface/transmission.hpp"
 #include "transmission_interface/exception.hpp"
+#include "transmission_interface/transmission.hpp"
 
 namespace transmission_interface
 {
-
 /// Implementation of a simple reducer transmission.
 /**
  * This transmission relates <b>one actuator</b> and <b>one joint</b> through a reductor (or amplifier).
@@ -86,9 +85,7 @@ public:
    * \param[in] joint_offset Joint position offset used in the position mappings.
    * \pre Nonzero reduction value.
    */
-  SimpleTransmission(
-    const double joint_to_actuator_reduction,
-    const double joint_offset = 0.0);
+  SimpleTransmission(const double joint_to_actuator_reduction, const double joint_offset = 0.0);
 
   /// Set up the data the transmission operates on.
   /**
@@ -115,11 +112,11 @@ public:
    */
   void joint_to_actuator() override;
 
-  std::size_t num_actuators() const override {return 1;}
-  std::size_t num_joints()    const override {return 1;}
+  std::size_t num_actuators() const override { return 1; }
+  std::size_t num_joints() const override { return 1; }
 
-  double get_actuator_reduction() const {return reduction_;}
-  double get_joint_offset()       const {return jnt_offset_;}
+  double get_actuator_reduction() const { return reduction_; }
+  double get_joint_offset() const { return jnt_offset_; }
 
 protected:
   double reduction_;
@@ -135,38 +132,36 @@ protected:
 };
 
 inline SimpleTransmission::SimpleTransmission(
-  const double joint_to_actuator_reduction,
-  const double joint_offset)
-: reduction_(joint_to_actuator_reduction),
-  jnt_offset_(joint_offset)
+  const double joint_to_actuator_reduction, const double joint_offset)
+: reduction_(joint_to_actuator_reduction), jnt_offset_(joint_offset)
 {
-  if (reduction_ == 0.0) {
+  if (reduction_ == 0.0)
+  {
     throw Exception("Transmission reduction ratio cannot be zero.");
   }
 }
 
-template<class HandleType>
+template <class HandleType>
 HandleType get_by_interface(
-  const std::vector<HandleType> & handles,
-  const std::string & interface_name)
+  const std::vector<HandleType> & handles, const std::string & interface_name)
 {
-  const auto result =
-    std::find_if(
-    handles.cbegin(), handles.cend(), [&interface_name](
-      const auto handle) {return handle.get_interface_name() == interface_name;});
-  if (result == handles.cend()) {
+  const auto result = std::find_if(
+    handles.cbegin(), handles.cend(),
+    [&interface_name](const auto handle) { return handle.get_interface_name() == interface_name; });
+  if (result == handles.cend())
+  {
     return HandleType(handles.cbegin()->get_name(), interface_name, nullptr);
   }
   return *result;
 }
 
-template<class T>
+template <class T>
 bool are_names_identical(const std::vector<T> & handles)
 {
   std::vector<std::string> names;
   std::transform(
     handles.cbegin(), handles.cend(), std::back_inserter(names),
-    [](const auto & handle) {return handle.get_name();});
+    [](const auto & handle) { return handle.get_name(); });
   return std::equal(names.cbegin() + 1, names.cend(), names.cbegin());
 }
 
@@ -174,19 +169,23 @@ void SimpleTransmission::configure(
   const std::vector<JointHandle> & joint_handles,
   const std::vector<ActuatorHandle> & actuator_handles)
 {
-  if (joint_handles.empty()) {
+  if (joint_handles.empty())
+  {
     throw Exception("No joint handles were passed in");
   }
 
-  if (actuator_handles.empty()) {
+  if (actuator_handles.empty())
+  {
     throw Exception("No actuator handles were passed in");
   }
 
-  if (!are_names_identical(joint_handles) ) {
+  if (!are_names_identical(joint_handles))
+  {
     throw Exception("Joint names given to transmissions should be identical");
   }
 
-  if (!are_names_identical(actuator_handles) ) {
+  if (!are_names_identical(actuator_handles))
+  {
     throw Exception("Actuator names given to transmissions should be identical");
   }
 
@@ -194,7 +193,8 @@ void SimpleTransmission::configure(
   joint_velocity_ = get_by_interface(joint_handles, hardware_interface::HW_IF_VELOCITY);
   joint_effort_ = get_by_interface(joint_handles, hardware_interface::HW_IF_EFFORT);
 
-  if (!joint_position_ && !joint_velocity_ && !joint_effort_) {
+  if (!joint_position_ && !joint_velocity_ && !joint_effort_)
+  {
     throw Exception("None of the provided joint handles are valid or from the required interfaces");
   }
 
@@ -202,38 +202,44 @@ void SimpleTransmission::configure(
   actuator_velocity_ = get_by_interface(actuator_handles, hardware_interface::HW_IF_VELOCITY);
   actuator_effort_ = get_by_interface(actuator_handles, hardware_interface::HW_IF_EFFORT);
 
-  if (!actuator_position_ && !actuator_velocity_ && !actuator_effort_) {
+  if (!actuator_position_ && !actuator_velocity_ && !actuator_effort_)
+  {
     throw Exception("None of the provided joint handles are valid or from the required interfaces");
   }
 }
 
 inline void SimpleTransmission::actuator_to_joint()
 {
-  if (joint_effort_ && actuator_effort_) {
+  if (joint_effort_ && actuator_effort_)
+  {
     joint_effort_.set_value(actuator_effort_.get_value() * reduction_);
   }
 
-  if (joint_velocity_ && actuator_velocity_) {
+  if (joint_velocity_ && actuator_velocity_)
+  {
     joint_velocity_.set_value(actuator_velocity_.get_value() / reduction_);
   }
 
-  if (joint_position_ && actuator_position_) {
+  if (joint_position_ && actuator_position_)
+  {
     joint_position_.set_value(actuator_position_.get_value() / reduction_ + jnt_offset_);
   }
 }
 
-
 inline void SimpleTransmission::joint_to_actuator()
 {
-  if (joint_effort_ && actuator_effort_) {
+  if (joint_effort_ && actuator_effort_)
+  {
     actuator_effort_.set_value(joint_effort_.get_value() / reduction_);
   }
 
-  if (joint_velocity_ && actuator_velocity_) {
+  if (joint_velocity_ && actuator_velocity_)
+  {
     actuator_velocity_.set_value(joint_velocity_.get_value() * reduction_);
   }
 
-  if (joint_position_ && actuator_position_) {
+  if (joint_position_ && actuator_position_)
+  {
     actuator_position_.set_value((joint_position_.get_value() - jnt_offset_) * reduction_);
   }
 }

--- a/transmission_interface/include/transmission_interface/simple_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/simple_transmission.hpp
@@ -85,7 +85,8 @@ public:
    * \param[in] joint_offset Joint position offset used in the position mappings.
    * \pre Nonzero reduction value.
    */
-  SimpleTransmission(const double joint_to_actuator_reduction, const double joint_offset = 0.0);
+  explicit SimpleTransmission(
+    const double joint_to_actuator_reduction, const double joint_offset = 0.0);
 
   /// Set up the data the transmission operates on.
   /**

--- a/transmission_interface/include/transmission_interface/transmission.hpp
+++ b/transmission_interface/include/transmission_interface/transmission.hpp
@@ -14,18 +14,16 @@
 #ifndef TRANSMISSION_INTERFACE__TRANSMISSION_HPP_
 #define TRANSMISSION_INTERFACE__TRANSMISSION_HPP_
 
-
 #include <cstddef>
-#include <string>
-#include <vector>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "transmission_interface/handle.hpp"
 
 namespace transmission_interface
 {
-
 /// Abstract base class for representing mechanical transmissions.
 /**
  * Mechanical transmissions transform effort/flow variables such that their product (power) remains constant.

--- a/transmission_interface/include/transmission_interface/transmission_parser.hpp
+++ b/transmission_interface/include/transmission_interface/transmission_parser.hpp
@@ -21,9 +21,8 @@
 #ifndef TRANSMISSION_INTERFACE__TRANSMISSION_PARSER_HPP_
 #define TRANSMISSION_INTERFACE__TRANSMISSION_PARSER_HPP_
 
-
-#include <transmission_interface/transmission_info.hpp>
 #include <transmission_interface/visibility_control.h>
+#include <transmission_interface/transmission_info.hpp>
 
 #include <tinyxml2.h>
 
@@ -32,7 +31,6 @@
 
 namespace transmission_interface
 {
-
 /// Parses the joint elements within transmission elements of a URDF
 /**
  * If parse errors occur a std::runtime_error will be thrown with a description of the problem.

--- a/transmission_interface/include/transmission_interface/visibility_control.h
+++ b/transmission_interface/include/transmission_interface/visibility_control.h
@@ -19,31 +19,31 @@
 //     https://gcc.gnu.org/wiki/Visibility
 
 #if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define TRANSMISSION_INTERFACE_EXPORT __attribute__ ((dllexport))
-    #define TRANSMISSION_INTERFACE_IMPORT __attribute__ ((dllimport))
-  #else
-    #define TRANSMISSION_INTERFACE_EXPORT __declspec(dllexport)
-    #define TRANSMISSION_INTERFACE_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef TRANSMISSION_INTERFACE_BUILDING_DLL
-    #define TRANSMISSION_INTERFACE_PUBLIC TRANSMISSION_INTERFACE_EXPORT
-  #else
-    #define TRANSMISSION_INTERFACE_PUBLIC TRANSMISSION_INTERFACE_IMPORT
-  #endif
-  #define TRANSMISSION_INTERFACE_PUBLIC_TYPE TRANSMISSION_INTERFACE_PUBLIC
-  #define TRANSMISSION_INTERFACE_LOCAL
+#ifdef __GNUC__
+#define TRANSMISSION_INTERFACE_EXPORT __attribute__((dllexport))
+#define TRANSMISSION_INTERFACE_IMPORT __attribute__((dllimport))
 #else
-  #define TRANSMISSION_INTERFACE_EXPORT __attribute__ ((visibility("default")))
-  #define TRANSMISSION_INTERFACE_IMPORT
-  #if __GNUC__ >= 4
-    #define TRANSMISSION_INTERFACE_PUBLIC __attribute__ ((visibility("default")))
-    #define TRANSMISSION_INTERFACE_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define TRANSMISSION_INTERFACE_PUBLIC
-    #define TRANSMISSION_INTERFACE_LOCAL
-  #endif
-  #define TRANSMISSION_INTERFACE_PUBLIC_TYPE
+#define TRANSMISSION_INTERFACE_EXPORT __declspec(dllexport)
+#define TRANSMISSION_INTERFACE_IMPORT __declspec(dllimport)
+#endif
+#ifdef TRANSMISSION_INTERFACE_BUILDING_DLL
+#define TRANSMISSION_INTERFACE_PUBLIC TRANSMISSION_INTERFACE_EXPORT
+#else
+#define TRANSMISSION_INTERFACE_PUBLIC TRANSMISSION_INTERFACE_IMPORT
+#endif
+#define TRANSMISSION_INTERFACE_PUBLIC_TYPE TRANSMISSION_INTERFACE_PUBLIC
+#define TRANSMISSION_INTERFACE_LOCAL
+#else
+#define TRANSMISSION_INTERFACE_EXPORT __attribute__((visibility("default")))
+#define TRANSMISSION_INTERFACE_IMPORT
+#if __GNUC__ >= 4
+#define TRANSMISSION_INTERFACE_PUBLIC __attribute__((visibility("default")))
+#define TRANSMISSION_INTERFACE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define TRANSMISSION_INTERFACE_PUBLIC
+#define TRANSMISSION_INTERFACE_LOCAL
+#endif
+#define TRANSMISSION_INTERFACE_PUBLIC_TYPE
 #endif
 
 #endif  // TRANSMISSION_INTERFACE__VISIBILITY_CONTROL_H_

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -17,17 +17,17 @@
 #include <vector>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "transmission_interface/differential_transmission.hpp"
 #include "random_generator_utils.hpp"
+#include "transmission_interface/differential_transmission.hpp"
 
+using hardware_interface::HW_IF_EFFORT;
+using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_VELOCITY;
+using testing::DoubleNear;
+using transmission_interface::ActuatorHandle;
 using transmission_interface::DifferentialTransmission;
 using transmission_interface::Exception;
 using transmission_interface::JointHandle;
-using transmission_interface::ActuatorHandle;
-using hardware_interface::HW_IF_POSITION;
-using hardware_interface::HW_IF_VELOCITY;
-using hardware_interface::HW_IF_EFFORT;
-using testing::DoubleNear;
 // Floating-point value comparison threshold
 const double EPS = 1e-6;
 
@@ -62,8 +62,7 @@ TEST(PreconditionsTest, ExceptionThrowing)
   EXPECT_THROW(DifferentialTransmission(reduction_bad_size, reduction_good), Exception);
   EXPECT_THROW(DifferentialTransmission(reduction_good, reduction_bad_size), Exception);
   EXPECT_THROW(
-    DifferentialTransmission(reduction_good, reduction_good, offset_bad_size),
-    Exception);
+    DifferentialTransmission(reduction_good, reduction_good, offset_bad_size), Exception);
 
   // Valid instance creation
   EXPECT_NO_THROW(DifferentialTransmission(reduction_good, reduction_good));
@@ -76,9 +75,7 @@ TEST(PreconditionsTest, AccessorValidation)
   std::vector<double> jnt_reduction = {4.0, -4.0};
   std::vector<double> jnt_offset = {1.0, -1.0};
 
-  DifferentialTransmission trans(act_reduction,
-    jnt_reduction,
-    jnt_offset);
+  DifferentialTransmission trans(act_reduction, jnt_reduction, jnt_offset);
 
   EXPECT_EQ(2u, trans.num_actuators());
   EXPECT_EQ(2u, trans.num_joints());
@@ -111,21 +108,16 @@ void testConfigureWithBadHandles(std::string interface_name)
   EXPECT_THROW(trans.configure({j1_handle, j2_handle}, {a1_handle}), Exception);
   EXPECT_THROW(trans.configure({j1_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle}),
-    Exception);
+    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure({j1_handle, j2_handle}, {a1_handle, a2_handle, a3_handle}),
-    Exception);
+    trans.configure({j1_handle, j2_handle}, {a1_handle, a2_handle, a3_handle}), Exception);
   EXPECT_THROW(
-    trans.configure(
-      {j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle,
-        a3_handle}), Exception);
+    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle, a3_handle}),
+    Exception);
   EXPECT_THROW(trans.configure({j1_handle, j2_handle}, {invalid_a1_handle, a2_handle}), Exception);
   EXPECT_THROW(trans.configure({invalid_j1_handle, j2_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure(
-      {invalid_j1_handle, j2_handle}, {invalid_a1_handle,
-        a2_handle}), Exception);
+    trans.configure({invalid_j1_handle, j2_handle}, {invalid_a1_handle, a2_handle}), Exception);
 }
 
 TEST(ConfigureTest, FailsWithBadHandles)
@@ -155,8 +147,7 @@ protected:
   /// and inverse transmission transformations.
   /// \param interface_name The name of the interface to test, position, velocity, etc.
   void testIdentityMap(
-    DifferentialTransmission & trans,
-    const std::vector<double> & ref_val,
+    DifferentialTransmission & trans, const std::vector<double> & ref_val,
     const std::string & interface_name)
   {
     // set actuator values to reference
@@ -189,13 +180,16 @@ protected:
     // NOTE: Magic value
     RandomDoubleGenerator rand_gen(-1000.0, 1000.0);
 
-    while (out.size() < size) {
-      try {
-        DifferentialTransmission trans(randomVector(2, rand_gen),
-          randomVector(2, rand_gen),
-          randomVector(2, rand_gen));
+    while (out.size() < size)
+    {
+      try
+      {
+        DifferentialTransmission trans(
+          randomVector(2, rand_gen), randomVector(2, rand_gen), randomVector(2, rand_gen));
         out.push_back(trans);
-      } catch (const Exception &) {
+      }
+      catch (const Exception &)
+      {
         // NOTE: If by chance a perfect zero is produced by the random number generator,
         // construction will fail
         // We swallow the exception and move on to prevent a test crash.
@@ -212,13 +206,15 @@ TEST_F(BlackBoxTest, IdentityMap)
   auto transmission_test_instances = createTestInstances(100);
 
   // Test different transmission configurations...
-  for (auto && transmission : transmission_test_instances) {
+  for (auto && transmission : transmission_test_instances)
+  {
     // ...and for each transmission, different input values
     // NOTE: Magic value
     RandomDoubleGenerator rand_gen(-1000.0, 1000.0);
     // NOTE: Magic value
     const unsigned int input_value_trials = 100;
-    for (unsigned int i = 0; i < input_value_trials; ++i) {
+    for (unsigned int i = 0; i < input_value_trials; ++i)
+    {
       vector<double> input_value = randomVector(2, rand_gen);
       // Test each interface type separately
       testIdentityMap(transmission, input_value, HW_IF_POSITION);
@@ -228,8 +224,9 @@ TEST_F(BlackBoxTest, IdentityMap)
   }
 }
 
-
-class WhiteBoxTest : public TransmissionSetup {};
+class WhiteBoxTest : public TransmissionSetup
+{
+};
 
 TEST_F(WhiteBoxTest, DontMoveJoints)
 {

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -19,18 +19,18 @@
 #include <vector>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "transmission_interface/four_bar_linkage_transmission.hpp"
 #include "random_generator_utils.hpp"
+#include "transmission_interface/four_bar_linkage_transmission.hpp"
 
-using transmission_interface::FourBarLinkageTransmission;
-using transmission_interface::Exception;
-using transmission_interface::JointHandle;
-using transmission_interface::ActuatorHandle;
+using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
-using hardware_interface::HW_IF_EFFORT;
-using testing::Not;
 using testing::DoubleNear;
+using testing::Not;
+using transmission_interface::ActuatorHandle;
+using transmission_interface::Exception;
+using transmission_interface::FourBarLinkageTransmission;
+using transmission_interface::JointHandle;
 
 // Floating-point value comparison threshold
 const double EPS = 1e-6;
@@ -66,9 +66,7 @@ TEST(PreconditionsTest, ExceptionThrowing)
   EXPECT_THROW(FourBarLinkageTransmission(reduction_bad_size, reduction_good), Exception);
   EXPECT_THROW(FourBarLinkageTransmission(reduction_good, reduction_bad_size), Exception);
   EXPECT_THROW(
-    FourBarLinkageTransmission(
-      reduction_good, reduction_good,
-      offset_bad_size), Exception);
+    FourBarLinkageTransmission(reduction_good, reduction_good, offset_bad_size), Exception);
 
   // Valid instance creation
   EXPECT_NO_THROW(FourBarLinkageTransmission(reduction_good, reduction_good));
@@ -114,23 +112,17 @@ void testConfigureWithBadHandles(std::string interface_name)
   EXPECT_THROW(trans.configure({j1_handle, j2_handle}, {a1_handle}), Exception);
   EXPECT_THROW(trans.configure({j1_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle}),
-    Exception);
+    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure({j1_handle, j2_handle}, {a1_handle, a2_handle, a3_handle}),
-    Exception);
+    trans.configure({j1_handle, j2_handle}, {a1_handle, a2_handle, a3_handle}), Exception);
   EXPECT_THROW(
-    trans.configure(
-      {j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle,
-        a3_handle}), Exception);
+    trans.configure({j1_handle, j2_handle, j3_handle}, {a1_handle, a2_handle, a3_handle}),
+    Exception);
   EXPECT_THROW(trans.configure({j1_handle, j2_handle}, {invalid_a1_handle, a2_handle}), Exception);
   EXPECT_THROW(trans.configure({invalid_j1_handle, j2_handle}, {a1_handle, a2_handle}), Exception);
   EXPECT_THROW(
-    trans.configure(
-      {invalid_j1_handle, j2_handle}, {invalid_a1_handle,
-        a2_handle}), Exception);
+    trans.configure({invalid_j1_handle, j2_handle}, {invalid_a1_handle, a2_handle}), Exception);
 }
-
 
 TEST(ConfigureTest, FailsWithBadHandles)
 {
@@ -159,8 +151,7 @@ protected:
   /// and inverse transmission transformations.
   /// \param interface_name The name of the interface to test, position, velocity, etc.
   void testIdentityMap(
-    FourBarLinkageTransmission & trans,
-    const std::vector<double> & ref_val,
+    FourBarLinkageTransmission & trans, const std::vector<double> & ref_val,
     const std::string & interface_name)
   {
     // set actuator values to reference
@@ -193,13 +184,16 @@ protected:
     // NOTE: Magic value
     RandomDoubleGenerator rand_gen(-1000.0, 1000.0);
 
-    while (out.size() < size) {
-      try {
-        FourBarLinkageTransmission trans(randomVector(2, rand_gen),
-          randomVector(2, rand_gen),
-          randomVector(2, rand_gen));
+    while (out.size() < size)
+    {
+      try
+      {
+        FourBarLinkageTransmission trans(
+          randomVector(2, rand_gen), randomVector(2, rand_gen), randomVector(2, rand_gen));
         out.push_back(trans);
-      } catch (const Exception &) {
+      }
+      catch (const Exception &)
+      {
         // NOTE: If by chance a perfect zero is produced by the random number generator,
         // construction will fail
         // We swallow the exception and move on to prevent a test crash.
@@ -216,13 +210,15 @@ TEST_F(BlackBoxTest, IdentityMap)
   auto transmission_test_instances = createTestInstances(100);
 
   // Test different transmission configurations...
-  for (auto && transmission : transmission_test_instances) {
+  for (auto && transmission : transmission_test_instances)
+  {
     // ...and for each transmission, different input values
     // NOTE: Magic value
     RandomDoubleGenerator rand_gen(-1000.0, 1000.0);
     // NOTE: Magic value
     const unsigned int input_value_trials = 100;
-    for (unsigned int i = 0; i < input_value_trials; ++i) {
+    for (unsigned int i = 0; i < input_value_trials; ++i)
+    {
       vector<double> input_value = randomVector(2, rand_gen);
       // Test each interface type separately
       testIdentityMap(transmission, input_value, HW_IF_POSITION);
@@ -232,8 +228,9 @@ TEST_F(BlackBoxTest, IdentityMap)
   }
 }
 
-
-class WhiteBoxTest : public TransmissionSetup {};
+class WhiteBoxTest : public TransmissionSetup
+{
+};
 
 TEST_F(WhiteBoxTest, DontMoveJoints)
 {

--- a/transmission_interface/test/random_generator_utils.hpp
+++ b/transmission_interface/test/random_generator_utils.hpp
@@ -17,7 +17,6 @@
 #ifndef RANDOM_GENERATOR_UTILS_HPP_
 #define RANDOM_GENERATOR_UTILS_HPP_
 
-
 #include <cstdlib>
 #include <ctime>
 #include <vector>
@@ -30,9 +29,7 @@ using std::vector;
 struct RandomDoubleGenerator
 {
 public:
-  RandomDoubleGenerator(double min_val, double max_val)
-  : min_val_(min_val),
-    max_val_(max_val)
+  RandomDoubleGenerator(double min_val, double max_val) : min_val_(min_val), max_val_(max_val)
   {
     srand(time(nullptr));
   }
@@ -48,13 +45,12 @@ private:
 };
 
 /// \brief Generator of a vector of pseudo-random doubles.
-vector<double> randomVector(
-  const vector<double>::size_type size,
-  RandomDoubleGenerator & generator)
+vector<double> randomVector(const vector<double>::size_type size, RandomDoubleGenerator & generator)
 {
   vector<double> out;
   out.reserve(size);
-  for (vector<double>::size_type i = 0; i < size; ++i) {
+  for (vector<double>::size_type i = 0; i < size; ++i)
+  {
     out.push_back(generator());
   }
   return out;

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -18,14 +18,14 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "transmission_interface/simple_transmission.hpp"
 
-using std::vector;
-using transmission_interface::SimpleTransmission;
-using transmission_interface::Exception;
-using transmission_interface::ActuatorHandle;
-using transmission_interface::JointHandle;
+using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
-using hardware_interface::HW_IF_EFFORT;
+using std::vector;
+using transmission_interface::ActuatorHandle;
+using transmission_interface::Exception;
+using transmission_interface::JointHandle;
+using transmission_interface::SimpleTransmission;
 
 // Floating-point value comparison threshold
 const double EPS = 1e-6;
@@ -72,28 +72,22 @@ TEST(PreconditionsTest, ConfigureFailsWithInvalidHandles)
   EXPECT_THROW(trans.configure({}, {actuator_handle}), transmission_interface::Exception);
 
   EXPECT_THROW(
-    trans.configure(
-      {joint_handle}, {actuator_handle,
-        actuator2_handle}), transmission_interface::Exception);
+    trans.configure({joint_handle}, {actuator_handle, actuator2_handle}),
+    transmission_interface::Exception);
   EXPECT_THROW(
-    trans.configure(
-      {joint_handle, joint2_handle},
-      {actuator_handle}), transmission_interface::Exception);
+    trans.configure({joint_handle, joint2_handle}, {actuator_handle}),
+    transmission_interface::Exception);
 
   auto invalid_actuator_handle = ActuatorHandle("act1", HW_IF_VELOCITY, nullptr);
   auto invalid_joint_handle = JointHandle("joint1", HW_IF_VELOCITY, nullptr);
   EXPECT_THROW(
-    trans.configure(
-      {invalid_joint_handle},
-      {invalid_actuator_handle}), transmission_interface::Exception);
+    trans.configure({invalid_joint_handle}, {invalid_actuator_handle}),
+    transmission_interface::Exception);
   EXPECT_THROW(
-    trans.configure(
-      {}, {actuator_handle,
-        invalid_actuator_handle}), transmission_interface::Exception);
+    trans.configure({}, {actuator_handle, invalid_actuator_handle}),
+    transmission_interface::Exception);
   EXPECT_THROW(
-    trans.configure(
-      {invalid_joint_handle},
-      {actuator_handle}), transmission_interface::Exception);
+    trans.configure({invalid_joint_handle}, {actuator_handle}), transmission_interface::Exception);
 }
 
 class TransmissionSetup
@@ -111,8 +105,7 @@ protected:
 };
 
 /// Exercises the actuator->joint->actuator roundtrip, which should yield the identity map.
-class BlackBoxTest : public TransmissionSetup,
-  public ::testing::TestWithParam<SimpleTransmission>
+class BlackBoxTest : public TransmissionSetup, public ::testing::TestWithParam<SimpleTransmission>
 {
 protected:
   /**
@@ -122,8 +115,7 @@ protected:
    * and inverse transmission transformations.
    */
   void testIdentityMap(
-    SimpleTransmission & trans, const std::string & interface_name,
-    const double ref_val)
+    SimpleTransmission & trans, const std::string & interface_name, const double ref_val)
   {
     // Effort interface
     {
@@ -169,33 +161,24 @@ TEST_P(BlackBoxTest, IdentityMap)
 
 #ifdef __APPLE__
 INSTANTIATE_TEST_CASE_P(
-  IdentityMap,
-  BlackBoxTest,
+  IdentityMap, BlackBoxTest,
   ::testing::Values(
-    SimpleTransmission(10.0),
-    SimpleTransmission(-10.0),
-    SimpleTransmission(10.0, 1.0),
-    SimpleTransmission(10.0, -1.0),
-    SimpleTransmission(-10.0, 1.0),
-    SimpleTransmission(-10.0, -1.0))
+    SimpleTransmission(10.0), SimpleTransmission(-10.0), SimpleTransmission(10.0, 1.0),
+    SimpleTransmission(10.0, -1.0), SimpleTransmission(-10.0, 1.0), SimpleTransmission(-10.0, -1.0))
   // cppcheck-suppress syntaxError
   , );
 #else
 INSTANTIATE_TEST_CASE_P(
-  IdentityMap,
-  BlackBoxTest,
+  IdentityMap, BlackBoxTest,
   ::testing::Values(
-    SimpleTransmission(10.0),
-    SimpleTransmission(-10.0),
-    SimpleTransmission(10.0, 1.0),
-    SimpleTransmission(10.0, -1.0),
-    SimpleTransmission(-10.0, 1.0),
+    SimpleTransmission(10.0), SimpleTransmission(-10.0), SimpleTransmission(10.0, 1.0),
+    SimpleTransmission(10.0, -1.0), SimpleTransmission(-10.0, 1.0),
     SimpleTransmission(-10.0, -1.0)));
 #endif
 
-
-class WhiteBoxTest : public TransmissionSetup,
-  public ::testing::Test {};
+class WhiteBoxTest : public TransmissionSetup, public ::testing::Test
+{
+};
 
 TEST_F(WhiteBoxTest, MoveJoint)
 {

--- a/transmission_interface/test/test_transmission_parser.cpp
+++ b/transmission_interface/test/test_transmission_parser.cpp
@@ -424,9 +424,7 @@ TEST_F(TestTransmissionParser, successfully_parse_valid_urdf)
 
 TEST_F(TestTransmissionParser, empty_string_throws_error)
 {
-  ASSERT_THROW(
-    transmission_interface::parse_transmissions_from_urdf(""),
-    std::runtime_error);
+  ASSERT_THROW(transmission_interface::parse_transmissions_from_urdf(""), std::runtime_error);
 }
 
 TEST_F(TestTransmissionParser, empty_urdf_returns_empty)
@@ -439,6 +437,5 @@ TEST_F(TestTransmissionParser, empty_urdf_returns_empty)
 TEST_F(TestTransmissionParser, wrong_urdf_throws_error)
 {
   EXPECT_THROW(
-    transmission_interface::parse_transmissions_from_urdf(wrong_urdf_xml_),
-    std::runtime_error);
+    transmission_interface::parse_transmissions_from_urdf(wrong_urdf_xml_), std::runtime_error);
 }


### PR DESCRIPTION
Use `clang-format` instead of `uncrustify` with the configuration demonstrated on `ros2_control_demos` repo.
Clang format is integrated into pre-commit.

For all tests to work, we have to remove `ament_uncrustify` and `ament_cpplint` to run with tests using default configuration.
On the CI `ament_cpplint` is run with adjusted configuration to support our chosen formatting.

The PR depends on #480 to run linters with proper configuration on CI.
