### PR TITLE
[GenericSystem] Add velocity-only mode in fake_components 

### DIFF
--- a/hardware_interface/include/fake_components/generic_system.hpp
+++ b/hardware_interface/include/fake_components/generic_system.hpp
@@ -100,7 +100,6 @@ protected:
   /// The size of this vector is (standard_interfaces_.size() x nr_joints)
   std::vector<std::vector<double>> joint_commands_;
   std::vector<std::vector<double>> joint_states_;
-  double joint_vel_commands_[2];
 
   std::vector<std::string> other_interfaces_;
   /// The size of this vector is (other_interfaces_.size() x nr_joints)
@@ -137,6 +136,7 @@ private:
   std::chrono::system_clock::time_point begin;
   // for velocity control, store last position command
   std::vector<double> joint_pos_commands_old_;
+  double period_;
 };
 
 typedef GenericSystem GenericRobot;

--- a/hardware_interface/include/fake_components/generic_system.hpp
+++ b/hardware_interface/include/fake_components/generic_system.hpp
@@ -109,6 +109,7 @@ private:
   double position_state_following_offset_;
   std::string custom_interface_with_following_offset_;
   size_t index_custom_interface_with_following_offset_;
+    bool command_propagation_disabled_;
 };
 
 typedef GenericSystem GenericRobot;

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -418,28 +418,6 @@ return_type GenericSystem::read()
   double period =
     std::chrono::duration_cast<std::chrono::milliseconds>(begin - begin_last).count() / 1000.0;
 
-//  printf("#############################\n");
-//
-//  for (size_t i = 0; i<joint_commands_.size(); ++i)
-//  {
-//    printf("\n");
-//    for (size_t j = 0; j<joint_commands_[i].size(); ++j)
-//    {
-//
-//        printf(" %f ", joint_commands_[i][j]);
-//
-//    }
-//    printf("\n");
-//
-//  }
-//  printf("!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-
-//  printf("pos ctrl = %d\n", position_controller_running_);
-//  printf("vel ctrl = %d\n", velocity_controller_running_);
-//  printf("disable cmd = %d\n", command_propagation_disabled_);
-//  printf("period = %f\n", period);
-//  printf("vel cmd size = %d\n", joint_commands_[VELOCITY_INTERFACE_INDEX].size());
-
   // apply offset to positions only
   for (size_t j = 0; j < joint_states_[POSITION_INTERFACE_INDEX].size(); ++j)
   {

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -96,6 +96,12 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
   joint_pos_commands_old_.resize(joint_commands_[POSITION_INTERFACE_INDEX].size());
   joint_pos_commands_old_ = joint_commands_[POSITION_INTERFACE_INDEX];
 
+  // joint velocity commands to zero
+  for (auto i = 0u; i < info_.joints.size(); ++i)
+  {
+    joint_vel_commands_[i] = 0.0;
+  }
+
   // Search for mimic joints
   for (auto i = 0u; i < info_.joints.size(); ++i)
   {
@@ -262,35 +268,36 @@ std::vector<hardware_interface::CommandInterface> GenericSystem::export_command_
   // Joints' state interfaces
   for (auto i = 0u; i < info_.joints.size(); i++)
   {
-//    const auto & joint = info_.joints[i];
-//    for (const auto & interface : joint.command_interfaces)
-//    {
+    //    const auto & joint = info_.joints[i];
+    //    for (const auto & interface : joint.command_interfaces)
+    //    {
 
-        command_interfaces.emplace_back(hardware_interface::CommandInterface(
-                info_.joints[i].name, hardware_interface::HW_IF_POSITION, &joint_commands_[POSITION_INTERFACE_INDEX][i]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_POSITION,
+      &joint_commands_[POSITION_INTERFACE_INDEX][i]));
 
-        command_interfaces.emplace_back(hardware_interface::CommandInterface(
-                info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joint_vel_commands_[i]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &joint_vel_commands_[i]));
 
-      command_interfaces.emplace_back(hardware_interface::CommandInterface(
-              info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &joint_commands_[2][i]));
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+      info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &joint_commands_[2][i]));
 
-      // Add interface: if not in the standard list than use "other" interface list
-//      if (!get_interface(
-//            joint.name, standard_interfaces_, interface.name, i, joint_commands_,
-//            command_interfaces))
-//      {
-//
-//        if (!get_interface(
-//              joint.name, other_interfaces_, interface.name, i, other_commands_,
-//              command_interfaces))
-//        {
-//          throw std::runtime_error(
-//            "Interface is not found in the standard nor other list. "
-//            "This should never happen!");
-//        }
-//      }
-//    }
+    // Add interface: if not in the standard list than use "other" interface list
+    //      if (!get_interface(
+    //            joint.name, standard_interfaces_, interface.name, i, joint_commands_,
+    //            command_interfaces))
+    //      {
+    //
+    //        if (!get_interface(
+    //              joint.name, other_interfaces_, interface.name, i, other_commands_,
+    //              command_interfaces))
+    //        {
+    //          throw std::runtime_error(
+    //            "Interface is not found in the standard nor other list. "
+    //            "This should never happen!");
+    //        }
+    //      }
+    //    }
   }
 
   // Fake sensor command interfaces
