### PR TITLE
Port four bar linkage and differential transmission loaders from ROS1

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -84,6 +84,7 @@ struct ActuatorInfo
   std::string name;
   std::vector<std::string> interfaces;
   std::string role;
+  double mechanical_reduction = 1.0;
   double offset = 0.0;
 };
 

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -385,6 +385,8 @@ ActuatorInfo parse_transmission_actuator_from_xml(const tinyxml2::XMLElement * e
   ActuatorInfo actuator_info;
   actuator_info.name = get_attribute_value(element_it, kNameAttribute, element_it->Name());
   actuator_info.role = get_attribute_value(element_it, kRoleAttribute, element_it->Name());
+  actuator_info.mechanical_reduction =
+    get_parameter_value_or(element_it->FirstChildElement(), kReductionAttribute, 1.0);
   actuator_info.offset =
     get_parameter_value_or(element_it->FirstChildElement(), kOffsetAttribute, 0.0);
   return actuator_info;
@@ -474,7 +476,7 @@ void auto_fill_transmission_interfaces(HardwareInfo & hardware)
       }
 
       transmission.actuators.push_back(
-        ActuatorInfo{"actuator1", transmission.joints[0].interfaces, "actuator1", 0.0});
+        ActuatorInfo{"actuator1", transmission.joints[0].interfaces, "actuator1", 1.0, 0.0});
     }
   }
 }

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -20,9 +20,13 @@ add_library(transmission_interface SHARED
   include/transmission_interface/transmission_loader.hpp
   include/transmission_interface/simple_transmission_loader.hpp
   include/transmission_interface/four_bar_linkage_transmission_loader.hpp
+  include/transmission_interface/differential_transmission_loader.hpp
+
 
   src/simple_transmission_loader.cpp
   src/four_bar_linkage_transmission_loader.cpp
+  src/differential_transmission_loader.cpp
+
 )
 
 target_include_directories(transmission_interface PUBLIC include)
@@ -86,6 +90,13 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_four_bar_linkage_transmission_loader PUBLIC include hardware_interface)
   ament_target_dependencies(test_four_bar_linkage_transmission_loader hardware_interface)
