### PR TITLE
Enable controller manager services to control hardware lifecycle #abi-breaking

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -157,6 +157,14 @@ if(BUILD_TESTING)
   target_include_directories(test_spawner_unspawner PRIVATE include)
   target_link_libraries(test_spawner_unspawner controller_manager test_controller)
   ament_target_dependencies(test_spawner_unspawner ros2_control_test_assets)
+
+  ament_add_gmock(
+    test_hardware_management_srvs
+    test/test_hardware_management_srvs.cpp
+  )
+  target_include_directories(test_hardware_management_srvs PRIVATE include)
+  target_link_libraries(test_hardware_management_srvs controller_manager test_controller)
+  ament_target_dependencies(test_hardware_management_srvs ros2_control_test_assets)
 endif()
 
 # Install Python modules

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -6,6 +6,36 @@ Controller Manager is the main component in the ros2_control framework.
 It manages lifecycle of controllers, access to the hardware interfaces and offers services to the ROS-world.
 
 
+Parameters
+-----------
+
+activate_components_on_start (optional; list<string>; default: empty)
+  Define which hardware components should be activated when controller manager is started.
+  The names of the components are defined as attribute of ``<ros2_control>``-tag in ``robot_description``.
+  All other components will stay ``UNCONFIGURED``.
+
+
+configure_components_on_start (optional; list<string>; default: empty)
+  Define which hardware components should be configured when controller manager is started.
+  The names of the components are defined as attribute of ``<ros2_control>``-tag in ``robot_description``.
+  All other components will stay ``UNCONFIGURED``.
+  If this and ``activate_components_on_start`` are empty, all available components will be activated.
+
+
+robot_description (mandatory; string)
+  String with the URDF string as robot description.
+  This is usually result of the parsed description files by ``xacro`` command.
+
+update_rate (mandatory; double)
+  The frequency of controller manager's real-time update loop.
+  This loop reads states from hardware, updates controller and writes commands to hardware.
+
+
+<controller_name>.type
+  Name of a plugin exported using ``pluginlib`` for a controller.
+  This is a class from which controller's instance with name "``controller_name``" is created.
+
+
 Helper scripts
 --------------
 There are two scripts to interact with controller manager from launch files:

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -13,6 +13,8 @@ activate_components_on_start (optional; list<string>; default: empty)
   Define which hardware components should be activated when controller manager is started.
   The names of the components are defined as attribute of ``<ros2_control>``-tag in ``robot_description``.
   All other components will stay ``UNCONFIGURED``.
+  If this and ``configure_components_on_start`` are empty, all available components will be activated.
+  If this or ``configure_components_on_start`` are not empty, any component not in either list will be in unconfigured state.
 
 
 configure_components_on_start (optional; list<string>; default: empty)
@@ -20,6 +22,7 @@ configure_components_on_start (optional; list<string>; default: empty)
   The names of the components are defined as attribute of ``<ros2_control>``-tag in ``robot_description``.
   All other components will stay ``UNCONFIGURED``.
   If this and ``activate_components_on_start`` are empty, all available components will be activated.
