### PR TITLE
Adding support for 'initial_value' parameter.

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -36,6 +36,8 @@ struct InterfaceInfo
   std::string min;
   /// (Optional) Maximal allowed values of the interface.
   std::string max;
+  /// (Optional) Initial value of the interface.
+  std::string initial_value;
   /// (Optional) The datatype of the interface, e.g. "bool", "int". Used by GPIOs.
   std::string data_type;
   /// (Optional) If the handle is an array, the size of the array. Used by GPIOs.

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -38,6 +38,7 @@ constexpr const auto kCommandInterfaceTag = "command_interface";
 constexpr const auto kStateInterfaceTag = "state_interface";
 constexpr const auto kMinTag = "min";
 constexpr const auto kMaxTag = "max";
+constexpr const auto kInitialValueTag = "initial_value";
 constexpr const auto kDataTypeAttribute = "data_type";
 constexpr const auto kSizeAttribute = "size";
 constexpr const auto kNameAttribute = "name";
@@ -45,7 +46,6 @@ constexpr const auto kTypeAttribute = "type";
 constexpr const auto kRoleAttribute = "role";
 constexpr const auto kReductionAttribute = "mechanical_reduction";
 constexpr const auto kOffsetAttribute = "offset";
-constexpr const auto kInitialValueAttribute = "initial_value";
 }  // namespace
 
 namespace hardware_interface
@@ -260,7 +260,7 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
   }
 
   // Optional initial_value attribute
-  interface_param = interface_params.find(kInitialValueAttribute);
+  interface_param = interface_params.find(kInitialValueTag);
   if (interface_param != interface_params.end())
   {
     interface.initial_value = interface_param->second;

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -45,6 +45,7 @@ constexpr const auto kTypeAttribute = "type";
 constexpr const auto kRoleAttribute = "role";
 constexpr const auto kReductionAttribute = "mechanical_reduction";
 constexpr const auto kOffsetAttribute = "offset";
+constexpr const auto kInitialValueAttribute = "initial_value";
 }  // namespace
 
 namespace hardware_interface
@@ -256,6 +257,13 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
   if (interface_param != interface_params.end())
   {
     interface.max = interface_param->second;
+  }
+
+  // Optional initial_value attribute
+  interface_param = interface_params.find(kInitialValueAttribute);
+  if (interface_param != interface_params.end())
+  {
+    interface.initial_value = interface_param->second;
   }
 
   // Default to a single double

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -174,6 +174,8 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_interface
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   ASSERT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(3));
   EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].initial_value, "1.2");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[1].initial_value, "3.4");
   ASSERT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(3));
   EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].name, HW_IF_VELOCITY);
 

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -59,10 +59,12 @@ const auto valid_urdf_ros2_control_system_multi_interface =
       <command_interface name="position">
         <param name="min">-1</param>
         <param name="max">1</param>
+        <param name="initial_value">1.2</param>
       </command_interface>
       <command_interface name="velocity">
         <param name="min">-1</param>
         <param name="max">1</param>
+        <param name="initial_value">3.4</param>
       </command_interface>
       <command_interface name="effort">
         <param name="min">-0.5</param>


### PR DESCRIPTION
This PR will support the "initial_value" parameter. This parameter will be used to initialize any value. Below is the sample,

```
    <joint name="joint1">
      <command_interface name="position">
        <param name="min">-1</param>
        <param name="max">1</param>
        <param name="initial_value">1.2</param>
      </command_interface>
    </joint>
```

