### PR TITLE
Spawner waits for services

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -44,7 +44,7 @@ class bcolors:
 
 
 def first_match(iterable, predicate):
-    return next(n for n in iterable if predicate(n), None)
+    return next((n for n in iterable if predicate(n)), None)
 
 
 def wait_for_value_or(function, node, timeout, default, description):

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -74,6 +74,8 @@ def find_node_and_namespace(node, full_node_name):
 
 def has_service_names(node, node_name, node_namespace, service_names):
     client_names_and_types = node.get_client_names_and_types_by_node(node_name, node_namespace)
+    node.get_logger().info(str(client_names_and_types), throttle_duration_sec=2)
+
     if len(client_names_and_types) == 0:
         return False
     client_names, _ = zip(*client_names_and_types)
@@ -97,14 +99,14 @@ def wait_for_controller_manager(node, controller_manager, timeout_duration):
     timeout = node.get_clock().now() + Duration(seconds=timeout_duration)
     node_and_namespace = wait_for_value_or(
         lambda: find_node_and_namespace(node, controller_manager),
-        node, timeout, None, f"'{controller_manager}' node to exist")
+        node, timeout, None, f'\'{controller_manager}\' node to exist')
 
     # Wait for the services if the node was found
     if node_and_namespace:
         node_name, namespace = node_and_namespace
         return wait_for_value_or(
             lambda: has_service_names(node, node_name, namespace, service_names),
-            node, timeout, False, "'{controller_manager}' services to be available")
+            node, timeout, False, f'\'{controller_manager}\' services to be available')
 
     return False
 

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -44,10 +44,7 @@ class bcolors:
 
 
 def first_match(iterable, predicate):
-    try:
-        return next(n for n in iterable if predicate(n))
-    except StopIteration:
-        return None
+    return next(n for n in iterable if predicate(n), None)
 
 
 def wait_for_value_or(function, node, timeout, default, description):
@@ -74,7 +71,7 @@ def find_node_and_namespace(node, full_node_name):
 
 def has_service_names(node, node_name, node_namespace, service_names):
     client_names_and_types = node.get_service_names_and_types_by_node(node_name, node_namespace)
-    if len(client_names_and_types) == 0:
+    if not client_names_and_types:
         return False
     client_names, _ = zip(*client_names_and_types)
     return all(service in client_names for service in service_names)

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -73,9 +73,7 @@ def find_node_and_namespace(node, full_node_name):
 
 
 def has_service_names(node, node_name, node_namespace, service_names):
-    client_names_and_types = node.get_client_names_and_types_by_node(node_name, node_namespace)
-    node.get_logger().info(str(client_names_and_types), throttle_duration_sec=2)
-
+    client_names_and_types = node.get_service_names_and_types_by_node(node_name, node_namespace)
     if len(client_names_and_types) == 0:
         return False
     client_names, _ = zip(*client_names_and_types)
@@ -85,14 +83,14 @@ def has_service_names(node, node_name, node_namespace, service_names):
 def wait_for_controller_manager(node, controller_manager, timeout_duration):
     # List of service names from controller_manager we wait for
     service_names = (
-        'configure_controller',
-        'list_controllers',
-        'list_controller_types',
-        'list_hardware_interfaces',
-        'load_controller',
-        'reload_controller_libraries',
-        'switch_controller',
-        'unload_controller',
+        controller_manager + '/configure_controller',
+        controller_manager + '/list_controllers',
+        controller_manager + '/list_controller_types',
+        controller_manager + '/list_hardware_interfaces',
+        controller_manager + '/load_controller',
+        controller_manager + '/reload_controller_libraries',
+        controller_manager + '/switch_controller',
+        controller_manager + '/unload_controller',
     )
 
     # Wait for controller_manager

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -50,12 +50,12 @@ def first_match(iterable, predicate):
         return None
 
 
-def wait_for_value_or(function, node, timeout, default):
+def wait_for_value_or(function, node, timeout, default, description):
     while node.get_clock().now() < timeout:
         if result := function():
             return result
         node.get_logger().info(
-            'Waiting for controller_manager to initalize',
+            f'Waiting for {description}',
             throttle_duration_sec=2)
         time.sleep(0.2)
     return default