+  If this or ``activate_components_on_start`` are not empty, any component not in either list will be in unconfigured state.
 
 
 robot_description (mandatory; string)

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1192,17 +1192,17 @@ void ControllerManager::list_hardware_components_srv_cb(
 
   response->component.reserve(hw_components_info.size());
 
-  for (auto it = hw_components_info.begin(); it != hw_components_info.end(); ++it)
+  for (const auto & [component_name, component_info] : hw_components_info)
   {
     auto component = controller_manager_msgs::msg::HardwareComponentState();
-    component.name = it->second.name;
-    component.type = it->second.type;
-    component.class_type = it->second.class_type;
-    component.state.id = it->second.state.id();
-    component.state.label = it->second.state.label();
+    component.name = component_name;
+    component.type = component_info.type;
+    component.class_type = component_info.class_type;
+    component.state.id = component_info.state.id();
+    component.state.label = component_info.state.label();
 
-    component.command_interfaces.reserve(it->second.command_interfaces.size());
-    for (const auto & interface : it->second.command_interfaces)
+    component.command_interfaces.reserve(component_info.command_interfaces.size());
+    for (const auto & interface : component_info.command_interfaces)
     {
       controller_manager_msgs::msg::HardwareInterface hwi;
       hwi.name = interface;
@@ -1211,8 +1211,8 @@ void ControllerManager::list_hardware_components_srv_cb(
       component.command_interfaces.push_back(hwi);
     }
 
-    component.state_interfaces.reserve(it->second.state_interfaces.size());
-    for (const auto & interface : it->second.state_interfaces)
+    component.state_interfaces.reserve(component_info.state_interfaces.size());
+    for (const auto & interface : component_info.state_interfaces)
     {
       controller_manager_msgs::msg::HardwareInterface hwi;
       hwi.name = interface;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -102,22 +102,29 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
 
   using lifecycle_msgs::msg::State;
 
-  std::vector<std::string> autoconfigure_components = {""};
-  get_parameter("autoconfigure_components", autoconfigure_components);
+  std::vector<std::string> configure_components_on_start = std::vector<std::string>({});
+  get_parameter("configure_components_on_start", configure_components_on_start);
   rclcpp_lifecycle::State inactive_state(
     State::PRIMARY_STATE_INACTIVE, hardware_interface::lifecycle_state_names::INACTIVE);
-  for (const auto & component : autoconfigure_components)
+  for (const auto & component : configure_components_on_start)
   {
     resource_manager_->set_component_state(component, inactive_state);
   }
 
-  std::vector<std::string> autostart_components = {""};
-  get_parameter("autostart_components", autostart_components);
+  std::vector<std::string> activate_components_on_start = std::vector<std::string>({});
+  get_parameter("activate_components_on_start", activate_components_on_start);
   rclcpp_lifecycle::State active_state(
     State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
-  for (const auto & component : autostart_components)
+  for (const auto & component : activate_components_on_start)
   {
     resource_manager_->set_component_state(component, active_state);
+  }
+
+  // if both parameter are empty or non-existing preserve behavior where all components are
+  // activated per default
+  if (configure_components_on_start.empty() && activate_components_on_start.empty())
+  {
+    resource_manager_->activate_all_components();
   }
 }
 

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -147,7 +147,8 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
   ASSERT_THAT(
     result->controller[0].claimed_interfaces,
     testing::ElementsAre(
-      "joint2/velocity", "joint3/velocity", "joint2/max_acceleration", "configuration/max_tcp_jerk", "joint1/position", "joint1/max_velocity"));
+      "joint2/velocity", "joint3/velocity", "joint2/max_acceleration", "configuration/max_tcp_jerk",
+      "joint1/position", "joint1/max_velocity"));
   ASSERT_THAT(
     result->controller[0].required_command_interfaces,
     testing::ElementsAre(

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -147,8 +147,7 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
   ASSERT_THAT(
     result->controller[0].claimed_interfaces,
     testing::ElementsAre(
-      "joint1/position", "joint1/max_velocity", "joint2/velocity", "joint3/velocity",
-      "joint2/max_acceleration", "configuration/max_tcp_jerk"));
+      "joint2/velocity", "joint3/velocity", "joint2/max_acceleration", "configuration/max_tcp_jerk", "joint1/position", "joint1/max_velocity"));
   ASSERT_THAT(
     result->controller[0].required_command_interfaces,
     testing::ElementsAre(

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -71,9 +71,9 @@ public:
     cm_->set_parameter(
       rclcpp::Parameter("robot_description", ros2_control_test_assets::minimal_robot_urdf));
     cm_->set_parameter(rclcpp::Parameter(
-      "autostart_components", std::vector<std::string>({TEST_ACTUATOR_HARDWARE_NAME})));
+      "activate_components_on_start", std::vector<std::string>({TEST_ACTUATOR_HARDWARE_NAME})));
     cm_->set_parameter(rclcpp::Parameter(
-      "autoconfigure_components", std::vector<std::string>({TEST_SENSOR_HARDWARE_NAME})));
+      "configure_components_on_start", std::vector<std::string>({TEST_SENSOR_HARDWARE_NAME})));
 
     std::string robot_description = "";
     cm_->get_parameter("robot_description", robot_description);
