### PR TITLE
Enable namespaces for controllers.

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -79,7 +79,8 @@ public:
   void release_interfaces();
 
   CONTROLLER_INTERFACE_PUBLIC
-  virtual return_type init(const std::string & controller_name);
+  virtual return_type init(
+    const std::string & controller_name, const std::string & namespace_ = "");
 
   /// Custom configure method to read additional parameters for controller-nodes
   /*

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -23,10 +23,11 @@
 
 namespace controller_interface
 {
-return_type ControllerInterface::init(const std::string & controller_name)
+return_type ControllerInterface::init(
+  const std::string & controller_name, const std::string & namespace_)
 {
   node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
-    controller_name,
+    controller_name, namespace_,
     rclcpp::NodeOptions()
       .allow_undeclared_parameters(true)
       .automatically_declare_parameters_from_overrides(true),

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "test_controller_with_options.hpp"
+
 #include <gtest/gtest.h>
 #include <string>
+
 #include "rclcpp/rclcpp.hpp"
 
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -15,12 +15,11 @@
 #ifndef TEST_CONTROLLER_WITH_OPTIONS_HPP_
 #define TEST_CONTROLLER_WITH_OPTIONS_HPP_
 
-#include <controller_interface/controller_interface.hpp>
-
 #include <map>
 #include <memory>
 #include <string>
 
+#include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 
 namespace controller_with_options
@@ -40,11 +39,12 @@ public:
     return LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  controller_interface::return_type init(const std::string & controller_name) override
+  controller_interface::return_type init(
+    const std::string & controller_name, const std::string & namespace_ = "") override
   {
     rclcpp::NodeOptions options;
     options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
-    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name, options);
+    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name, namespace_, options);
 
     switch (on_init())
     {

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -103,6 +103,14 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_controller_manager ros2_control_test_assets)
 
   ament_add_gmock(
+    test_controller_manager_with_namespace.cpp
+    test/test_controller_manager_with_namespace.cpp
+  )
+  target_include_directories(test_controller_manager_with_namespace.cpp PRIVATE include)
+  target_link_libraries(test_controller_manager_with_namespace.cpp controller_manager test_controller)
+  ament_target_dependencies(test_controller_manager_with_namespace.cpp ros2_control_test_assets)
+
+  ament_add_gmock(
     test_load_controller
     test/test_load_controller.cpp
     APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}_$<CONFIG>

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -705,7 +705,9 @@ controller_interface::ControllerInterfaceSharedPtr ControllerManager::add_contro
     return nullptr;
   }
 
-  if (controller.c->init(controller.info.name) == controller_interface::return_type::ERROR)
+  if (
+    controller.c->init(controller.info.name, get_namespace()) ==
+    controller_interface::return_type::ERROR)
   {
     to.clear();
     RCLCPP_ERROR(

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "./test_controller_failed_init.hpp"
+#include "test_controller_failed_init.hpp"
 
 #include <memory>
 #include <string>
@@ -32,7 +32,7 @@ TestControllerFailedInit::on_init()
 }
 
 controller_interface::return_type TestControllerFailedInit::init(
-  const std::string & /* controller_name */)
+  const std::string & /* controller_name */, const std::string & /*namespace_*/)
 {
   return controller_interface::return_type::ERROR;
 }

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
@@ -18,8 +18,8 @@
 #include <memory>
 #include <string>
 
-#include "controller_interface/visibility_control.h"
 #include "controller_manager/controller_manager.hpp"
+#include "controller_manager/visibility_control.h"
 
 namespace test_controller_failed_init
 {
@@ -39,7 +39,8 @@ public:
   virtual ~TestControllerFailedInit() = default;
 
   CONTROLLER_INTERFACE_PUBLIC
-  controller_interface::return_type init(const std::string & controller_name) override;
+  controller_interface::return_type init(
+    const std::string & controller_name, const std::string & namespace_ = "") override;
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -82,15 +82,15 @@ TEST_P(TestControllerManager, controller_lifecycle)
 
   // Check if namespace is set correctly
   RCLCPP_INFO(
-    rclcpp::get_logger("test_controll_manager_with_namespace"),
-    "Controller Manager namespace is '%s'", cm_->get_namespace());
+    rclcpp::get_logger("test_controller_manager"), "Controller Manager namespace is '%s'",
+    cm_->get_namespace());
   EXPECT_STREQ(cm_->get_namespace(), "/");
   RCLCPP_INFO(
-    rclcpp::get_logger("test_controll_manager_with_namespace"), "Controller 1 namespace is '%s'",
+    rclcpp::get_logger("test_controller_manager"), "Controller 1 namespace is '%s'",
     test_controller->get_node()->get_namespace());
   EXPECT_STREQ(test_controller->get_node()->get_namespace(), "/");
   RCLCPP_INFO(
-    rclcpp::get_logger("test_controll_manager_with_namespace"), "Controller 2 namespace is '%s'",
+    rclcpp::get_logger("test_controller_manager"), "Controller 2 namespace is '%s'",
     test_controller2->get_node()->get_namespace());
   EXPECT_STREQ(test_controller2->get_node()->get_namespace(), "/");
 


### PR DESCRIPTION
When using ros2_control in a multi-robot system with separate controller managers, it is useful to put controllers into namespaces.
Otherwise, it gets tricky to connect it with MoveIt.
Except that this enables clear structure of multi-robot systems.﻿

This is also extending a test of controller manager so that `test_controller` actually claims some interfaces. This makes it more realistic. 
