### PR TITLE
Error if a hardware name is duplicated

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -102,10 +102,12 @@ public:
     // Check for identical names
     if (hardware_info_map_.find(hardware_info.name) != hardware_info_map_.end())
     {
-      throw std::runtime_error("Hardware name " + hardware_info.name + " is duplicated. Please provide a unique 'name' in the URDF.");
+      throw std::runtime_error(
+        "Hardware name " + hardware_info.name +
+        " is duplicated. Please provide a unique 'name' in the URDF.");
     }
 
-    hardware_info_map_.insert(std::make_pair(component_info.name, component_info));  
+    hardware_info_map_.insert(std::make_pair(component_info.name, component_info));
   }
 
   template <class HardwareT>

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -98,7 +98,14 @@ public:
     component_info.name = hardware_info.name;
     component_info.type = hardware_info.type;
     component_info.class_type = hardware_info.hardware_class_type;
-    hardware_info_map_.insert(std::make_pair(component_info.name, component_info));
+
+    // Check for identical names
+    if (hardware_info_map_.find(hardware_info.name) != hardware_info_map_.end())
+    {
+      throw std::runtime_error("Hardware name " + hardware_info.name + " is duplicated. Please provide a unique 'name' in the URDF.");
+    }
+
+    hardware_info_map_.insert(std::make_pair(component_info.name, component_info));  
   }
 
   template <class HardwareT>
@@ -139,7 +146,6 @@ public:
       // happened and only then trigger this part of the code?
       // On the other side this part of the code should never be executed in real-time critical
       // thread, so it could be also OK as it is...
-      // @bmagyar what do you think?
       for (const auto & interface : hardware_info_map_[hardware.get_name()].state_interfaces)
       {
         // add all state interfaces to available list
@@ -426,6 +432,7 @@ public:
     for (auto & interface : interfaces)
     {
       auto key = interface.get_full_name();
+      RCUTILS_LOG_INFO_NAMED("resource_manager", "Command interface: '%s'", key.c_str());
       command_interface_map_.emplace(std::make_pair(key, std::move(interface)));
       claimed_command_interface_map_.emplace(std::make_pair(key, false));
       interface_names.push_back(key);

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -434,7 +434,6 @@ public:
     for (auto & interface : interfaces)
     {
       auto key = interface.get_full_name();
-      RCUTILS_LOG_INFO_NAMED("resource_manager", "Command interface: '%s'", key.c_str());
       command_interface_map_.emplace(std::make_pair(key, std::move(interface)));
       claimed_command_interface_map_.emplace(std::make_pair(key, false));
       interface_names.push_back(key);


### PR DESCRIPTION
I fell into this pitfall when trying to launch a dual-arm system. The robot xacro was duplicated so hardware loading failed.