### PR TITLE
fix: :bug: Fix for Doxygen link needing to be relative for GitHub pages

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@
 API Documentation
 =================
 
-API documentation is parsed by doxygen and can be found `here </api/index.html>`_
+API documentation is parsed by doxygen and can be found `here <../../api/index.html>`_
 
 =====================
 Core functionalities


### PR DESCRIPTION
* Change url for Doxygen pages to be from root to a relative link

Fixes #510

You can verify the change works by going to my [fork of control.ros.org](https://jaron-l.github.io/control.ros.org/).