### PR TITLE
[CI] Replace colcon-mixin-name with colcon-defaults

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -30,7 +30,7 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: |
+          colcon-defaults: |
             {
               "build": {
                 "mixin": ["coverage-gcc"]

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -30,7 +30,12 @@ jobs:
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
             https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/ros2_control/ros2_control.repos
-          colcon-mixin-name: coverage-gcc
+          colcon-mixin-name: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
The former is not a valid option in action-ros-ci@v0.2.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>