### PR TITLE
Remove unused constructors and methods in handles

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -86,11 +86,7 @@ public:
 
   virtual ~ReadWriteHandle() = default;
 
-  void set_value(double value)
-  {
-    THROW_ON_NULLPTR(this->value_ptr_);
-    *this->value_ptr_ = value;
-  }
+  void set_value(double value) { *this->value_ptr_ = value; }
 };
 
 class StateInterface : public ReadOnlyHandle

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -29,19 +29,10 @@ class ReadOnlyHandle
 public:
   ReadOnlyHandle(
     const std::string & prefix_name, const std::string & interface_name,
-    double * value_ptr = nullptr)
+    double * value_ptr)
   : prefix_name_(prefix_name), interface_name_(interface_name), value_ptr_(value_ptr)
   {
-  }
-
-  explicit ReadOnlyHandle(const std::string & interface_name)
-  : interface_name_(interface_name), value_ptr_(nullptr)
-  {
-  }
-
-  explicit ReadOnlyHandle(const char * interface_name)
-  : interface_name_(interface_name), value_ptr_(nullptr)
-  {
+    THROW_ON_NULLPTR(value_ptr_);
   }
 
   ReadOnlyHandle(const ReadOnlyHandle & other) = default;
@@ -53,9 +44,6 @@ public:
   ReadOnlyHandle & operator=(ReadOnlyHandle && other) = default;
 
   virtual ~ReadOnlyHandle() = default;
-
-  /// Returns true if handle references a value.
-  inline operator bool() const { return value_ptr_ != nullptr; }
 
   const std::string get_name() const { return prefix_name_ + "/" + interface_name_; }
 
@@ -70,11 +58,7 @@ public:
 
   const std::string & get_prefix_name() const { return prefix_name_; }
 
-  double get_value() const
-  {
-    THROW_ON_NULLPTR(value_ptr_);
-    return *value_ptr_;
-  }
+  double get_value() const { return *value_ptr_; }
 
 protected:
   std::string prefix_name_;
@@ -87,14 +71,10 @@ class ReadWriteHandle : public ReadOnlyHandle
 public:
   ReadWriteHandle(
     const std::string & prefix_name, const std::string & interface_name,
-    double * value_ptr = nullptr)
+    double * value_ptr)
   : ReadOnlyHandle(prefix_name, interface_name, value_ptr)
   {
   }
-
-  explicit ReadWriteHandle(const std::string & interface_name) : ReadOnlyHandle(interface_name) {}
-
-  explicit ReadWriteHandle(const char * interface_name) : ReadOnlyHandle(interface_name) {}
 
   ReadWriteHandle(const ReadWriteHandle & other) = default;
 

--- a/hardware_interface/test/test_components/test_actuator.cpp
+++ b/hardware_interface/test/test_components/test_actuator.cpp
@@ -52,8 +52,8 @@ class TestActuator : public ActuatorInterface
       info_.joints[0].name, info_.joints[0].state_interfaces[0].name, &position_state_));
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       info_.joints[0].name, info_.joints[0].state_interfaces[1].name, &velocity_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(info_.joints[0].name, "some_unlisted_interface", nullptr));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      info_.joints[0].name, "some_unlisted_interface", &unlisted_interface_state_));
 
     return state_interfaces;
   }
@@ -107,6 +107,8 @@ private:
   double velocity_state_ = 0.0;
   double velocity_command_ = 0.0;
   double max_velocity_command_ = 0.0;
+
+  double unlisted_interface_state_ = 1989.0;
 };
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -45,19 +45,9 @@ TEST(TestHandle, state_interface)
   // interface.set_value(5);  compiler error, no set_value function
 }
 
-TEST(TestHandle, name_getters_work)
-{
-  StateInterface handle{JOINT_NAME, FOO_INTERFACE};
-  EXPECT_EQ(handle.get_name(), std::string(JOINT_NAME) + "/" + std::string(FOO_INTERFACE));
-  EXPECT_EQ(handle.get_interface_name(), FOO_INTERFACE);
-  EXPECT_EQ(handle.get_prefix_name(), JOINT_NAME);
-}
-
 TEST(TestHandle, value_methods_throw_for_nullptr)
 {
-  CommandInterface handle{JOINT_NAME, FOO_INTERFACE};
-  EXPECT_ANY_THROW(handle.get_value());
-  EXPECT_ANY_THROW(handle.set_value(0.0));
+  EXPECT_ANY_THROW(CommandInterface(JOINT_NAME, FOO_INTERFACE, nullptr));
 }
 
 TEST(TestHandle, value_methods_work_on_non_nullptr)

