### PR TITLE
added a fixed control period to loop

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -47,10 +47,6 @@ int main(int argc, char ** argv)
     // Use nanoseconds to avoid chrono's rounding
     rclcpp::Duration period(std::chrono::nanoseconds(1000000000 / cm->get_update_rate()));
 
-    std::this_thread::sleep_for(std::chrono::nanoseconds(
-      (end_loop - cm->now()).nanoseconds()));  // wait until we hit the end of the period
-    end_loop += period;
-
     while (rclcpp::ok())
     {
       // wait until we hit the end of the period

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -43,12 +43,13 @@ int main(int argc, char ** argv)
     rclcpp::Time begin = cm->now();
     rclcpp::Time begin_last = begin;
     rclcpp::Time end = begin;
-    
+
     // Use nanoseconds to avoid chrono's rounding
     rclcpp::Duration period(std::chrono::nanoseconds(1000000000 / cm->get_update_rate()));
     rclcpp::Time end_loop = begin + period;
 
-    std::this_thread::sleep_for(std::chrono::nanoseconds((end_loop - cm->now()).nanoseconds())); // wait until we hit the end of the period
+    std::this_thread::sleep_for(std::chrono::nanoseconds(
+      (end_loop - cm->now()).nanoseconds()));  // wait until we hit the end of the period
     end_loop += period;
 
     while (rclcpp::ok())
@@ -60,7 +61,8 @@ int main(int argc, char ** argv)
       cm->write();
       end = cm->now();
 
-      std::this_thread::sleep_for(std::chrono::nanoseconds((end_loop - cm->now()).nanoseconds())); // wait until we hit the end of the period
+      std::this_thread::sleep_for(std::chrono::nanoseconds(
+        (end_loop - cm->now()).nanoseconds()));  // wait until we hit the end of the period
       end_loop += period;
     }
   });

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -41,7 +41,7 @@ int main(int argc, char ** argv)
     RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
 
     rclcpp::Time current_time = cm->now();
-    rclcpp::Time previous_time = begin;
+    rclcpp::Time previous_time = current_time;
     rclcpp::Time end_period = current_time;
 
     // Use nanoseconds to avoid chrono's rounding
@@ -51,8 +51,7 @@ int main(int argc, char ** argv)
     {
       // wait until we hit the end of the period
       end_period += period;
-      std::this_thread::sleep_for(std::chrono::nanoseconds(
-        (end_period - cm->now()).nanoseconds()));
+      std::this_thread::sleep_for(std::chrono::nanoseconds((end_period - cm->now()).nanoseconds()));
 
       // execute "real-time" update loop
       cm->read();


### PR DESCRIPTION
This uses a fixed control period to remove the drift issue brought up in Issue #644. It also has the time adjustment from PR #646. I ran some simple tests based on the attachment replacing `controller_manager/ros2_control_node.cpp` (similar to what was done in #644) while running the rrbot (`ros2 launch ros2_control_demo_bringup rrbot.launch.py`) using 10 and 1,000 Hz control loops for 10 seconds.  

At 1000Hz the current implementation and PR #646 drift almost a full second over the 10-second experiment. This proposed implementation doesn't show any signs of drift over the same test. The data from my quick experiment is [here](https://docs.google.com/spreadsheets/d/171hXZe9Kps0NN-Hutd5xFktWDz_Cl8S0VuuRP88dyvw/edit?usp=sharing).

I wasn't sure if the period time would need to be updated in the loop or not (I didn't think so), but please let me know if you think it should be moved.

(edit: added test file attachment)
[ros2_control_node.cpp.txt](https://github.com/ros-controls/ros2_control/files/8081195/ros2_control_node.cpp.txt)
