### PR TITLE
No need to get angles from source anymore, causes issues now

### DIFF
--- a/ros2_control/ros2_control.repos
+++ b/ros2_control/ros2_control.repos
@@ -15,7 +15,3 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: galactic-devel
-  angles:
-    type: git
-    url: https://github.com/ros/angles.git
-    version: ros2


### PR DESCRIPTION
There's some unreleased/untested rework at angles that is being pulled in by this unintentionally: https://github.com/ros/angles/commits/ros2

...and causing pipelines to fail over at https://github.com/ros-controls/ros2_controllers/pull/285

time to let go of this, I'd also backport this to Galactic and Foxy as there are releases of angles there already too