### PR TITLE
Resolve unused parameter warnings

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1151,7 +1151,7 @@ void ControllerManager::unload_controller_service_cb(
 
 void ControllerManager::list_hardware_components_srv_cb(
   const std::shared_ptr<controller_manager_msgs::srv::ListHardwareComponents::Request>,
-  std::shared_ptr<controller_manager_msgs::srv::ListHardwareComponents::Response> response)
+  std::shared_ptr<controller_manager_msgs::srv::ListHardwareComponents::Response> /*response*/)
 {
   RCLCPP_DEBUG(get_logger(), "list hardware components service called");
   std::lock_guard<std::mutex> guard(services_lock_);
@@ -1192,7 +1192,7 @@ void ControllerManager::list_hardware_interfaces_srv_cb(
 
 void ControllerManager::set_hardware_component_state_srv_cb(
   const std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Request> request,
-  std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Response> response)
+  std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Response> /*response*/)
 {
   RCLCPP_DEBUG(get_logger(), "set hardware component state service called");
   std::lock_guard<std::mutex> guard(services_lock_);


### PR DESCRIPTION
```
Warning: unused parameter ‘response’ [-Wunused-parameter]
 1154 |   std::shared_ptr<controller_manager_msgs::srv::ListHardwareComponents::Response> response)
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/home/bence/workspaces/ros2-ws/src/ros2_control/controller_manager/src/controller_manager.cpp: In member function ‘void controller_manager::ControllerManager::set_hardware_component_state_srv_cb(std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState_Request_<std::allocator<void> > >, std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState_Response_<std::allocator<void> > >)’:
/home/bence/workspaces/ros2-ws/src/ros2_control/controller_manager/src/controller_manager.cpp:1195:86: warning: unused parameter ‘response’ [-Wunused-parameter]
 1195 |   std::shared_ptr<controller_manager_msgs::srv::SetHardwareComponentState::Response> response)
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```