### PR TITLE
Add controller_manager_msgs dependency to test_hardware_management_srvs

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -157,7 +157,11 @@ if(BUILD_TESTING)
   )
   target_include_directories(test_hardware_management_srvs PRIVATE include)
   target_link_libraries(test_hardware_management_srvs controller_manager test_controller)
-  ament_target_dependencies(test_hardware_management_srvs ros2_control_test_assets)
+  ament_target_dependencies(
+    test_hardware_management_srvs
+    controller_manager_msgs
+    ros2_control_test_assets
+  )
 endif()
 
 # Install Python modules


### PR DESCRIPTION
Fixes issue
```
/ros2_workspace/src/ros-controls/ros2_control/controller_manager/test/test_hardware_management_srvs.cpp:128:35: error: ‘const value_type’ {aka ‘const struct controller_manager_msgs::msg::HardwareInterface_<std::allocator<void> >’} has no member named ‘is_available’
  128 |           EXPECT_EQ(interfaces[i].is_available, is_available_status[i]);
      |                                   ^~~~~~~~~~~~
```