### PR TITLE
Added timeout argument for service_caller timeout

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -23,18 +23,18 @@ def service_caller(node, service_name, service_type, request, service_timeout=10
     cli = node.create_client(service_type, service_name)
 
     if not cli.service_is_ready():
-        node.get_logger().debug('waiting {} seconds for service {} to become available...'
-                                .format(service_timeout, service_name))
+        node.get_logger().debug(
+            f'waiting {service_timeout} seconds for service {service_name} to become available...')
         if not cli.wait_for_service(service_timeout):
             raise RuntimeError(f'Could not contact service {service_name}')
 
-    node.get_logger().debug('requester: making request: %r\n' % request)
+    node.get_logger().debug(f'requester: making request: {request}\n')
     future = cli.call_async(request)
     rclpy.spin_until_future_complete(node, future)
     if future.result() is not None:
         return future.result()
     else:
-        raise RuntimeError('Exception while calling service: %r' % future.exception())
+        raise RuntimeError(f'Exception while calling service: {future.exception()}')
 
 
 def configure_controller(node, controller_manager_name, controller_name):


### PR DESCRIPTION
Fixes #405

Added an optional argument to service_caller() with a default value of 10.0 seconds so individual calls can specify the value. Tested using the demos to ensure the default time and argument input works.