@@ -436,7 +443,7 @@ return_type GenericSystem::read()
   }
 
   // velocity
-//  for (size_t j = 0; j < joint_commands_[VELOCITY_INTERFACE_INDEX].size(); ++j)
+  //  for (size_t j = 0; j < joint_commands_[VELOCITY_INTERFACE_INDEX].size(); ++j)
   for (size_t j = 0; j < 2; ++j)
 
   {
@@ -444,14 +451,12 @@ return_type GenericSystem::read()
       !std::isnan(joint_commands_[VELOCITY_INTERFACE_INDEX][j]) && !command_propagation_disabled_ &&
       velocity_controller_running_)
     {
-//      joint_states_[POSITION_INTERFACE_INDEX][j] +=
-//        joint_commands_[VELOCITY_INTERFACE_INDEX][j] * period;
+      //      joint_states_[POSITION_INTERFACE_INDEX][j] +=
+      //        joint_commands_[VELOCITY_INTERFACE_INDEX][j] * period;
 
-      joint_states_[POSITION_INTERFACE_INDEX][j] +=
-              joint_vel_commands_[j] * period;
+      joint_states_[POSITION_INTERFACE_INDEX][j] += joint_vel_commands_[j] * period;
 
-
-//      joint_states_[VELOCITY_INTERFACE_INDEX][j] = joint_commands_[VELOCITY_INTERFACE_INDEX][j];
+      //      joint_states_[VELOCITY_INTERFACE_INDEX][j] = joint_commands_[VELOCITY_INTERFACE_INDEX][j];
 
       joint_states_[VELOCITY_INTERFACE_INDEX][j] = joint_vel_commands_[j];
 

--- a/hardware_interface/src/fake_components/generic_system.cpp
+++ b/hardware_interface/src/fake_components/generic_system.cpp
@@ -47,6 +47,18 @@ return_type GenericSystem::configure(const hardware_interface::HardwareInfo & in
     fake_sensor_command_interfaces_ = false;
   }
 
+  // check if there is parameter that disables commands
+  // this way we simulate disconnected driver
+  it = info_.hardware_parameters.find("disable_commands");
+  if (it != info.hardware_parameters.end())
+  {
+    command_propagation_disabled_ = it->second == "true" || it->second == "True";
+  }
+  else
+  {
+    command_propagation_disabled_ = false;
+  }
+
   // process parameters about state following
   position_state_following_offset_ = 0.0;
   custom_interface_with_following_offset_ = "";
@@ -283,7 +295,7 @@ return_type GenericSystem::read()
   // apply offset to positions only
   for (size_t j = 0; j < joint_states_[POSITION_INTERFACE_INDEX].size(); ++j)
   {
-    if (!std::isnan(joint_commands_[POSITION_INTERFACE_INDEX][j]))
+    if (!std::isnan(joint_commands_[POSITION_INTERFACE_INDEX][j]) && !command_propagation_disabled_)
     {
       joint_states_[POSITION_INTERFACE_INDEX][j] =
         joint_commands_[POSITION_INTERFACE_INDEX][j] +


### PR DESCRIPTION
PR info:

- Add `disable_command` flag to be able to simulate disconnected driver
- Add `prepare_command_mode_switch` and `perform_command_mode_switch` for switching between velocity-only and position-only controllers
- Add first-order integration of velocity for position calculation in velocity mode 