### PR TITLE
add M_PI macro for windows foxy in test_component_parser.cpp

### DIFF
--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -20,6 +20,10 @@
 #include "ros2_control_test_assets/components_urdfs.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
+#ifdef _WIN32
+#define M_PI 3.1415926535897932384626433832795
+#endif
+
 using namespace ::testing;  // NOLINT
 
 class TestComponentParser : public Test


### PR DESCRIPTION
The exact same changes than for #502 to make `ros2_control` work for windows for `foxy` ROS2 distribution, as M_PI is used.