+
+    ament_add_gmock(
+    test_differential_transmission_loader
+    test/differential_transmission_loader_test.cpp
+  )
+  target_include_directories(test_differential_transmission_loader PUBLIC include hardware_interface)
+  ament_target_dependencies(test_differential_transmission_loader hardware_interface)
 endif()
 
 ament_export_include_directories(

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -91,7 +91,7 @@ if(BUILD_TESTING)
   target_include_directories(test_four_bar_linkage_transmission_loader PUBLIC include hardware_interface)
   ament_target_dependencies(test_four_bar_linkage_transmission_loader hardware_interface)
 
-    ament_add_gmock(
+  ament_add_gmock(
     test_differential_transmission_loader
     test/differential_transmission_loader_test.cpp
   )

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -19,7 +19,10 @@ install(
 add_library(transmission_interface SHARED
   include/transmission_interface/transmission_loader.hpp
   include/transmission_interface/simple_transmission_loader.hpp
+  include/transmission_interface/four_bar_linkage_transmission_loader.hpp
+
   src/simple_transmission_loader.cpp
+  src/four_bar_linkage_transmission_loader.cpp
 )
 
 target_include_directories(transmission_interface PUBLIC include)
@@ -76,6 +79,13 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_simple_transmission_loader PUBLIC include hardware_interface)
   ament_target_dependencies(test_simple_transmission_loader hardware_interface)
+
+  ament_add_gmock(
+    test_four_bar_linkage_transmission_loader
+    test/four_bar_linkage_transmission_loader_test.cpp
+  )
+  target_include_directories(test_four_bar_linkage_transmission_loader PUBLIC include hardware_interface)
+  ament_target_dependencies(test_four_bar_linkage_transmission_loader hardware_interface)
 endif()
 
 ament_export_include_directories(

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -17,16 +17,9 @@ install(
 )
 
 add_library(transmission_interface SHARED
-  include/transmission_interface/transmission_loader.hpp
-  include/transmission_interface/simple_transmission_loader.hpp
-  include/transmission_interface/four_bar_linkage_transmission_loader.hpp
-  include/transmission_interface/differential_transmission_loader.hpp
-
-
   src/simple_transmission_loader.cpp
   src/four_bar_linkage_transmission_loader.cpp
   src/differential_transmission_loader.cpp
-
 )
 
 target_include_directories(transmission_interface PUBLIC include)

--- a/transmission_interface/include/transmission_interface/differential_transmission_loader.hpp
+++ b/transmission_interface/include/transmission_interface/differential_transmission_loader.hpp
@@ -1,0 +1,37 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSMISSION_INTERFACE__DIFFERENTIAL_TRANSMISSION_LOADER_HPP_
+#define TRANSMISSION_INTERFACE__DIFFERENTIAL_TRANSMISSION_LOADER_HPP_
+
+#include <memory>
+
+#include "transmission_interface/transmission.hpp"
+#include "transmission_interface/transmission_loader.hpp"
+
+namespace transmission_interface
+{
+/**
+ * \brief Class for loading a four-bar linkage transmission instance from configuration data.
+ */
+class DifferentialTransmissionLoader : public TransmissionLoader
+{
+public:
+  std::shared_ptr<Transmission> load(
+    const hardware_interface::TransmissionInfo & transmission_info) override;
+};
+
+}  // namespace transmission_interface
+
+#endif  // TRANSMISSION_INTERFACE__DIFFERENTIAL_TRANSMISSION_LOADER_HPP_

--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.hpp
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission_loader.hpp
@@ -1,0 +1,37 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRANSMISSION_INTERFACE__FOUR_BAR_LINKAGE_TRANSMISSION_LOADER_HPP_
+#define TRANSMISSION_INTERFACE__FOUR_BAR_LINKAGE_TRANSMISSION_LOADER_HPP_
+
+#include <memory>
+
+#include "transmission_interface/transmission.hpp"
+#include "transmission_interface/transmission_loader.hpp"
+
+namespace transmission_interface
+{
+/**
+ * \brief Class for loading a four-bar linkage transmission instance from configuration data.
+ */
+class FourBarLinkageTransmissionLoader : public TransmissionLoader
+{
+public:
+  std::shared_ptr<Transmission> load(
+    const hardware_interface::TransmissionInfo & transmission_info) override;
+};
+
+}  // namespace transmission_interface
+
+#endif  // TRANSMISSION_INTERFACE__FOUR_BAR_LINKAGE_TRANSMISSION_LOADER_HPP_

--- a/transmission_interface/ros2_control_plugins.xml
+++ b/transmission_interface/ros2_control_plugins.xml
@@ -7,4 +7,12 @@
       Load configuration of a simple transmission from a URDF description.
     </description>
   </class>
+
+  <class name="transmission_interface/FourBarLinkageTransmission"
+         type="transmission_interface::FourBarLinkageTransmissionLoader"
+         base_class_type="transmission_interface::TransmissionLoader">
+    <description>
+      Load configuration of a four bar linkage transmission from a URDF description.
+    </description>
+  </class>
 </library>

--- a/transmission_interface/ros2_control_plugins.xml
+++ b/transmission_interface/ros2_control_plugins.xml
@@ -15,4 +15,12 @@
       Load configuration of a four bar linkage transmission from a URDF description.
     </description>
   </class>
+
+  <class name="transmission_interface/DifferentialTransmission"
+         type="transmission_interface::DifferentialTransmissionLoader"
+         base_class_type="transmission_interface::TransmissionLoader">
+    <description>
+      Load configuration of a four bar linkage transmission from a URDF description.
+    </description>
+  </class>
 </library>

--- a/transmission_interface/src/differential_transmission_loader.cpp
+++ b/transmission_interface/src/differential_transmission_loader.cpp
@@ -1,0 +1,61 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transmission_interface/differential_transmission_loader.hpp"
+
+#include <memory>
+
+#include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "transmission_interface/differential_transmission.hpp"
+
+namespace transmission_interface
+{
+std::shared_ptr<Transmission> DifferentialTransmissionLoader::load(
+  const hardware_interface::TransmissionInfo & transmission_info)
+{
+  try
+  {
+    const auto act_reduction1 = transmission_info.actuators.at(0).mechanical_reduction;
+    const auto act_reduction2 = transmission_info.actuators.at(1).mechanical_reduction;
+
+    const auto jnt_reduction1 = transmission_info.joints.at(0).mechanical_reduction;
+    const auto jnt_reduction2 = transmission_info.joints.at(1).mechanical_reduction;
+
+    const auto jnt_offset1 = transmission_info.joints.at(0).offset;
+    const auto jnt_offset2 = transmission_info.joints.at(1).offset;
+
+    std::shared_ptr<Transmission> transmission(new DifferentialTransmission(
+      {act_reduction1, act_reduction2}, {jnt_reduction1, jnt_reduction2},
+      {jnt_offset1, jnt_offset2}));
+    return transmission;
+  }
+  catch (const Exception & ex)
+  {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("four_bar_linkage_transmission_loader"),
+      "Failed to construct transmission '%s'", ex.what());
+    return std::shared_ptr<Transmission>();
+  }
+}
+
+}  // namespace transmission_interface
+
+PLUGINLIB_EXPORT_CLASS(
+  transmission_interface::DifferentialTransmissionLoader,
+  transmission_interface::TransmissionLoader)

--- a/transmission_interface/src/differential_transmission_loader.cpp
+++ b/transmission_interface/src/differential_transmission_loader.cpp
@@ -45,10 +45,10 @@ std::shared_ptr<Transmission> DifferentialTransmissionLoader::load(
       {jnt_offset1, jnt_offset2}));
     return transmission;
   }
