### PR TITLE
Import and Initialize components

### DIFF
--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -186,6 +186,48 @@ public:
    */
   void import_component(std::unique_ptr<SystemInterface> system);
 
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] actuator pointer to the actuator interface.
+   * \param[in]hardware_info hardware info
+   */
+  void import_component(std::unique_ptr<ActuatorInterface> actuator,
+      const HardwareInfo & hardware_info);
+
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] sensor pointer to the sensor interface.
+   * \param[in] hardware_info hardware info
+   */
+  void import_component(std::unique_ptr<SensorInterface> sensor,
+    const HardwareInfo & hardware_info);
+
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] system pointer to the system interface.
+   * \param[in] hardware_info hardware info
+   */
+  void import_component(std::unique_ptr<SystemInterface> system,
+    const HardwareInfo & hardware_info);
+
   /// Return status for all components.
   /**
    * \return map of hardware names and their states

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -197,8 +197,8 @@ public:
    * \param[in] actuator pointer to the actuator interface.
    * \param[in]hardware_info hardware info
    */
-  void import_component(std::unique_ptr<ActuatorInterface> actuator,
-      const HardwareInfo & hardware_info);
+  void import_component(
+    std::unique_ptr<ActuatorInterface> actuator, const HardwareInfo & hardware_info);
 
   /// Import a hardware component which is not listed in the URDF
   /**
@@ -211,8 +211,8 @@ public:
    * \param[in] sensor pointer to the sensor interface.
    * \param[in] hardware_info hardware info
    */
-  void import_component(std::unique_ptr<SensorInterface> sensor,
-    const HardwareInfo & hardware_info);
+  void import_component(
+    std::unique_ptr<SensorInterface> sensor, const HardwareInfo & hardware_info);
 
   /// Import a hardware component which is not listed in the URDF
   /**
@@ -225,8 +225,8 @@ public:
    * \param[in] system pointer to the system interface.
    * \param[in] hardware_info hardware info
    */
