### PR TITLE
Adjusted path for api reference in documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@
 API Documentation
 =================
 
-API documentation is parsed by doxygen and can be found `here </api/index.html>`_
+API documentation is parsed by doxygen and can be found `here <../../api/index.html>`_
 
 =====================
 Core functionalities


### PR DESCRIPTION
Path for api documents at wrong location.

Part of ros-controls/control.ros.org#39