-  catch (const Exception & ex)
+  catch (const std::exception & ex)
   {
     RCLCPP_ERROR(
-      rclcpp::get_logger("four_bar_linkage_transmission_loader"),
+      rclcpp::get_logger("differential_transmission_loader"),
       "Failed to construct transmission '%s'", ex.what());
     return std::shared_ptr<Transmission>();
   }

--- a/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
+++ b/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<Transmission> FourBarLinkageTransmissionLoader::load(
       {jnt_offset1, jnt_offset2}));
     return transmission;
   }
-  catch (const Exception & ex)
+  catch (const std::exception & ex)
   {
     RCLCPP_ERROR(
       rclcpp::get_logger("four_bar_linkage_transmission_loader"),

--- a/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
+++ b/transmission_interface/src/four_bar_linkage_transmission_loader.cpp
@@ -1,0 +1,61 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
+
+#include <memory>
+
+#include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/logging.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "transmission_interface/four_bar_linkage_transmission.hpp"
+
+namespace transmission_interface
+{
+std::shared_ptr<Transmission> FourBarLinkageTransmissionLoader::load(
+  const hardware_interface::TransmissionInfo & transmission_info)
+{
+  try
+  {
+    const auto act_reduction1 = transmission_info.actuators.at(0).mechanical_reduction;
+    const auto act_reduction2 = transmission_info.actuators.at(1).mechanical_reduction;
+
+    const auto jnt_reduction1 = transmission_info.joints.at(0).mechanical_reduction;
+    const auto jnt_reduction2 = transmission_info.joints.at(1).mechanical_reduction;
+
+    const auto jnt_offset1 = transmission_info.joints.at(0).offset;
+    const auto jnt_offset2 = transmission_info.joints.at(1).offset;
+
+    std::shared_ptr<Transmission> transmission(new FourBarLinkageTransmission(
+      {act_reduction1, act_reduction2}, {jnt_reduction1, jnt_reduction2},
+      {jnt_offset1, jnt_offset2}));
+    return transmission;
+  }
+  catch (const Exception & ex)
+  {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("four_bar_linkage_transmission_loader"),
+      "Failed to construct transmission '%s'", ex.what());
+    return std::shared_ptr<Transmission>();
+  }
+}
+
+}  // namespace transmission_interface
+
+PLUGINLIB_EXPORT_CLASS(
+  transmission_interface::FourBarLinkageTransmissionLoader,
+  transmission_interface::TransmissionLoader)

--- a/transmission_interface/src/simple_transmission_loader.cpp
+++ b/transmission_interface/src/simple_transmission_loader.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<Transmission> SimpleTransmissionLoader::load(
       new SimpleTransmission(mechanical_reduction, offset));
     return transmission;
   }
