### PR TITLE
fix typo in .repos control_msgs version

### DIFF
--- a/ros2_control/ros2_control.repos
+++ b/ros2_control/ros2_control.repos
@@ -14,7 +14,7 @@ repositories:
   ros-controls/control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: galacitc-devel
+    version: galactic-devel
   angles:
     type: git
     url: https://github.com/ros/angles.git


### PR DESCRIPTION
caused by[ manual commit](https://github.com/ros-controls/ros2_control/commit/0467c6ce2dabd2c21f46c6e71914b60b7f234d30) instead of #590 merging