### PR TITLE
Cleaning Controller Interface from obsolete code.

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -30,20 +30,12 @@
 
 namespace controller_interface
 {
-// TODO(karsten1987): Remove clang pragma within Galactic
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc++17-extensions"
-#endif
 enum class return_type : std::uint8_t
 {
   OK = 0,
   ERROR = 1,
   SUCCESS [[deprecated("Use controller_interface::return_type::OK instead.")]] = OK
 };
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 /// Indicating which interfaces are to be claimed.
 /**

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -34,7 +34,6 @@ enum class return_type : std::uint8_t
 {
   OK = 0,
   ERROR = 1,
-  SUCCESS [[deprecated("Use controller_interface::return_type::OK instead.")]] = OK
 };
 
 /// Indicating which interfaces are to be claimed.


### PR DESCRIPTION
- Remove obsolete pre-compiler commands for OSx
- Remove deprecated return type from controller_interface.