--- a/hardware_interface/test/test_resource_manager.cpp
+++ b/hardware_interface/test/test_resource_manager.cpp
@@ -293,8 +293,8 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     std::vector<hardware_interface::StateInterface> state_interfaces;
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface("external_joint", "external_state_interface", nullptr));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      "external_joint", "external_state_interface", &external_state_interface_));
 
     return state_interfaces;
   }
@@ -303,7 +303,7 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
   {
     std::vector<hardware_interface::CommandInterface> command_interfaces;
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      "external_joint", "external_command_interface", nullptr));
+      "external_joint", "external_command_interface", &external_command_interface_));
 
     return command_interfaces;
   }
@@ -321,6 +321,10 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
   {
     return hardware_interface::return_type::OK;
   }
+
+private:
+  double external_state_interface_ = 28.0;
+  double external_command_interface_ = 1989.0;
 };
 
 TEST_F(ResourceManagerTest, post_initialization_add_components)

--- a/transmission_interface/include/transmission_interface/accessor.hpp
+++ b/transmission_interface/include/transmission_interface/accessor.hpp
@@ -16,6 +16,7 @@
 #define TRANSMISSION_INTERFACE__ACCESSOR_HPP_
 
 #include <algorithm>
+#include <cmath>
 #include <set>
 #include <string>
 #include <vector>
@@ -62,8 +63,8 @@ std::vector<T> get_ordered_handles(
       unordered_handles.cbegin(), unordered_handles.cend(), std::back_inserter(result),
       [&](const auto & handle)
       {
-        return (handle.get_name() == name) && (handle.get_interface_name() == interface_type) &&
-               handle;
+        return (handle.get_prefix_name() == name) &&
+               (handle.get_interface_name() == interface_type) && std::isnan(handle.get_value());
       });
   }
   return result;

--- a/transmission_interface/include/transmission_interface/simple_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/simple_transmission.hpp
@@ -194,7 +194,9 @@ inline void SimpleTransmission::configure(
   joint_velocity_ = get_by_interface(joint_handles, hardware_interface::HW_IF_VELOCITY);
   joint_effort_ = get_by_interface(joint_handles, hardware_interface::HW_IF_EFFORT);
 
-  if (!joint_position_ && !joint_velocity_ && !joint_effort_)
+  if (
+    std::isnan(joint_position_.get_value()) && std::isnan(joint_velocity_.get_value()) &&
+    std::isnan(joint_effort_.get_value()))
   {
     throw Exception("None of the provided joint handles are valid or from the required interfaces");
   }
@@ -234,12 +236,12 @@ inline void SimpleTransmission::joint_to_actuator()
     actuator_effort_.set_value(joint_effort_.get_value() / reduction_);
   }
 
-  if (joint_velocity_ && actuator_velocity_)
+  if (!std::isnan(joint_velocity_.get_value()) && actuator_velocity_)
   {
     actuator_velocity_.set_value(joint_velocity_.get_value() * reduction_);
   }
 
-  if (joint_position_ && actuator_position_)
+  if (!std::isnan(joint_position_.get_value()) && !std::isnan(actuator_position_))
   {
     actuator_position_.set_value((joint_position_.get_value() - jnt_offset_) * reduction_);
   }


### PR DESCRIPTION
The PR addresses late detection of invalid (`nullptr`) pointers detection for interfaces.
This is done by not allowing to have at all `nullptr` in handles. 
Until now, a handle with `nullprt` could be created, but there is no way to change it to valid pointer, so there is no much use of this functionality.

Some other related things are also addressed:

- remove unused constructors for handles
- remove `bool()` operator from handles because it is not relevant anymore
- remove execution of linters on testing stage of hardware_interface package (everything is done using `pre-commit`)