-  catch (const Exception & ex)
+  catch (const std::exception & ex)
   {
     RCLCPP_ERROR(
       rclcpp::get_logger("simple_transmission_loader"), "Failed to construct transmission '%s'",

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -105,7 +105,6 @@ TEST(DifferentialTransmissionLoaderTest, FullSpec)
   std::shared_ptr<transmission_interface::Transmission> transmission;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::DifferentialTransmission * differential_transmission =
@@ -178,7 +177,6 @@ TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::DifferentialTransmission * differential_transmission =
@@ -242,7 +240,6 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::DifferentialTransmission * differential_transmission =
@@ -314,7 +311,6 @@ TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::DifferentialTransmission * differential_transmission =
@@ -389,7 +385,6 @@ TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::DifferentialTransmission * differential_transmission =

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -22,8 +22,8 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "pluginlib/class_loader.hpp"
-#include "transmission_interface/four_bar_linkage_transmission.hpp"
-#include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
+#include "transmission_interface/differential_transmission.hpp"
+#include "transmission_interface/differential_transmission_loader.hpp"
 #include "transmission_interface/transmission_loader.hpp"
 
 using testing::SizeIs;
@@ -108,21 +108,21 @@ TEST(DifferentialTransmissionLoaderTest, FullSpec)
   ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
-  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+  transmission_interface::DifferentialTransmission * differential_transmission =
     dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
-  ASSERT_TRUE(nullptr != four_bar_linkage_transmission);
+  ASSERT_TRUE(nullptr != differential_transmission);
 
   const std::vector<double> & actuator_reduction =
-    four_bar_linkage_transmission->get_actuator_reduction();
+    differential_transmission->get_actuator_reduction();
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
   const std::vector<double> & joint_reduction =
-    four_bar_linkage_transmission->get_joint_reduction();
+    differential_transmission->get_joint_reduction();
   EXPECT_EQ(2.0, joint_reduction[0]);
   EXPECT_EQ(-2.0, joint_reduction[1]);
 
-  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
   EXPECT_EQ(0.5, joint_offset[0]);
   EXPECT_EQ(-0.5, joint_offset[1]);
 }
@@ -182,20 +182,20 @@ TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
   ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
-  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+  transmission_interface::DifferentialTransmission * differential_transmission =
     dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
 
   const std::vector<double> & actuator_reduction =
-    four_bar_linkage_transmission->get_actuator_reduction();
+    differential_transmission->get_actuator_reduction();
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
   const std::vector<double> & joint_reduction =
-    four_bar_linkage_transmission->get_joint_reduction();
+    differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
-  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
   EXPECT_EQ(0.0, joint_offset[0]);
   EXPECT_EQ(0.0, joint_offset[1]);
 }
@@ -247,20 +247,20 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
   ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
-  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+  transmission_interface::DifferentialTransmission * differential_transmission =
     dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
 
   const std::vector<double> & actuator_reduction =
-    four_bar_linkage_transmission->get_actuator_reduction();
+    differential_transmission->get_actuator_reduction();
   EXPECT_EQ(1.0, actuator_reduction[0]);
   EXPECT_EQ(1.0, actuator_reduction[1]);
 
   const std::vector<double> & joint_reduction =
-    four_bar_linkage_transmission->get_joint_reduction();
+    differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
-  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
   EXPECT_EQ(0.0, joint_offset[0]);
   EXPECT_EQ(0.0, joint_offset[1]);
 }
@@ -320,21 +320,21 @@ TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
   ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
-  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+  transmission_interface::DifferentialTransmission * differential_transmission =
     dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
 
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
-    four_bar_linkage_transmission->get_actuator_reduction();
+    differential_transmission->get_actuator_reduction();
   EXPECT_EQ(1.0, actuator_reduction[0]);
   EXPECT_EQ(1.0, actuator_reduction[1]);
 
   const std::vector<double> & joint_reduction =