-  void import_component(std::unique_ptr<SystemInterface> system,
-    const HardwareInfo & hardware_info);
+  void import_component(
+    std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info);
 
   /// Return status for all components.
   /**

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -189,6 +189,8 @@ public:
   /// Import a hardware component which is not listed in the URDF
   /**
    * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
    *
    * \note this might invalidate existing state and command interfaces and should thus
    * not be called when a controller is running.
@@ -203,6 +205,8 @@ public:
   /// Import a hardware component which is not listed in the URDF
   /**
    * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
    *
    * \note this might invalidate existing state and command interfaces and should thus
    * not be called when a controller is running.
@@ -217,6 +221,8 @@ public:
   /// Import a hardware component which is not listed in the URDF
   /**
    * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
    *
    * \note this might invalidate existing state and command interfaces and should thus
    * not be called when a controller is running.

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -51,6 +51,23 @@ public:
   {
   }
 
+  // A new generic method to do initialization checks
+  template <class HardwareT>
+  void check_last_hardware_initialization_and_configure(std::vector<HardwareT> & container,
+    const HardwareInfo & hardware_info)
+  {
+    if (
+      container.back().initialize(hardware_info).id() !=
+      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+    {
+      throw std::runtime_error(std::string("Failed to initialize '") + hardware_info.name + "'");
+    }
+    if (container.back().configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+    {
+      throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
+    }
+  }
+
   template <class HardwareT, class HardwareInterfaceT>
   void initialize_hardware(
     const HardwareInfo & hardware_info, pluginlib::ClassLoader<HardwareInterfaceT> & loader,
@@ -96,16 +113,7 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     initialize_hardware<Actuator, ActuatorInterface>(hardware_info, actuator_loader_, actuators_);
-    if (
-      actuators_.back().initialize(hardware_info).id() !=
-      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-    {
-      throw std::runtime_error(std::string("Failed to initialize '") + hardware_info.name + "'");
-    }
-    if (actuators_.back().configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-    {
-      throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
-    }
+    check_last_hardware_initialization_and_configure(actuators_, hardware_info);
     import_state_interfaces(actuators_.back());
     import_command_interfaces(actuators_.back(), claimed_command_interface_map);
   }
@@ -113,16 +121,7 @@ public:
   void initialize_sensor(const HardwareInfo & hardware_info)
   {
     initialize_hardware<Sensor, SensorInterface>(hardware_info, sensor_loader_, sensors_);
-    if (
-      sensors_.back().initialize(hardware_info).id() !=
-      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-    {
-      throw std::runtime_error(std::string("Failed to initialize '") + hardware_info.name + "'");
-    }
-    if (sensors_.back().configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-    {
-      throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
-    }
+    check_last_hardware_initialization_and_configure(sensors_, hardware_info);
     import_state_interfaces(sensors_.back());
   }
 
@@ -131,16 +130,35 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     initialize_hardware<System, SystemInterface>(hardware_info, system_loader_, systems_);
-    if (
-      systems_.back().initialize(hardware_info).id() !=
-      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-    {
-      throw std::runtime_error(std::string("Failed to initialize '") + hardware_info.name + "'");
-    }
-    if (systems_.back().configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-    {
-      throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
-    }
+    check_last_hardware_initialization_and_configure(systems_, hardware_info);
+    import_state_interfaces(systems_.back());
+    import_command_interfaces(systems_.back(), claimed_command_interface_map);
+  }
+
+  void initialize_actuator(
+    std::unique_ptr<ActuatorInterface> actuator, const HardwareInfo & hardware_info,
+    std::unordered_map<std::string, bool> & claimed_command_interface_map)
+  {
+    this->actuators_.emplace_back(Actuator(std::move(actuator)));
+    check_last_hardware_initialization_and_configure(actuators_, hardware_info);
+    import_state_interfaces(actuators_.back());
+    import_command_interfaces(actuators_.back(), claimed_command_interface_map);
+  }
+
+  void initialize_sensor(
+    std::unique_ptr<SensorInterface> sensor, const HardwareInfo & hardware_info)
+  {
+    this->sensors_.emplace_back(Sensor(std::move(sensor)));
+    check_last_hardware_initialization_and_configure(sensors_, hardware_info);
+    import_state_interfaces(sensors_.back());
+  }
+
+  void initialize_system(
+    std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info,
+    std::unordered_map<std::string, bool> & claimed_command_interface_map)
+  {
+    this->systems_.emplace_back(System(std::move(system)));
+    check_last_hardware_initialization_and_configure(systems_, hardware_info);
     import_state_interfaces(systems_.back());
     import_command_interfaces(systems_.back(), claimed_command_interface_map);
   }
@@ -309,6 +327,26 @@ void ResourceManager::import_component(std::unique_ptr<SystemInterface> system)
   resource_storage_->import_state_interfaces(resource_storage_->systems_.back());
   resource_storage_->import_command_interfaces(
     resource_storage_->systems_.back(), claimed_command_interface_map_);
+}
+
+void ResourceManager::import_component(std::unique_ptr<ActuatorInterface> actuator,
+  const HardwareInfo & hardware_info)
+{
+  resource_storage_->initialize_actuator(
+    std::move(actuator), hardware_info, claimed_command_interface_map_);
+}
+
+void ResourceManager::import_component(std::unique_ptr<SensorInterface> sensor,
+  const HardwareInfo & hardware_info)
+{
+  resource_storage_->initialize_sensor(std::move(sensor), hardware_info);
+}
+
+void ResourceManager::import_component(std::unique_ptr<SystemInterface> system,
+  const HardwareInfo & hardware_info)
+{
+  resource_storage_->initialize_system(
+    std::move(system), hardware_info, claimed_command_interface_map_);
 }
 
 size_t ResourceManager::system_components_size() const

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -53,16 +53,16 @@ public:
 
   // A new generic method to do initialization checks
   template <class HardwareT>
-  void check_last_hardware_initialization_and_configure(
-    std::vector<HardwareT> & container, const HardwareInfo & hardware_info)
+  void check_hardware_initialization_and_configure(
+    HardwareT & hardware, const HardwareInfo & hardware_info)
   {
     if (
-      container.back().initialize(hardware_info).id() !=
+      hardware.initialize(hardware_info).id() !=
       lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
     {
       throw std::runtime_error(std::string("Failed to initialize '") + hardware_info.name + "'");
     }
-    if (container.back().configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
+    if (hardware.configure().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
     {
       throw std::runtime_error(std::string("Failed to configure '") + hardware_info.name + "'");
     }
@@ -113,7 +113,7 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     initialize_hardware<Actuator, ActuatorInterface>(hardware_info, actuator_loader_, actuators_);
-    check_last_hardware_initialization_and_configure(actuators_, hardware_info);
+    check_hardware_initialization_and_configure(actuators_.back(), hardware_info);
     import_state_interfaces(actuators_.back());
     import_command_interfaces(actuators_.back(), claimed_command_interface_map);
   }
@@ -121,7 +121,7 @@ public:
   void initialize_sensor(const HardwareInfo & hardware_info)
   {
     initialize_hardware<Sensor, SensorInterface>(hardware_info, sensor_loader_, sensors_);
-    check_last_hardware_initialization_and_configure(sensors_, hardware_info);
+    check_hardware_initialization_and_configure(sensors_.back(), hardware_info);
     import_state_interfaces(sensors_.back());
   }
 
@@ -130,7 +130,7 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     initialize_hardware<System, SystemInterface>(hardware_info, system_loader_, systems_);
-    check_last_hardware_initialization_and_configure(systems_, hardware_info);
+    check_hardware_initialization_and_configure(systems_.back(), hardware_info);
     import_state_interfaces(systems_.back());
     import_command_interfaces(systems_.back(), claimed_command_interface_map);
   }
@@ -140,7 +140,7 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     this->actuators_.emplace_back(Actuator(std::move(actuator)));
-    check_last_hardware_initialization_and_configure(actuators_, hardware_info);
+    check_hardware_initialization_and_configure(actuators_.back(), hardware_info);
     import_state_interfaces(actuators_.back());
     import_command_interfaces(actuators_.back(), claimed_command_interface_map);
   }
@@ -149,7 +149,7 @@ public:
     std::unique_ptr<SensorInterface> sensor, const HardwareInfo & hardware_info)
   {
     this->sensors_.emplace_back(Sensor(std::move(sensor)));
-    check_last_hardware_initialization_and_configure(sensors_, hardware_info);
+    check_hardware_initialization_and_configure(sensors_.back(), hardware_info);
     import_state_interfaces(sensors_.back());
   }
 
@@ -158,7 +158,7 @@ public:
     std::unordered_map<std::string, bool> & claimed_command_interface_map)
   {
     this->systems_.emplace_back(System(std::move(system)));
-    check_last_hardware_initialization_and_configure(systems_, hardware_info);
+    check_hardware_initialization_and_configure(systems_.back(), hardware_info);
     import_state_interfaces(systems_.back());
     import_command_interfaces(systems_.back(), claimed_command_interface_map);
   }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -53,8 +53,8 @@ public:
 
   // A new generic method to do initialization checks
   template <class HardwareT>
-  void check_last_hardware_initialization_and_configure(std::vector<HardwareT> & container,
-    const HardwareInfo & hardware_info)
+  void check_last_hardware_initialization_and_configure(
+    std::vector<HardwareT> & container, const HardwareInfo & hardware_info)
   {
     if (
       container.back().initialize(hardware_info).id() !=
@@ -329,21 +329,21 @@ void ResourceManager::import_component(std::unique_ptr<SystemInterface> system)
     resource_storage_->systems_.back(), claimed_command_interface_map_);
 }
 
-void ResourceManager::import_component(std::unique_ptr<ActuatorInterface> actuator,
-  const HardwareInfo & hardware_info)
+void ResourceManager::import_component(
+  std::unique_ptr<ActuatorInterface> actuator, const HardwareInfo & hardware_info)
 {
   resource_storage_->initialize_actuator(
     std::move(actuator), hardware_info, claimed_command_interface_map_);
 }
 
-void ResourceManager::import_component(std::unique_ptr<SensorInterface> sensor,
-  const HardwareInfo & hardware_info)
+void ResourceManager::import_component(
+  std::unique_ptr<SensorInterface> sensor, const HardwareInfo & hardware_info)
 {
   resource_storage_->initialize_sensor(std::move(sensor), hardware_info);
 }
 
-void ResourceManager::import_component(std::unique_ptr<SystemInterface> system,
-  const HardwareInfo & hardware_info)
+void ResourceManager::import_component(
+  std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info)
 {
   resource_storage_->initialize_system(
     std::move(system), hardware_info, claimed_command_interface_map_);


### PR DESCRIPTION
While I was migrating `gazebo_ros2_control` to Galatic something went wrong and the examples were not working. 

`gazebo_ros2_control` creates a system component and then imports this component in to the ResourceManager with this method:

```
void ResourceManager::import_component(std::unique_ptr<SystemInterface> system)
```

but this method is just adding the system to the data structures but it's not initializing the system. I added this method to be able to make the examples work.

I don't know if you want to expose this or if this should be done in the future calling a service.

do you mind to take a look @bmagyar @destogl ?

Signed-off-by: ahcorde <ahcorde@gmail.com>