### PR TITLE
fix get_update_rate visibility in windows

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -148,6 +148,7 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   const rclcpp_lifecycle::State & get_state() const;
 
+  CONTROLLER_INTERFACE_PUBLIC
   unsigned int get_update_rate() const;
 
 protected:

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -145,6 +145,7 @@ public:
   // rclcpp::CallbackGroup::SharedPtr deterministic_callback_group_;
 
   // Per controller update rate support
+  CONTROLLER_MANAGER_PUBLIC
   unsigned int get_update_rate() const;
 
 protected:


### PR DESCRIPTION
I was previously getting the following compile error on Windows using Rolling:
```
controller_manager.obj : error LNK2019: unresolved external symbol "public: unsigned int __cdecl controller_interface::ControllerInterface::get_update_rate(void)const " (?get_update_rate@ControllerInterface@controller_interface@@QEBAIXZ) referenced in function "public: enum controller_interface::return_type __cdecl controller_manager::ControllerManager::update(class rclcpp::Time const &,class rclcpp::Duration const &)" (?update@ControllerManager@controller_manager@@QEAA?AW4return_type@controller_interface@@AEBVTime@rclcpp@@AEBVDuration@6@@Z) [C:\Users\melvi\git-repos\uwrt_ros2_ws\build\controller_manager\controller_manager.vcxproj]
C:\Users\melvi\git-repos\uwrt_ros2_ws\build\controller_manager\Release\controller_manager.dll : fatal error LNK1120: 1 unresolved externals [C:\Users\melvi\git-repos\uwrt_ros2_ws\build\controller_manager\controller_manager.vcxproj]
```

Looks like it was probably introduced in #513 .

my ws uses the following ros2_control.repos:
```
repositories:
  ros-controls/ros2_control:
    type: git
    url: https://github.com/ros-controls/ros2_control.git
    version: galactic
  ros-controls/ros2_controllers:
    type: git
    url: https://github.com/ros-controls/ros2_controllers.git
    version: master
  ros-controls/realtime_tools:
    type: git
    url: https://github.com/ros-controls/realtime_tools.git
    version: ros2_devel
  ros-controls/control_msgs:
    type: git
    url: https://github.com/ros-controls/control_msgs.git
    version: galactic-devel
  angles:
    type: git
    url: https://github.com/ros/angles.git
    version: ros2
```

Sidenote: Should https://github.com/ros-controls/ros2_control/blob/galactic/ros2_control/ros2_control.repos be updated to point to galactic, instead of what its currently pointing to (ie. master(ros2_control) and foxy-devel(control_msgs))?
