### PR TITLE
Automatic parameter declaration - enable existence of undeclared parameters from overrides

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -110,14 +110,14 @@ public:
   template <typename ParameterT>
   auto auto_declare(const std::string & name, const ParameterT & default_value)
   {
-      if (!node_->has_parameter(name))
-      {
-          return node_->declare_parameter<ParameterT>(name, default_value);
-      }
-      else
-      {
-          return node_->get_parameter(name).get_value<ParameterT>();
-      }
+    if (!node_->has_parameter(name))
+    {
+      return node_->declare_parameter<ParameterT>(name, default_value);
+    }
+    else
+    {
+      return node_->get_parameter(name).get_value<ParameterT>();
+    }
   }
 
   /**

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -100,6 +100,26 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   std::shared_ptr<rclcpp::Node> get_node();
 
+  /// Declare and initialize a parameter with a type.
+  /**
+   *
+   * Wrapper function for templated node's declare_parameter() which checks if
+   * parameter is already declared.
+   * For use in all components that inherit from ControllerInterface
+   */
+  template <typename ParameterT>
+  auto auto_declare(const std::string & name, const ParameterT & default_value)
+  {
+      if (!node_->has_parameter(name))
+      {
+          return node_->declare_parameter<ParameterT>(name, default_value);
+      }
+      else
+      {
+          return node_->get_parameter(name).get_value<ParameterT>();
+      }
+  }
+
   /**
    * The methods below are a substitute to the LifecycleNode methods with the same name.
    * The Life cycle is shown in ROS2 design document:

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -27,7 +27,9 @@ namespace controller_interface
 return_type ControllerInterface::init(const std::string & controller_name)
 {
   node_ = std::make_shared<rclcpp::Node>(
-    controller_name, rclcpp::NodeOptions().allow_undeclared_parameters(true));
+    controller_name, rclcpp::NodeOptions()
+                       .allow_undeclared_parameters(true)
+                       .automatically_declare_parameters_from_overrides(true));
   lifecycle_state_ = rclcpp_lifecycle::State(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;
@@ -36,8 +38,10 @@ return_type ControllerInterface::init(const std::string & controller_name)
 return_type ControllerInterface::init(
   const std::string & controller_name, rclcpp::NodeOptions & node_options)
 {
-  node_ =
-    std::make_shared<rclcpp::Node>(controller_name, node_options.allow_undeclared_parameters(true));
+  node_ = std::make_shared<rclcpp::Node>(
+    controller_name,
+    node_options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(
+      true));
   lifecycle_state_ = rclcpp_lifecycle::State(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state_names::UNCONFIGURED);
   return return_type::OK;


### PR DESCRIPTION
PR comes in combination with  [#ros2_controllers/PR224](https://github.com/ros-controls/ros2_controllers/pull/224).

PR enables undeclared parameters to be automatically declared if uploaded via overrides (e.g. yaml files). Helper function is also added to make declaration + check if some parameter already exists easier for components that inherit from ContorllerInterface.