@@ -193,9 +193,39 @@ public:
   }
 };
 
+class TestControllerManagerHWManagementSrvsWithoutParams : public TestControllerManagerHWManagementSrvs
+{
+public:
+  void SetUp() override
+  {
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    cm_ = std::make_shared<controller_manager::ControllerManager>(
+      std::make_unique<hardware_interface::ResourceManager>(), executor_, TEST_CM_NAME);
+    run_updater_ = false;
+
+    // TODO(destogl): separate this to init_tests method where parameter can be set for each test
+    // separately
+    cm_->set_parameter(
+      rclcpp::Parameter("robot_description", ros2_control_test_assets::minimal_robot_urdf));
+
+    std::string robot_description = "";
+    cm_->get_parameter("robot_description", robot_description);
+    if (robot_description.empty())
+    {
+      throw std::runtime_error(
+        "Unable to initialize resource manager, no robot description found.");
+    }
+
+    cm_->init_resource_manager(robot_description);
+
+    SetUpSrvsCMExecutor();
+  }
+};
+
 TEST_F(TestControllerManagerHWManagementSrvs, list_hardware_components)
 {
-  // Default status after start - checks also if "autostart_parameter is correctly read"
+  // Default status after start:
+  // checks if "configure_components_on_start" and "activate_components_on_start" are correctly read
 
   list_hardware_components_and_check(
     // actuator, sensor, system
@@ -339,6 +369,30 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
       // is available
       {{true, true}, {true, true, true}},                                     // actuator
       {{}, {false}},                                                           // sensor
+      {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+}
+
+TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activation_of_all_hardware)
+{
+  // "configure_components_on_start" and "activate_components_on_start" are not set (empty) therefore
+  // all hardware components are active
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_ACTIVE,
+       LFC_STATE::PRIMARY_STATE_ACTIVE}),
+    std::vector<std::string>({ACTIVE, ACTIVE, ACTIVE}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{true, true}, {true, true, true}},  // actuator
+      {{}, {true}},                        // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
     std::vector<std::vector<std::vector<bool>>>({

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -124,7 +124,6 @@ public:
         for (auto i = 0ul; i < interfaces.size(); ++i)
         {
           auto it = std::find(interface_names.begin(), interface_names.end(), interfaces[i].name);
-          std::cout << "Interface name is: " << interfaces[i].name << std::endl;
           EXPECT_NE(it, interface_names.end());
           EXPECT_EQ(interfaces[i].is_available, is_available_status[i]);
           EXPECT_EQ(interfaces[i].is_claimed, is_claimed_status[i]);
@@ -295,7 +294,7 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     std::vector<std::string>({INACTIVE, ACTIVE, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{false, true}, {true, true, true}},                                     // actuator
+      {{true, true}, {true, true, true}},                                      // actuator
       {{}, {true}},                                                            // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
@@ -316,7 +315,7 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     std::vector<std::string>({INACTIVE, ACTIVE, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{false, true}, {true, true, true}},                                     // actuator
+      {{true, true}, {true, true, true}},                                     // actuator
       {{}, {true}},                                                            // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
@@ -338,7 +337,7 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     std::vector<std::string>({INACTIVE, UNCONFIGURED, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{false, true}, {true, true, true}},                                     // actuator
+      {{true, true}, {true, true, true}},                                     // actuator
       {{}, {false}},                                                           // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -193,7 +193,8 @@ public:
   }
 };
 
-class TestControllerManagerHWManagementSrvsWithoutParams : public TestControllerManagerHWManagementSrvs
+class TestControllerManagerHWManagementSrvsWithoutParams
+: public TestControllerManagerHWManagementSrvs
 {
 public:
   void SetUp() override
@@ -345,7 +346,7 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     std::vector<std::string>({INACTIVE, ACTIVE, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{true, true}, {true, true, true}},                                     // actuator
+      {{true, true}, {true, true, true}},                                      // actuator
       {{}, {true}},                                                            // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
@@ -367,7 +368,7 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     std::vector<std::string>({INACTIVE, UNCONFIGURED, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{true, true}, {true, true, true}},                                     // actuator
+      {{true, true}, {true, true, true}},                                      // actuator
       {{}, {false}},                                                           // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
@@ -391,8 +392,8 @@ TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activati
     std::vector<std::string>({ACTIVE, ACTIVE, ACTIVE}),
     std::vector<std::vector<std::vector<bool>>>({
       // is available
-      {{true, true}, {true, true, true}},  // actuator
-      {{}, {true}},                        // sensor
+      {{true, true}, {true, true, true}},                                      // actuator
+      {{}, {true}},                                                            // sensor
       {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
     }),
     std::vector<std::vector<std::vector<bool>>>({

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -21,7 +21,7 @@
 #include "controller_manager_test_common.hpp"
 
 #include "controller_manager/controller_manager.hpp"
-#include "controller_manager_msgs/msg/hardware_components_state.hpp"
+#include "controller_manager_msgs/msg/hardware_component_state.hpp"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/set_hardware_component_state.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+// Copyright 2022 Stogl Robotics Consulting UG (haftungsbeschränkt)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -382,8 +382,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
 
 TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activation_of_all_hardware)
 {
-  // "configure_components_on_start" and "activate_components_on_start" are not set (empty) therefore
-  // all hardware components are active
+  // "configure_components_on_start" and "activate_components_on_start" are not set (empty)
+  // therefore all hardware components are active
   list_hardware_components_and_check(
     // actuator, sensor, system
     std::vector<uint8_t>(

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -1,0 +1,351 @@
+// Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "controller_manager_test_common.hpp"
+
+#include "controller_manager/controller_manager.hpp"
+#include "controller_manager_msgs/msg/hardware_components_state.hpp"
+#include "controller_manager_msgs/srv/list_controllers.hpp"
+#include "controller_manager_msgs/srv/set_hardware_component_state.hpp"
+#include "hardware_interface/types/lifecycle_state_names.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/parameter.hpp"
+
+using ::testing::_;
+using ::testing::Return;
+
+using hardware_interface::lifecycle_state_names::ACTIVE;
+using hardware_interface::lifecycle_state_names::FINALIZED;
+using hardware_interface::lifecycle_state_names::INACTIVE;
+using hardware_interface::lifecycle_state_names::UNCONFIGURED;
+
+using ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_CLASS_TYPE;
+using ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_COMMAND_INTERFACES;
+using ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME;
+using ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_STATE_INTERFACES;
+using ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_TYPE;
+using ros2_control_test_assets::TEST_SENSOR_HARDWARE_CLASS_TYPE;
+using ros2_control_test_assets::TEST_SENSOR_HARDWARE_COMMAND_INTERFACES;
+using ros2_control_test_assets::TEST_SENSOR_HARDWARE_NAME;
+using ros2_control_test_assets::TEST_SENSOR_HARDWARE_STATE_INTERFACES;
+using ros2_control_test_assets::TEST_SENSOR_HARDWARE_TYPE;
+using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_CLASS_TYPE;
+using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_COMMAND_INTERFACES;
+using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_NAME;
+using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_STATE_INTERFACES;
+using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_TYPE;
+
+using LFC_STATE = lifecycle_msgs::msg::State;
+
+using namespace std::chrono_literals;  // NOLINT
+
+class TestControllerManagerHWManagementSrvs : public TestControllerManagerSrvs
+{
+public:
+  void SetUp() override
+  {
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    cm_ = std::make_shared<controller_manager::ControllerManager>(
+      std::make_unique<hardware_interface::ResourceManager>(), executor_, TEST_CM_NAME);
+    run_updater_ = false;
+
+    // TODO(destogl): separate this to init_tests method where parameter can be set for each test
+    // separately
+    cm_->set_parameter(
+      rclcpp::Parameter("robot_description", ros2_control_test_assets::minimal_robot_urdf));
+    cm_->set_parameter(rclcpp::Parameter(
+      "autostart_components", std::vector<std::string>({TEST_ACTUATOR_HARDWARE_NAME})));
+    cm_->set_parameter(rclcpp::Parameter(
+      "autoconfigure_components", std::vector<std::string>({TEST_SENSOR_HARDWARE_NAME})));
+
+    std::string robot_description = "";
+    cm_->get_parameter("robot_description", robot_description);
+    if (robot_description.empty())
+    {
+      throw std::runtime_error(
+        "Unable to initialize resource manager, no robot description found.");
+    }
+
+    cm_->init_resource_manager(robot_description);
+
+    SetUpSrvsCMExecutor();
+  }
+
+  void check_component_fileds(
+    const controller_manager_msgs::msg::HardwareComponentState & component,
+    const std::string & name, const std::string & type, const std::string & class_type,
+    const uint8_t state_id, const std::string & state_label)
+  {
+    EXPECT_EQ(component.name, name);
+    EXPECT_EQ(component.type, type);
+    EXPECT_EQ(component.class_type, class_type);
+    EXPECT_EQ(component.state.id, state_id);
+    EXPECT_EQ(component.state.label, state_label);
+  }
+
+  void list_hardware_components_and_check(
+    const std::vector<uint8_t> & hw_state_ids, const std::vector<std::string> & hw_state_labels,
+    const std::vector<std::vector<std::vector<bool>>> & hw_itfs_available_status,
+    const std::vector<std::vector<std::vector<bool>>> & hw_itfs_claimed_status)
+  {
+    rclcpp::executors::SingleThreadedExecutor srv_executor;
+    rclcpp::Node::SharedPtr list_srv_node = std::make_shared<rclcpp::Node>("list_srv_client");
+    srv_executor.add_node(list_srv_node);
+    rclcpp::Client<controller_manager_msgs::srv::ListHardwareComponents>::SharedPtr list_client =
+      list_srv_node->create_client<controller_manager_msgs::srv::ListHardwareComponents>(
+        std::string(TEST_CM_NAME) + "/list_hardware_components");
+    auto request =
+      std::make_shared<controller_manager_msgs::srv::ListHardwareComponents::Request>();
+
+    auto result = call_service_and_wait(*list_client, request, srv_executor);
+
+    auto check_interfaces =
+      [](
+        const std::vector<controller_manager_msgs::msg::HardwareInterface> & interfaces,
+        const std::vector<const char *> & interface_names,
+        const std::vector<bool> is_available_status, const std::vector<bool> is_claimed_status) {
+        for (auto i = 0ul; i < interfaces.size(); ++i)
+        {
+          auto it = std::find(interface_names.begin(), interface_names.end(), interfaces[i].name);
+          std::cout << "Interface name is: " << interfaces[i].name << std::endl;
+          EXPECT_NE(it, interface_names.end());
+          EXPECT_EQ(interfaces[i].is_available, is_available_status[i]);
+          EXPECT_EQ(interfaces[i].is_claimed, is_claimed_status[i]);
+        }
+      };
+
+    for (const auto & component : result->component)
+    {
+      if (component.name == TEST_ACTUATOR_HARDWARE_NAME)
+      {
+        check_component_fileds(
+          component, TEST_ACTUATOR_HARDWARE_NAME, TEST_ACTUATOR_HARDWARE_TYPE,
+          TEST_ACTUATOR_HARDWARE_CLASS_TYPE, hw_state_ids[0], hw_state_labels[0]);
+        check_interfaces(
+          component.command_interfaces, TEST_ACTUATOR_HARDWARE_COMMAND_INTERFACES,
+          hw_itfs_available_status[0][0], hw_itfs_claimed_status[0][0]);
+        check_interfaces(
+          component.state_interfaces, TEST_ACTUATOR_HARDWARE_STATE_INTERFACES,
+          hw_itfs_available_status[0][1], hw_itfs_claimed_status[0][1]);
+      }
+      if (component.name == TEST_SENSOR_HARDWARE_NAME)
+      {
+        check_component_fileds(
+          component, TEST_SENSOR_HARDWARE_NAME, TEST_SENSOR_HARDWARE_TYPE,
+          TEST_SENSOR_HARDWARE_CLASS_TYPE, hw_state_ids[1], hw_state_labels[1]);
+        check_interfaces(
+          component.command_interfaces, TEST_SENSOR_HARDWARE_COMMAND_INTERFACES,
+          hw_itfs_available_status[1][0], hw_itfs_claimed_status[1][0]);
+        check_interfaces(
+          component.state_interfaces, TEST_SENSOR_HARDWARE_STATE_INTERFACES,
+          hw_itfs_available_status[1][1], hw_itfs_claimed_status[1][1]);
+      }
+      if (component.name == TEST_SYSTEM_HARDWARE_NAME)
+      {
+        check_component_fileds(
+          component, TEST_SYSTEM_HARDWARE_NAME, TEST_SYSTEM_HARDWARE_TYPE,
+          TEST_SYSTEM_HARDWARE_CLASS_TYPE, hw_state_ids[2], hw_state_labels[2]);
+        check_interfaces(
+          component.command_interfaces, TEST_SYSTEM_HARDWARE_COMMAND_INTERFACES,
+          hw_itfs_available_status[2][0], hw_itfs_claimed_status[2][0]);
+        check_interfaces(
+          component.state_interfaces, TEST_SYSTEM_HARDWARE_STATE_INTERFACES,
+          hw_itfs_available_status[2][1], hw_itfs_claimed_status[2][1]);
+      }
+    }
+  }
+
+  bool set_hardware_component_state(
+    const std::string & hardware_name, const uint8_t target_state_id,
+    const std::string & target_state_label)
+  {
+    rclcpp::executors::SingleThreadedExecutor srv_executor;
+    rclcpp::Node::SharedPtr mha_srv_node = std::make_shared<rclcpp::Node>("mha_srv_client");
+    srv_executor.add_node(mha_srv_node);
+    rclcpp::Client<controller_manager_msgs::srv::SetHardwareComponentState>::SharedPtr mha_client =
+      mha_srv_node->create_client<controller_manager_msgs::srv::SetHardwareComponentState>(
+        std::string(TEST_CM_NAME) + "/set_hardware_component_state");
+    auto request =
+      std::make_shared<controller_manager_msgs::srv::SetHardwareComponentState::Request>();
+
+    request->name = hardware_name;
+    request->target_state.id = target_state_id;
+    request->target_state.label = target_state_label;
+
+    auto result = call_service_and_wait(*mha_client, request, srv_executor);
+    return result->ok;
+  }
+};
+
+TEST_F(TestControllerManagerHWManagementSrvs, list_hardware_components)
+{
+  // Default status after start - checks also if "autostart_parameter is correctly read"
+
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_INACTIVE,
+       LFC_STATE::PRIMARY_STATE_UNCONFIGURED}),
+    std::vector<std::string>({ACTIVE, INACTIVE, UNCONFIGURED}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{true, true}, {true, true, true}},  // actuator
+      {{}, {true}},                        // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+}
+
+// TODO(destogl): Add tests for testing controller starting/stopping depending on hw state
+TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_components_set_state)
+{
+  using lifecycle_msgs::msg::State;
+
+  // Default status after start
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_INACTIVE,
+       LFC_STATE::PRIMARY_STATE_UNCONFIGURED}),
+    std::vector<std::string>({ACTIVE, INACTIVE, UNCONFIGURED}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{true, true}, {true, true, true}},  // actuator
+      {{}, {true}},                        // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+
+  // Activate sensor
+  set_hardware_component_state(TEST_SENSOR_HARDWARE_NAME, State::PRIMARY_STATE_ACTIVE, "");
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_ACTIVE,
+       LFC_STATE::PRIMARY_STATE_UNCONFIGURED}),
+    std::vector<std::string>({ACTIVE, ACTIVE, UNCONFIGURED}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{true, true}, {true, true, true}},  // actuator
+      {{}, {true}},                        // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+
+  // Activate system directly - it should do configure automatically; ID is determined from label
+  set_hardware_component_state(TEST_SYSTEM_HARDWARE_NAME, 0, ACTIVE);
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_ACTIVE,
+       LFC_STATE::PRIMARY_STATE_ACTIVE}),
+    std::vector<std::string>({ACTIVE, ACTIVE, ACTIVE}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{true, true}, {true, true, true}},                                      // actuator
+      {{}, {true}},                                                            // sensor
+      {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+
+  // Deactivate actuator
+  set_hardware_component_state(TEST_ACTUATOR_HARDWARE_NAME, 0, INACTIVE);
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_INACTIVE, LFC_STATE::PRIMARY_STATE_ACTIVE,
+       LFC_STATE::PRIMARY_STATE_ACTIVE}),
+    std::vector<std::string>({INACTIVE, ACTIVE, ACTIVE}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{false, true}, {true, true, true}},                                     // actuator
+      {{}, {true}},                                                            // sensor
+      {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+
+  // Double activate system
+  set_hardware_component_state(TEST_SYSTEM_HARDWARE_NAME, LFC_STATE::PRIMARY_STATE_ACTIVE, ACTIVE);
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_INACTIVE, LFC_STATE::PRIMARY_STATE_ACTIVE,
+       LFC_STATE::PRIMARY_STATE_ACTIVE}),
+    std::vector<std::string>({INACTIVE, ACTIVE, ACTIVE}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{false, true}, {true, true, true}},                                     // actuator
+      {{}, {true}},                                                            // sensor
+      {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+
+  // Set sensor to UNCONFIGURED - inactive and cleanup transitions has to be automatically done
+  set_hardware_component_state(
+    TEST_SENSOR_HARDWARE_NAME, LFC_STATE::PRIMARY_STATE_UNCONFIGURED, UNCONFIGURED);
+  list_hardware_components_and_check(
+    // actuator, sensor, system
+    std::vector<uint8_t>(
+      {LFC_STATE::PRIMARY_STATE_INACTIVE, LFC_STATE::PRIMARY_STATE_UNCONFIGURED,
+       LFC_STATE::PRIMARY_STATE_ACTIVE}),
+    std::vector<std::string>({INACTIVE, UNCONFIGURED, ACTIVE}),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is available
+      {{false, true}, {true, true, true}},                                     // actuator
+      {{}, {false}},                                                           // sensor
+      {{true, true, true, true}, {true, true, true, true, true, true, true}},  // system
+    }),
+    std::vector<std::vector<std::vector<bool>>>({
+      // is claimed
+      {{false, false}, {false, false}},  // actuator
+      {{}, {false}},                     // sensor
+      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
+    }));
+}

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -302,8 +302,13 @@ public:
    */
   void write();
 
-  // Temporary method to keep old interface and reduce framework changes in PRs
-  void start_components();
+  /// Activates all available hardware components in the system.
+  /**
+   * All available hardware components int the ros2_control framework are activated.
+   * This is used to preserve default behavior from previous versions where all hardware components
+   * are activated per default.
+   */
+  void activate_all_components();
 
 private:
   void validate_storage(const std::vector<hardware_interface::HardwareInfo> & hardware_info) const;

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -972,7 +972,7 @@ void ResourceManager::validate_storage(
 }
 
 // Temporary method to keep old interface and reduce framework changes in PRs
-void ResourceManager::start_components()
+void ResourceManager::activate_all_components()
 {
   using lifecycle_msgs::msg::State;
   rclcpp_lifecycle::State active_state(


### PR DESCRIPTION
This is the last part of #559.
It implements service logic in controller manager to utilize hardware lifecycle.
It also add parameters to "configure_components_on_start" and "activate_components_on_start" to configure and activate hardware when controller manager is started.
If the parameters are empty or not existent "the old" behavior is preserved where all hardware components are activated at start of the controller manager.
