### PR TITLE
Add CallbackReturn into controller_interface namespace for simpler usage in controllers.

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -29,6 +29,8 @@
 
 namespace controller_interface
 {
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
 enum class return_type : std::uint8_t
 {
   OK = 0,
@@ -91,7 +93,7 @@ public:
 
   /// Extending interface with initialization method which is individual for each controller
   CONTROLLER_INTERFACE_PUBLIC
-  virtual LifecycleNodeInterface::CallbackReturn on_init() = 0;
+  virtual CallbackReturn on_init() = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
   virtual return_type update(const rclcpp::Time & time, const rclcpp::Duration & period) = 0;

--- a/controller_interface/test/test_controller_interface.hpp
+++ b/controller_interface/test/test_controller_interface.hpp
@@ -18,14 +18,15 @@
 #include "controller_interface/controller_interface.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 
-using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
-
 constexpr char TEST_CONTROLLER_NAME[] = "testable_controller_interface";
 
 class TestableControllerInterface : public controller_interface::ControllerInterface
 {
 public:
-  CallbackReturn on_init() override { return CallbackReturn::SUCCESS; }
+  controller_interface::CallbackReturn on_init() override
+  {
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
 
   controller_interface::InterfaceConfiguration command_interface_configuration() const override
   {
@@ -49,13 +50,19 @@ public:
 class TestableControllerInterfaceInitError : public TestableControllerInterface
 {
 public:
-  CallbackReturn on_init() override { return CallbackReturn::ERROR; }
+  controller_interface::CallbackReturn on_init() override
+  {
+    return controller_interface::CallbackReturn::ERROR;
+  }
 };
 
 class TestableControllerInterfaceInitFailure : public TestableControllerInterface
 {
 public:
-  CallbackReturn on_init() override { return CallbackReturn::FAILURE; }
+  controller_interface::CallbackReturn on_init() override
+  {
+    return controller_interface::CallbackReturn::FAILURE;
+  }
 };
 
 #endif  // TEST_CONTROLLER_INTERFACE_HPP_


### PR DESCRIPTION
Add  `CallbackReturn` into `controller_interface` namespace to enable clearer usage of constants in controllers.

The idea comes from @fmauch from [UR-Driver](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/339#issuecomment-1098912220).
The concept is much more future-proof because if we ever change underlying management (state machine) users would not have to change their code.
It also avoids repetitive definition of `using...` in each controller.


@bmagyar if you agree with the concept, we have to open a follow-up issue to update all controllers.