### PR TITLE
Resource Manager extension to support management of reference interfaces from chained controllers.

### DIFF
--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -114,6 +114,28 @@ public:
    */
   bool state_interface_is_available(const std::string & name) const;
 
+  /// Add controllers' reference interfaces to resource manager.
+  /**
+   * Interface for transferring management of reference interfaces to resource manager.
+   * When chaining controllers, reference interfaces are used as command interface of preceding
+   * controllers.
+   * Therefore, they should be managed in the same way as command interface of hardware.
+   *
+   * \param[in] interfaces list of controller's reference interfaces as CommandInterfaces.
+   * \return list of added reference interfaces
+   */
+  std::vector<std::string> import_controller_reference_interfaces(
+    std::vector<CommandInterface> & interfaces);
+
+  /// Remove controllers reference interfaces from resource manager.
+  /**
+   * Remove reference interfaces from resource manager, i.e., resource storage.
+   * The interfaces will be deleted from all internal maps and lists.
+   *
+   * \param[in] interface_names list of interface names that will be deleted from resource manager.
+   */
+  void remove_controller_reference_interfaces(const std::vector<std::string> & interface_names);
+
   /// Checks whether a command interface is already claimed.
   /**
    * Any command interface can only be claimed by a single instance.

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -121,20 +121,50 @@ public:
    * controllers.
    * Therefore, they should be managed in the same way as command interface of hardware.
    *
+   * \param[in] controller_name name of the controller which reference interfaces are imported.
    * \param[in] interfaces list of controller's reference interfaces as CommandInterfaces.
-   * \return list of added reference interfaces
    */
-  std::vector<std::string> import_controller_reference_interfaces(
-    std::vector<CommandInterface> & interfaces);
+  void import_controller_reference_interfaces(
+    const std::string & controller_name, std::vector<CommandInterface> & interfaces);
+
+  /// Get list of reference interface of a controller.
+  /**
+   * Returns lists of stored reference interfaces names for a controller.
+   *
+   * \param[in] controller_name for which list of reference interface names is returned.
+   * \returns list of reference interface names.
+   */
+  std::vector<std::string> get_controller_reference_interface_names(
+    const std::string & controller_name);
+
+  /// Add controller's reference interface to available list.
+  /**
+   * Adds interfaces of a controller with given name to the available list. This method should be
+   * called when a controller gets activated with chained mode turned on. That means, the
+   * controller's reference interfaces can be used by another controller in chained architectures.
+   *
+   * \param[in] controller_name name of the controller which interfaces should become available.
+   */
+  void make_controller_reference_interfaces_available(const std::string & controller_name);
+
+  /// Remove controller's reference interface to available list.
+  /**
+   * Removes interfaces of a controller with given name from the available list. This method should
+   * be called when a controller gets deactivated and its reference interfaces cannot be used by
+   * another controller anymore.
+   *
+   * \param[in] controller_name name of the controller which interfaces should become unavailable.
+   */
+  void make_controller_reference_interfaces_unavailable(const std::string & controller_name);
 
   /// Remove controllers reference interfaces from resource manager.
   /**
    * Remove reference interfaces from resource manager, i.e., resource storage.
    * The interfaces will be deleted from all internal maps and lists.
    *
-   * \param[in] interface_names list of interface names that will be deleted from resource manager.
+   * \param[in] controller_name list of interface names that will be deleted from resource manager.
    */
-  void remove_controller_reference_interfaces(const std::vector<std::string> & interface_names);
+  void remove_controller_reference_interfaces(const std::string & controller_name);
 
   /// Checks whether a command interface is already claimed.
   /**

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -434,6 +434,17 @@ public:
     hardware_info_map_[hardware.get_name()].command_interfaces = add_command_interfaces(interfaces);
   }
 
+  /// Adds exported command interfaces into internal storage.
+  /**
+   * Add command interfaces to the internal storage. Command interfaces exported from hardware or
+   * chainable controllers are moved to the map with name-interface pairs, the interface names are
+   * added to the claimed map and available list's size is increased to reserve storage when
+   * interface change theirs status in real-time control loop.
+   *
+   * \param[interfaces] list of command interface to add into storage.
+   * \returns list of interface names that are added into internal storage. The output is used to
+   * avoid additional iterations to cache interface names, e.g., for initializing info structures.
+   */
   std::vector<std::string> add_command_interfaces(std::vector<CommandInterface> & interfaces)
   {
     std::vector<std::string> interface_names;
@@ -451,6 +462,12 @@ public:
     return interface_names;
   }
 
