### PR TITLE
Improvement ⏩: ControllerManager make output about available controller types nicer and informative instead of error.

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -161,13 +161,12 @@ controller_interface::ControllerInterfaceSharedPtr ControllerManager::load_contr
 
   if (!loader_->isClassAvailable(controller_type))
   {
-    const std::string error_msg("Loader for controller '" + controller_name + "' not found.");
-    RCLCPP_ERROR(get_logger(), "Available classes:");
-    for (const auto & c : loader_->getDeclaredClasses())
+    RCLCPP_ERROR(get_logger(), "Loader for controller '%s' not found.", controller_name.c_str());
+    RCLCPP_INFO(get_logger(), "Available classes:");
+    for (const auto & available_class : loader_->getDeclaredClasses())
     {
-      RCLCPP_ERROR(get_logger(), "%s", c.c_str());
+      RCLCPP_INFO(get_logger(), "  %s", available_class.c_str());
     }
-    RCLCPP_ERROR(get_logger(), "%s", error_msg.c_str());
     return nullptr;
   }
 


### PR DESCRIPTION
When we try to load controller with unavailable type now the output looks like this:

```
[ros2_control_node-2] [INFO] [1637180998.063704840] [controller_manager]: Loading controller 'stoglrobotics_controller'
[ros2_control_node-2] [ERROR] [1637180998.063739504] [controller_manager]: Loader for controller 'stoglrobotics_controller' not found.
[ros2_control_node-2] [INFO] [1637180998.063745894] [controller_manager]: Available classes:
[ros2_control_node-2] [INFO] [1637180998.063753888] [controller_manager]:   admittance_controller/AdmittanceController
[ros2_control_node-2] [INFO] [1637180998.063758628] [controller_manager]:   controller_manager/test_controller
[ros2_control_node-2] [INFO] [1637180998.063763418] [controller_manager]:   controller_manager/test_controller_failed_init
[ros2_control_node-2] [INFO] [1637180998.063767954] [controller_manager]:   controller_manager/test_controller_with_interfaces
[ros2_control_node-2] [INFO] [1637180998.063772640] [controller_manager]:   diff_drive_controller/DiffDriveController
[ros2_control_node-2] [INFO] [1637180998.063777379] [controller_manager]:   effort_controllers/GripperActionController
[ros2_control_node-2] [INFO] [1637180998.063781293] [controller_manager]:   effort_controllers/JointGroupEffortController
[ros2_control_node-2] [INFO] [1637180998.063785605] [controller_manager]:   force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
[ros2_control_node-2] [INFO] [1637180998.063793932] [controller_manager]:   forward_command_controller/ForwardCommandController
[ros2_control_node-2] [INFO] [1637180998.063798820] [controller_manager]:   forward_command_controller/MultiInterfaceForwardCommandController
[ros2_control_node-2] [INFO] [1637180998.063803599] [controller_manager]:   imu_sensor_broadcaster/IMUSensorBroadcaster
[ros2_control_node-2] [INFO] [1637180998.063807671] [controller_manager]:   jaw_tool_controller/JawToolController
[ros2_control_node-2] [INFO] [1637180998.063811598] [controller_manager]:   joint_state_broadcaster/JointStateBroadcaster
[ros2_control_node-2] [INFO] [1637180998.063815308] [controller_manager]:   joint_state_controller/JointStateController
[ros2_control_node-2] [INFO] [1637180998.063819463] [controller_manager]:   joint_trajectory_controller/JointTrajectoryController
[ros2_control_node-2] [INFO] [1637180998.063823881] [controller_manager]:   position_controllers/GripperActionController
[ros2_control_node-2] [INFO] [1637180998.063828636] [controller_manager]:   position_controllers/JointGroupPositionController
[ros2_control_node-2] [INFO] [1637180998.063832692] [controller_manager]:   velocity_controllers/JointGroupVelocityController
```

This is more readable then a huge pile of red (ERROR) lines. Also a bit of formatting is not bad, don't you think?﻿
