### PR TITLE
fix link to point to read-the-docs

### DIFF
--- a/ros2controlcli/README.rst
+++ b/ros2controlcli/README.rst
@@ -1,3 +1,3 @@
 Read the `Docs`_ for example usage and command line arguments.
 
-.. _Docs: doc/index.rst
+.. _Docs: https://ros-controls.github.io/control.ros.org/ros2_control/ros2controlcli/doc/userdoc.html


### PR DESCRIPTION
the current reference was not working.