@@ -97,14 +97,14 @@ def wait_for_controller_manager(node, controller_manager, timeout_duration):
     timeout = node.get_clock().now() + Duration(seconds=timeout_duration)
     node_and_namespace = wait_for_value_or(
         lambda: find_node_and_namespace(node, controller_manager),
-        node, timeout, None)
+        node, timeout, None, f"'{controller_manager}' node to exist")
 
     # Wait for the services if the node was found
     if node_and_namespace:
         node_name, namespace = node_and_namespace
         return wait_for_value_or(
             lambda: has_service_names(node, node_name, namespace, service_names),
-            node, timeout, False)
+            node, timeout, False, "'{controller_manager}' services to be available")
 
     return False
 

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -61,7 +61,7 @@ def wait_for_value_or(function, node, timeout, default):
 
 def combine_name_and_namespace(name_and_namespace):
     node_name, namespace = name_and_namespace
-    return (namespace + ('' if namespace.endswith('/') else '/') + node_name)
+    return namespace + ('' if namespace.endswith('/') else '/') + node_name
 
 
 def find_node_and_namespace(node, full_node_name):

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -43,21 +43,66 @@ class bcolors:
     UNDERLINE = '\033[4m'
 
 
+def first_match(iterable, predicate):
+    try:
+        return next(n for n in iterable if predicate(n))
+    except StopIteration:
+        return None
+
+
+def wait_for_value_or(function, node, timeout, default):
+    while node.get_clock().now() < timeout:
+        result = function()
+        if result:
+            return result
+        time.sleep(0.2)
+    return default
+
+
+def combine_name_and_namespace(name_and_namespace):
+    node_name, namespace = name_and_namespace
+    return (namespace + ('' if namespace.endswith('/') else '/') + node_name)
+
+
+def find_node_and_namespace(node, full_node_name):
+    node_names_and_namespaces = node.get_node_names_and_namespaces()
+    return first_match(node_names_and_namespaces,
+                       lambda n: combine_name_and_namespace(n) == full_node_name)
+
+
+def has_service_names(node, node_name, node_namespace, service_names):
+    client_names_and_types = node.get_client_names_and_types_by_node(node_name, node_namespace)
+    if len(client_names_and_types) == 0:
+        return False
+    client_names, _ = zip(*client_names_and_types)
+    return all(service in client_names for service in service_names)
+
+
 def wait_for_controller_manager(node, controller_manager, timeout_duration):
-    def full_name(n):
-        return n[1] + ('' if n[1].endswith('/') else '/') + n[0]
+    # List of service names from controller_manager we wait for
+    service_names = (
+        'configure_controller',
+        'list_controllers',
+        'list_controller_types',
+        'list_hardware_interfaces',
+        'load_controller',
+        'reload_controller_libraries',
+        'switch_controller',
+        'unload_controller',
+    )
 
     # Wait for controller_manager
     timeout = node.get_clock().now() + Duration(seconds=timeout_duration)
-    while node.get_clock().now() < timeout:
-        node_names_and_namespaces = node.get_node_names_and_namespaces()
-        if any(full_name(n) == controller_manager for n in node_names_and_namespaces):
-            return True
+    node_and_namespace = wait_for_value_or(
+        lambda: find_node_and_namespace(node, controller_manager),
+        node, timeout, None)
 
