### PR TITLE
Make node private

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -82,7 +82,11 @@ public:
 
   CONTROLLER_INTERFACE_PUBLIC
   virtual return_type init(
-    const std::string & controller_name, const std::string & namespace_ = "");
+    const std::string & controller_name, const std::string & namespace_ = "",
+    const rclcpp::NodeOptions & node_options =
+      rclcpp::NodeOptions()
+        .allow_undeclared_parameters(true)
+        .automatically_declare_parameters_from_overrides(true));
 
   /// Custom configure method to read additional parameters for controller-nodes
   /*

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -102,6 +102,9 @@ public:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node();
 
   CONTROLLER_INTERFACE_PUBLIC
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node_const() const;
+
+  CONTROLLER_INTERFACE_PUBLIC
   const rclcpp_lifecycle::State & get_state() const;
 
   CONTROLLER_INTERFACE_PUBLIC
@@ -130,8 +133,10 @@ public:
 protected:
   std::vector<hardware_interface::LoanedCommandInterface> command_interfaces_;
   std::vector<hardware_interface::LoanedStateInterface> state_interfaces_;
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
   unsigned int update_rate_ = 0;
+
+private:
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
 };
 
 using ControllerInterfaceSharedPtr = std::shared_ptr<ControllerInterface>;

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -102,7 +102,7 @@ public:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node();
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node_const() const;
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> get_node() const;
 
   CONTROLLER_INTERFACE_PUBLIC
   const rclcpp_lifecycle::State & get_state() const;

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -25,14 +25,11 @@
 namespace controller_interface
 {
 return_type ControllerInterface::init(
-  const std::string & controller_name, const std::string & namespace_)
+  const std::string & controller_name, const std::string & namespace_,
+  const rclcpp::NodeOptions & node_options)
 {
   node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
-    controller_name, namespace_,
-    rclcpp::NodeOptions()
-      .allow_undeclared_parameters(true)
-      .automatically_declare_parameters_from_overrides(true),
-    false);  // disable LifecycleNode service interfaces
+    controller_name, namespace_, node_options, false);  // disable LifecycleNode service interfaces
 
   try
   {

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -119,6 +119,15 @@ std::shared_ptr<rclcpp_lifecycle::LifecycleNode> ControllerInterface::get_node()
   return node_;
 }
 
+std::shared_ptr<rclcpp_lifecycle::LifecycleNode> ControllerInterface::get_node_const() const
+{
+  if (!node_.get())
+  {
+    throw std::runtime_error("Lifecycle node hasn't been initialized yet!");
+  }
+  return node_;
+}
+
 unsigned int ControllerInterface::get_update_rate() const { return update_rate_; }
 
 }  // namespace controller_interface

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<rclcpp_lifecycle::LifecycleNode> ControllerInterface::get_node()
   return node_;
 }
 
-std::shared_ptr<rclcpp_lifecycle::LifecycleNode> ControllerInterface::get_node_const() const
+std::shared_ptr<rclcpp_lifecycle::LifecycleNode> ControllerInterface::get_node() const
 {
   if (!node_.get())
   {

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -44,7 +44,7 @@ TEST(ControllerWithOption, init_with_overrides)
   FriendControllerWithOptions controller;
   EXPECT_EQ(controller.init("controller_name"), controller_interface::return_type::OK);
   // checks that the node options have been updated
-  const auto & node_options = controller.node_->get_node_options();
+  const auto & node_options = controller.get_node()->get_node_options();
   EXPECT_TRUE(node_options.allow_undeclared_parameters());
   EXPECT_TRUE(node_options.automatically_declare_parameters_from_overrides());
   // checks that the parameters have been correctly processed
@@ -65,7 +65,7 @@ TEST(ControllerWithOption, init_without_overrides)
   FriendControllerWithOptions controller;
   EXPECT_EQ(controller.init("controller_name"), controller_interface::return_type::ERROR);
   // checks that the node options have been updated
-  const auto & node_options = controller.node_->get_node_options();
+  const auto & node_options = controller.get_node()->get_node_options();
   EXPECT_TRUE(node_options.allow_undeclared_parameters());
   EXPECT_TRUE(node_options.automatically_declare_parameters_from_overrides());
   // checks that no parameter has been declared from overrides

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -44,7 +44,8 @@ public:
   {
     rclcpp::NodeOptions options;
     options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
-    node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name, namespace_, options);
+    set_node(
+      std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name, namespace_, options));
 
     switch (on_init())
     {
@@ -54,9 +55,9 @@ public:
       case LifecycleNodeInterface::CallbackReturn::FAILURE:
         return controller_interface::return_type::ERROR;
     }
-    if (node_->get_parameters("parameter_list", params))
+    if (get_node()->get_parameters("parameter_list", params))
     {
-      RCLCPP_INFO_STREAM(node_->get_logger(), "I found " << params.size() << " parameters.");
+      RCLCPP_INFO_STREAM(get_node()->get_logger(), "I found " << params.size() << " parameters.");
       return controller_interface::return_type::OK;
     }
     else

--- a/controller_interface/test/test_controller_with_options.hpp
+++ b/controller_interface/test/test_controller_with_options.hpp
@@ -40,12 +40,13 @@ public:
   }
 
   controller_interface::return_type init(
-    const std::string & controller_name, const std::string & namespace_ = "") override
+    const std::string & controller_name, const std::string & namespace_ = "",
+    const rclcpp::NodeOptions & node_options =
+      rclcpp::NodeOptions()
+        .allow_undeclared_parameters(true)
+        .automatically_declare_parameters_from_overrides(true)) override
   {
-    rclcpp::NodeOptions options;
-    options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true);
-    set_node(
-      std::make_shared<rclcpp_lifecycle::LifecycleNode>(controller_name, namespace_, options));
+    ControllerInterface::init(controller_name, namespace_, node_options);
 
     switch (on_init())
     {

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
@@ -32,7 +32,8 @@ TestControllerFailedInit::on_init()
 }
 
 controller_interface::return_type TestControllerFailedInit::init(
-  const std::string & /* controller_name */, const std::string & /*namespace_*/)
+  const std::string & /* controller_name */, const std::string & /*namespace_*/,
+  const rclcpp::NodeOptions & /*node_options*/)
 {
   return controller_interface::return_type::ERROR;
 }

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp
@@ -40,7 +40,11 @@ public:
 
   CONTROLLER_INTERFACE_PUBLIC
   controller_interface::return_type init(
-    const std::string & controller_name, const std::string & namespace_ = "") override;
+    const std::string & controller_name, const std::string & namespace_ = "",
+    const rclcpp::NodeOptions & node_options =
+      rclcpp::NodeOptions()
+        .allow_undeclared_parameters(true)
+        .automatically_declare_parameters_from_overrides(true)) override;
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {


### PR DESCRIPTION
Solves #679 

Updated node_ to private and added the function everywhere node_ was used previously.

I also add a `get_node_const()` method because some controllers need a const method. There are probably other ways to do this and I'd be open to your thoughts if you don't like this.  

[ros2_controllers/pull/329](https://github.com/ros-controls/ros2_controllers/pull/329) depends on this PR.