### PR TITLE
Use ControllerManager node clock for control loop timepoints

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -51,7 +51,7 @@ int main(int argc, char ** argv)
       cm->read();
       cm->update(
         rclcpp::Time(
-          std::chrono::duration_cast<std::chrono::nanoseconds>(begin - timepoint_start).count()),
+          std::chrono::duration_cast<std::chrono::nanoseconds>(begin.time_since_epoch()).count()),
         rclcpp::Duration(std::chrono::duration_cast<std::chrono::nanoseconds>(begin - begin_last)));
       cm->write();
       std::chrono::system_clock::time_point end = std::chrono::system_clock::now();

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -40,21 +40,21 @@ int main(int argc, char ** argv)
   std::thread cm_thread([cm]() {
     RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
 
-    std::chrono::system_clock::time_point timepoint_start = std::chrono::system_clock::now();
+    std::chrono::system_clock::time_point timepoint_start(std::chrono::nanoseconds(cm->now().nanoseconds()));
     std::chrono::system_clock::time_point begin = timepoint_start;
     // Use nanoseconds to avoid chrono's rounding
     std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / cm->get_update_rate()));
     while (rclcpp::ok())
     {
       std::chrono::system_clock::time_point begin_last = begin;
-      begin = std::chrono::system_clock::now();
+      begin = std::chrono::system_clock::time_point(std::chrono::nanoseconds(cm->now().nanoseconds()));;
       cm->read();
       cm->update(
         rclcpp::Time(
           std::chrono::duration_cast<std::chrono::nanoseconds>(begin.time_since_epoch()).count()),
         rclcpp::Duration(std::chrono::duration_cast<std::chrono::nanoseconds>(begin - begin_last)));
       cm->write();
-      std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
+      std::chrono::system_clock::time_point end(std::chrono::nanoseconds(cm->now().nanoseconds()));;
       std::this_thread::sleep_for(std::max(
         std::chrono::nanoseconds(0),
         std::chrono::nanoseconds(1000000000 / cm->get_update_rate()) -


### PR DESCRIPTION
In the current version of `ros2_control_node.cpp`, [this line](https://github.com/ros-controls/ros2_control/blob/d9fd0b9b4a555bbe1b6162a8456fda3e87fad5b3/controller_manager/src/ros2_control_node.cpp#L53-L54) (from #520) incorrectly calculates a timepoint that is relative to the time when the controller manager node was initialized, where it should instead use either the actual epoch time for real hardware or the simulated time when running in Gazebo or another simulated context. When a controller plugin publishes ROS messages (for example, when the JointStateBroadcaster publishes JointState messages), it uses these incorrect timestamps in the message headers, which causes problems downstream with TF lookups and perception calculations.

This PR changes the calculated timepoint to be correct relative to the start of the epoch.

This PR also changes the control loop to use the ControllerManager ROS node's clock as the time source instead of the system clock, which allows switching between simulated and real time through the `use_sim_time` ROS parameter. Prior to the [API update](https://github.com/ros-controls/ros2_controllers/pull/241/files) the controller plugins used ROS time, so the end result here should be the same as how it was before.