-        node.get_logger().info(
-            f'Waiting for {controller_manager} services',
-            throttle_duration_sec=2)
-        time.sleep(0.2)
+    # Wait for the services if the node was found
+    if node_and_namespace:
+        node_name, namespace = node_and_namespace
+        return wait_for_value_or(
+            lambda: has_service_names(node, node_name, namespace, service_names),
+            node, timeout, False)
 
     return False
 

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -80,14 +80,14 @@ def has_service_names(node, node_name, node_namespace, service_names):
 def wait_for_controller_manager(node, controller_manager, timeout_duration):
     # List of service names from controller_manager we wait for
     service_names = (
-        controller_manager + '/configure_controller',
-        controller_manager + '/list_controllers',
-        controller_manager + '/list_controller_types',
-        controller_manager + '/list_hardware_interfaces',
-        controller_manager + '/load_controller',
-        controller_manager + '/reload_controller_libraries',
-        controller_manager + '/switch_controller',
-        controller_manager + '/unload_controller',
+        f'{controller_manager}/configure_controller',
+        f'{controller_manager}/list_controllers',
+        f'{controller_manager}/list_controller_types',
+        f'{controller_manager}/list_hardware_interfaces',
+        f'{controller_manager}/load_controller',
+        f'{controller_manager}/reload_controller_libraries',
+        f'{controller_manager}/switch_controller',
+        f'{controller_manager}/unload_controller'
     )
 
     # Wait for controller_manager
@@ -101,7 +101,7 @@ def wait_for_controller_manager(node, controller_manager, timeout_duration):
         node_name, namespace = node_and_namespace
         return wait_for_value_or(
             lambda: has_service_names(node, node_name, namespace, service_names),
-            node, timeout, False, f'\'{controller_manager}\' services to be available')
+            node, timeout, False, f"'{controller_manager}' services to be available")
 
     return False
 

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -52,9 +52,11 @@ def first_match(iterable, predicate):
 
 def wait_for_value_or(function, node, timeout, default):
     while node.get_clock().now() < timeout:
-        result = function()
-        if result:
+        if result := function():
             return result
+        node.get_logger().info(
+            'Waiting for controller_manager to initalize',
+            throttle_duration_sec=2)
         time.sleep(0.2)
     return default
 


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <tyler@picknik.ai>

Resolves #682 

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.

## Testing

Locally I'm getting two test failures with this. I would appreciate any help in resolving these test failures:

```
    [----------] Global test environment tear-down
    [==========] 6 tests from 1 test suite ran. (49366 ms total)
    [  PASSED  ] 4 tests.
    [  FAILED  ] 2 tests, listed below:
    [  FAILED  ] TestLoadController.spawner_test_type_in_param
    [  FAILED  ] TestLoadController.spawner_test_type_in_arg
    
     2 FAILED TESTS
    -- run_test.py: return code 1
    -- run_test.py: inject classname prefix into gtest result file '/home/tyler/code/l0/ws_target/build/controller_manager/test_results/controller_manager/test_spawner_unspawner.gtest.xml'
    -- run_test.py: verify result file '/home/tyler/code/l0/ws_target/build/controller_manager/test_results/controller_manager/test_spawner_unspawner.gtest.xml'
  >>>
build/controller_manager/test_results/controller_manager/test_spawner_unspawner.gtest.xml: 6 tests, 0 errors, 2 failures, 0 skipped
- controller_manager.TestLoadController spawner_test_type_in_param
  <<< failure message
    /home/tyler/code/l0/ws_target/src/ros2_control/controller_manager/test/test_spawner_unspawner.cpp:96
    Expected equality of these values:
      call_spawner("ctrl_1 -c test_controller_manager")
        Which is: 256
      0
    /home/tyler/code/l0/ws_target/src/ros2_control/controller_manager/test/test_spawner_unspawner.cpp:98
    Expected equality of these values:
      cm_->get_loaded_controllers().size()
        Which is: 0
      1ul
        Which is: 1
  >>>
- controller_manager.TestLoadController spawner_test_type_in_arg
  <<< failure message
    /home/tyler/code/l0/ws_target/src/ros2_control/controller_manager/test/test_spawner_unspawner.cpp:127
    Expected equality of these values:
      call_spawner( "ctrl_2 -c test_controller_manager -t " + std::string(test_controller::TEST_CONTROLLER_CLASS_NAME))
        Which is: 256
      0
    /home/tyler/code/l0/ws_target/src/ros2_control/controller_manager/test/test_spawner_unspawner.cpp:133
    Expected equality of these values:
      cm_->get_loaded_controllers().size()
        Which is: 0
      1ul
        Which is: 1
  >>>
```