-    four_bar_linkage_transmission->get_joint_reduction();
+    differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
-  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
   EXPECT_EQ(0.0, joint_offset[0]);
   EXPECT_EQ(0.0, joint_offset[1]);
 }
@@ -396,22 +396,22 @@ TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
   ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
-  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+  transmission_interface::DifferentialTransmission * differential_transmission =
     dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
 
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
-    four_bar_linkage_transmission->get_actuator_reduction();
+    differential_transmission->get_actuator_reduction();
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
   const std::vector<double> & joint_reduction =
-    four_bar_linkage_transmission->get_joint_reduction();
+    differential_transmission->get_joint_reduction();
   EXPECT_EQ(2.0, joint_reduction[0]);
   EXPECT_EQ(-2.0, joint_reduction[1]);
 
   // default kicks in for ill-defined values
-  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
   EXPECT_EQ(0.0, joint_offset[0]);
   EXPECT_EQ(0.0, joint_offset[1]);
 }

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -1,0 +1,474 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "transmission_interface/four_bar_linkage_transmission.hpp"
+#include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
+#include "transmission_interface/transmission_loader.hpp"
+
+using testing::SizeIs;
+
+class TransmissionPluginLoader
+{
+public:
+  std::shared_ptr<transmission_interface::TransmissionLoader> create(const std::string & type)
+  {
+    try
+    {
+      return class_loader_.createUniqueInstance(type);
+    }
+    catch (std::exception & ex)
+    {
+      std::cerr << ex.what() << std::endl;
+      return std::shared_ptr<transmission_interface::TransmissionLoader>();
+    }
+  }
+
+private:
+  // must keep it alive because instance destroyers need it
+  pluginlib::ClassLoader<transmission_interface::TransmissionLoader> class_loader_ = {
+    "transmission_interface", "transmission_interface::TransmissionLoader"};
+};
+
+TEST(DifferentialTransmissionLoaderTest, FullSpec)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>0.5</offset>
+            <mechanical_reduction>2.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>-0.5</offset>
+            <mechanical_reduction>-2.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
+  ASSERT_TRUE(nullptr != four_bar_linkage_transmission);
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(2.0, joint_reduction[0]);
+  EXPECT_EQ(-2.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.5, joint_offset[0]);
+  EXPECT_EQ(-0.5, joint_offset[1]);
+}
+
+TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <mechanical_reduction>1.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <mechanical_reduction>1.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1"/>
+          <actuator name="joint2_motor" role="actuator2"/>
+          <joint name="joint1" role="joint1"/>
+          <joint name="joint2" role="joint2"/>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(1.0, actuator_reduction[0]);
+  EXPECT_EQ(1.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>one</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>two</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <mechanical_reduction>three</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <mechanical_reduction>four</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(1.0, actuator_reduction[0]);
+  EXPECT_EQ(1.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>two</offset>  <!-- Not a number -->
+            <mechanical_reduction>2.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>three</offset>  <!-- Not a number -->
+            <mechanical_reduction>-2.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::DifferentialTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::DifferentialTransmission *>(transmission.get());
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(2.0, joint_reduction[0]);
+  EXPECT_EQ(-2.0, joint_reduction[1]);
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(DifferentialTransmissionLoaderTest, mech_red_invalid_value)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/DifferentialTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>0</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>0</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>2</offset>
+            <mechanical_reduction>0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>3</offset>
+            <mechanical_reduction>0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr == transmission);
+}

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -117,8 +117,7 @@ TEST(DifferentialTransmissionLoaderTest, FullSpec)
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
-  const std::vector<double> & joint_reduction =
-    differential_transmission->get_joint_reduction();
+  const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
   EXPECT_EQ(2.0, joint_reduction[0]);
   EXPECT_EQ(-2.0, joint_reduction[1]);
 
