### PR TITLE
Require lifecycle-msgs in package.xml and CMakeLists.txt

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(control_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcpputils REQUIRED)
@@ -31,6 +32,7 @@ target_include_directories(
 ament_target_dependencies(
   hardware_interface
   control_msgs
+  lifecycle_msgs
   pluginlib
   rclcpp_lifecycle
   rcutils
@@ -158,6 +160,8 @@ ament_export_libraries(
 )
 ament_export_dependencies(
   control_msgs
+  lifecycle_msgs
+  rclcpp_lifecycle
   pluginlib
   rcpputils
   tinyxml2_vendor

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>control_msgs</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rcpputils</depend>


### PR DESCRIPTION
Hey, I just tried to build it on Ubuntu 18.04 and it (+ gazebo_ros2_control) failed. 

As `hardware_interface/system_interface.hpp` includes state.hpp:

https://github.com/ros-controls/ros2_control/blob/500233ac3d7f337881922ae7a96abd0a87b70dfa/hardware_interface/include/hardware_interface/system_interface.hpp#L26

I guess lifecycle_msgs should be a public dependency.