### PR TITLE
feat: add colored output into spawner.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     rev: 3.9.0
     hooks:
     - id: flake8
-      args: ["--ignore=E501"]
+      args: ["--extend-ignore=E501"]
 
   # CPP hooks
   - repo: local

--- a/controller_manager/scripts/spawner.py
+++ b/controller_manager/scripts/spawner.py
@@ -29,6 +29,8 @@ from rclpy.duration import Duration
 from rclpy.node import Node
 
 # from https://stackoverflow.com/a/287944
+
+
 class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -39,6 +41,7 @@ class bcolors:
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+
 
 def wait_for_controller_manager(node, controller_manager, timeout_duration):
     def full_name(n):
@@ -123,7 +126,8 @@ def main(args=None):
             if controller_type:
                 ret = subprocess.run(['ros2', 'param', 'set', controller_manager_name,
                                       controller_name + '.type', controller_type])
-            ret = load_controller(node, controller_manager_name, controller_name)
+            ret = load_controller(
+                node, controller_manager_name, controller_name)
             if not ret.ok:
                 # Error message printed by ros2 control
                 return 1
@@ -138,7 +142,8 @@ def main(args=None):
             node.get_logger().info('Loaded ' + param_file + ' into ' + controller_name)
 
         if not args.load_only:
-            ret = configure_controller(node, controller_manager_name, controller_name)
+            ret = configure_controller(
+                node, controller_manager_name, controller_name)
             if not ret.ok:
                 node.get_logger().info('Failed to configure controller')
                 return 1
@@ -157,7 +162,7 @@ def main(args=None):
                     return 1
 
                 node.get_logger().info(bcolors.OKGREEN + 'Configured and started ' +
-                    bcolors.OKCYAN + controller_name + bcolors.ENDC)
+                                       bcolors.OKCYAN + controller_name + bcolors.ENDC)
 
         if not args.unload_on_kill:
             return 0
@@ -183,7 +188,8 @@ def main(args=None):
 
                 node.get_logger().info('Stopped controller')
 
-            ret = unload_controller(node, controller_manager_name, controller_name)
+            ret = unload_controller(
+                node, controller_manager_name, controller_name)
             if not ret.ok:
                 node.get_logger().info('Failed to unload controller')
                 return 1


### PR DESCRIPTION
in order to highlight if controllers are loaded and configured and started. This has been requested in #535 .

This PR proposes first changes in spawner.py which can make the output look like:

![image](https://user-images.githubusercontent.com/50864015/138161341-fac1f39b-9939-4a8c-86f9-d4bceda69e3c.png)
