### PR TITLE
Make URDF available to HW components on initialize #abi-breaking

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -130,6 +130,10 @@ struct HardwareInfo
    * Optional for Actuator and System Hardware.
    */
   std::vector<TransmissionInfo> transmissions;
+  /**
+   * The XML contents prior to parsing
+   */
+  std::string original_xml;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -488,7 +488,8 @@ void auto_fill_transmission_interfaces(HardwareInfo & hardware)
  * \return HardwareInfo filled with information about the robot
  * \throws std::runtime_error if a attributes or tag are not found
  */
-HardwareInfo parse_resource_from_xml(const tinyxml2::XMLElement * ros2_control_it)
+HardwareInfo parse_resource_from_xml(
+  const tinyxml2::XMLElement * ros2_control_it, const std::string & urdf)
 {
   HardwareInfo hardware;
   hardware.name = get_attribute_value(ros2_control_it, kNameAttribute, kROS2ControlTag);
@@ -535,6 +536,8 @@ HardwareInfo parse_resource_from_xml(const tinyxml2::XMLElement * ros2_control_i
 
   auto_fill_transmission_interfaces(hardware);
 
+  hardware.original_xml = urdf;
+
   return hardware;
 }
 
@@ -574,7 +577,7 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
   std::vector<HardwareInfo> hardware_info;
   while (ros2_control_it)
   {
-    hardware_info.push_back(detail::parse_resource_from_xml(ros2_control_it));
+    hardware_info.push_back(detail::parse_resource_from_xml(ros2_control_it, urdf));
     ros2_control_it = ros2_control_it->NextSiblingElement(kROS2ControlTag);
   }
 


### PR DESCRIPTION
Motivation: 

Some hardware components require access to more XML components than what is parsed. 
Some hardware components require access to the URDF for setting limits, etc.

This PR solves both cases, now if you need to get this information, you can do it by doing your own parsing inside the component. 

This information is handed to each hardware component here: https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/include/hardware_interface/system.hpp#L44