+  /// Removes command interfaces from internal storage.
+  /**
+   * Command interface are removed from the maps with theirs storage and their claimed status.
+   *
+   * \param[interface_names] list of command interface names to remove from storage.
+   */
   void remove_command_interfaces(const std::vector<std::string> & interface_names)
   {
     for (const auto & interface : interface_names)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -221,7 +221,8 @@ public:
         {
           available_command_interfaces_.erase(found_it);
           RCUTILS_LOG_DEBUG_NAMED(
-            "resource_manager", "(hardware '%s'): '%s' command removed from available list",
+            "resource_manager",
+            "(hardware '%s'): '%s' command interface removed from available list",
             hardware.get_name().c_str(), interface.c_str());
         }
         else
@@ -275,6 +276,7 @@ public:
       // TODO(destogl): change this - deimport all things if there is there are interfaces there
       // deimport_non_movement_command_interfaces(hardware);
       // deimport_state_interfaces(hardware);
+      // use remove_command_interfaces(hardware);
     }
     return result;
   }
@@ -429,6 +431,11 @@ public:
   void import_command_interfaces(HardwareT & hardware)
   {
     auto interfaces = hardware.export_command_interfaces();
+    hardware_info_map_[hardware.get_name()].command_interfaces = add_command_interfaces(interfaces);
+  }
+
+  std::vector<std::string> add_command_interfaces(std::vector<CommandInterface> & interfaces)
+  {
     std::vector<std::string> interface_names;
     interface_names.reserve(interfaces.size());
     for (auto & interface : interfaces)
@@ -438,9 +445,29 @@ public:
       claimed_command_interface_map_.emplace(std::make_pair(key, false));
       interface_names.push_back(key);
     }
-    hardware_info_map_[hardware.get_name()].command_interfaces = interface_names;
     available_command_interfaces_.reserve(
       available_command_interfaces_.capacity() + interface_names.size());
+
+    return interface_names;
+  }
+
+  void remove_command_interfaces(const std::vector<std::string> & interface_names)
+  {
+    for (const auto & interface : interface_names)
+    {
+      command_interface_map_.erase(interface);
+      claimed_command_interface_map_.erase(interface);
+
+      auto found_it = std::find(
+        available_command_interfaces_.begin(), available_command_interfaces_.end(), interface);
+      if (found_it != available_command_interfaces_.end())
+      {
+        available_command_interfaces_.erase(found_it);
+        RCUTILS_LOG_DEBUG_NAMED(
+          "resource_manager", "'%s' command interface removed from available list",
+          interface.c_str());
+      }
+    }
   }
 
   // TODO(destogl): Propagate "false" up, if happens in initialize_hardware
@@ -616,7 +643,23 @@ bool ResourceManager::state_interface_is_available(const std::string & name) con
            name) != resource_storage_->available_state_interfaces_.end();
 }
 
-// CM API
+std::vector<std::string> ResourceManager::import_controller_reference_interfaces(
+  std::vector<CommandInterface> & interfaces)
+{
+  auto interface_names = resource_storage_->add_command_interfaces(interfaces);
+  resource_storage_->available_command_interfaces_.insert(
+    resource_storage_->available_command_interfaces_.end(), interface_names.begin(),
+    interface_names.end());
+  return interface_names;
+}
+
+void ResourceManager::remove_controller_reference_interfaces(
+  const std::vector<std::string> & interface_names)
+{
+  resource_storage_->remove_command_interfaces(interface_names);
+}
+
+// CM API: Called in "update"-thread
 bool ResourceManager::command_interface_is_claimed(const std::string & key) const
 {
   if (!command_interface_is_available(key))


### PR DESCRIPTION
This PR introduces changes for Resource Manager regarding management of reference interfaces from chained controllers.
Resource Manager already has implemented management of Command (Read/Write) interfaces, therefore only methods for accessing reference interfaces specifically are created.
The main reason for putting the code here is to avoid code duplication in Controller Manager.

The PR doesn't depend on any PR specifically because the changes and functionality is limited to Resource Manager.