@@ -190,8 +189,7 @@ TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
-  const std::vector<double> & joint_reduction =
-    differential_transmission->get_joint_reduction();
+  const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
@@ -255,8 +253,7 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
   EXPECT_EQ(1.0, actuator_reduction[0]);
   EXPECT_EQ(1.0, actuator_reduction[1]);
 
-  const std::vector<double> & joint_reduction =
-    differential_transmission->get_joint_reduction();
+  const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
@@ -329,8 +326,7 @@ TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
   EXPECT_EQ(1.0, actuator_reduction[0]);
   EXPECT_EQ(1.0, actuator_reduction[1]);
 
-  const std::vector<double> & joint_reduction =
-    differential_transmission->get_joint_reduction();
+  const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
   EXPECT_EQ(1.0, joint_reduction[0]);
   EXPECT_EQ(1.0, joint_reduction[1]);
 
@@ -405,8 +401,7 @@ TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
   EXPECT_EQ(50.0, actuator_reduction[0]);
   EXPECT_EQ(-50.0, actuator_reduction[1]);
 
-  const std::vector<double> & joint_reduction =
-    differential_transmission->get_joint_reduction();
+  const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
   EXPECT_EQ(2.0, joint_reduction[0]);
   EXPECT_EQ(-2.0, joint_reduction[1]);
 

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -105,7 +105,6 @@ TEST(FourBarLinkageTransmissionLoaderTest, FullSpec)
   std::shared_ptr<transmission_interface::Transmission> transmission;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
@@ -179,7 +178,6 @@ TEST(FourBarLinkageTransmissionLoaderTest, only_mech_red_specified)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
@@ -200,7 +198,7 @@ TEST(FourBarLinkageTransmissionLoaderTest, only_mech_red_specified)
   EXPECT_EQ(0.0, joint_offset[1]);
 }
 
-TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
+TEST(DifferentialTransmissionLoaderTest, offset_and_mech_red_not_specified)
 {
   // Parse transmission info
   std::string urdf_to_test = R"(
@@ -244,7 +242,6 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
@@ -317,7 +314,6 @@ TEST(FourBarLinkageTransmissionLoaderTest, mechanical_reduction_not_a_number)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
@@ -393,7 +389,6 @@ TEST(FourBarLinkageTransmissionLoaderTest, offset_ill_defined)
   std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
   const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
   transmission = transmission_loader->load(info);
-  ASSERT_TRUE(nullptr != transmission);
 
   // Validate transmission
   transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -1,0 +1,474 @@
+// Copyright 2022 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/component_parser.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "transmission_interface/four_bar_linkage_transmission.hpp"
+#include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
+#include "transmission_interface/transmission_loader.hpp"
+
+using testing::SizeIs;
+
+class TransmissionPluginLoader
+{
+public:
+  std::shared_ptr<transmission_interface::TransmissionLoader> create(const std::string & type)
+  {
+    try
+    {
+      return class_loader_.createUniqueInstance(type);
+    }
+    catch (std::exception & ex)
+    {
+      std::cerr << ex.what() << std::endl;
+      return std::shared_ptr<transmission_interface::TransmissionLoader>();
+    }
+  }
+
+private:
+  // must keep it alive because instance destroyers need it
+  pluginlib::ClassLoader<transmission_interface::TransmissionLoader> class_loader_ = {
+    "transmission_interface", "transmission_interface::TransmissionLoader"};
+};
+
+TEST(FourBarLinkageTransmissionLoaderTest, FullSpec)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>0.5</offset>
+            <mechanical_reduction>2.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>-0.5</offset>
+            <mechanical_reduction>-2.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::FourBarLinkageTransmission *>(transmission.get());
+  ASSERT_TRUE(nullptr != four_bar_linkage_transmission);
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(2.0, joint_reduction[0]);
+  EXPECT_EQ(-2.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.5, joint_offset[0]);
+  EXPECT_EQ(-0.5, joint_offset[1]);
+}
+
+TEST(FourBarLinkageTransmissionLoaderTest, only_mech_red_specified)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <mechanical_reduction>1.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <mechanical_reduction>1.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::FourBarLinkageTransmission *>(transmission.get());
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1"/>
+          <actuator name="joint2_motor" role="actuator2"/>
+          <joint name="joint1" role="joint1"/>
+          <joint name="joint2" role="joint2"/>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::FourBarLinkageTransmission *>(transmission.get());
+
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(1.0, actuator_reduction[0]);
+  EXPECT_EQ(1.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(FourBarLinkageTransmissionLoaderTest, mechanical_reduction_not_a_number)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>one</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>two</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <mechanical_reduction>three</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <mechanical_reduction>four</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::FourBarLinkageTransmission *>(transmission.get());
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(1.0, actuator_reduction[0]);
+  EXPECT_EQ(1.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(1.0, joint_reduction[0]);
+  EXPECT_EQ(1.0, joint_reduction[1]);
+
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(FourBarLinkageTransmissionLoaderTest, offset_ill_defined)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>50</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>-50</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>two</offset>  <!-- Not a number -->
+            <mechanical_reduction>2.0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>three</offset>  <!-- Not a number -->
+            <mechanical_reduction>-2.0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr != transmission);
+
+  // Validate transmission
+  transmission_interface::FourBarLinkageTransmission * four_bar_linkage_transmission =
+    dynamic_cast<transmission_interface::FourBarLinkageTransmission *>(transmission.get());
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & actuator_reduction =
+    four_bar_linkage_transmission->get_actuator_reduction();
+  EXPECT_EQ(50.0, actuator_reduction[0]);
+  EXPECT_EQ(-50.0, actuator_reduction[1]);
+
+  const std::vector<double> & joint_reduction =
+    four_bar_linkage_transmission->get_joint_reduction();
+  EXPECT_EQ(2.0, joint_reduction[0]);
+  EXPECT_EQ(-2.0, joint_reduction[1]);
+
+  // default kicks in for ill-defined values
+  const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
+  EXPECT_EQ(0.0, joint_offset[0]);
+  EXPECT_EQ(0.0, joint_offset[1]);
+}
+
+TEST(FourBarLinkageTransmissionLoaderTest, mech_red_invalid_value)
+{
+  // Parse transmission info
+  std::string urdf_to_test = R"(
+    <?xml version="1.0"?>
+    <robot name="robot" xmlns="http://www.ros.org">
+      <ros2_control name="FullSpec" type="system">
+        <joint name="joint1">
+          <command_interface name="velocity">
+            <param name="min">-0.5</param>
+            <param name="max">0.5</param>
+          </command_interface>
+          <state_interface name="velocity"/>
+        </joint>
+        <joint name="joint2">
+          <command_interface name="position">
+            <param name="min">-1</param>
+            <param name="max">1</param>
+          </command_interface>
+          <state_interface name="position"/>
+        </joint>
+        <transmission name="transmission1">
+          <plugin>transmission_interface/FourBarLinkageTransmission</plugin>
+          <actuator name="joint1_motor" role="actuator1">
+            <mechanical_reduction>0</mechanical_reduction>
+          </actuator>
+          <actuator name="joint2_motor" role="actuator2">
+            <mechanical_reduction>0</mechanical_reduction>
+          </actuator>
+          <joint name="joint1" role="joint1">
+            <offset>2</offset>
+            <mechanical_reduction>0</mechanical_reduction>
+          </joint>
+          <joint name="joint2" role="joint2">
+            <offset>3</offset>
+            <mechanical_reduction>0</mechanical_reduction>
+          </joint>
+        </transmission>
+      </ros2_control>
+    </robot>
+    )";
+  std::vector<hardware_interface::HardwareInfo> infos =
+    hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(infos[0].transmissions, SizeIs(1));
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  std::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader =
+    loader.create(infos[0].transmissions[0].type);
+  ASSERT_TRUE(nullptr != transmission_loader);
+
+  std::shared_ptr<transmission_interface::Transmission> transmission = nullptr;
+  const hardware_interface::TransmissionInfo & info = infos[0].transmissions[0];
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(nullptr == transmission);
+}


### PR DESCRIPTION
Plus minor changes to parsing
Should I create test cases with invalid roles, since they were present in the ROS1 version?

Issue: #599 