### PR TITLE
Proposal for solving multiple issues with implict interface in hardware.

### DIFF
--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -91,6 +91,9 @@ public:
 
 private:
   std::unique_ptr<SystemInterface> impl_;
+
+  std::vector<Variant> commands_;
+  std::vector<Variant> states_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -97,6 +97,10 @@ public:
     return CallbackReturn::SUCCESS;
   };
 
+  virtual std::vector<InterfaceConfiguration> export_state_interfaces_info() = 0;
+
+  virtual std::vector<InterfaceConfiguration> export_command_interfaces_info() = 0;
+
   /// Exports all state interfaces for this hardware interface.
   /**
    * The state interfaces have to be created and transferred according
@@ -166,7 +170,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual return_type read() = 0;
+  virtual return_type read(std::vector<Variant> & states) = 0;
 
   /// Write the current command values to the actuator.
   /**
@@ -175,7 +179,7 @@ public:
    *
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual return_type write() = 0;
+  virtual return_type write(std::vector<Variant> & commands) = 0;
 
   /// Get name of the actuator hardware.
   /**


### PR DESCRIPTION
This PR makes a proposal to address some of the issues mentioned in #712. For now, only minimal changes to the System interface to trigger discussion.

### Explicitly there are the following changes as the base for the discussion

1. `Variant` as base storage of values (address long-standing issue of data-types different than double), related to #490

2. PIMPL-classes actually store variants to simplify management from the user's perspective and provide more explicit `read` and `write`.

### Open questions

1. Should we actually store `Handles` inside PMPL-Classes to preserve the explicit connection between `Variant` and joint/interface name? This would probably result in using multiple maps, one in ResouceManager and one in PIMPL-Class --> searching through 2 maps to create a loaned interface (real-time critical).

#### Other issues (please comment on this too)

- using templates in specific places to save the code
- using `unique_ptr` for Variants instead of a raw pointer (?)

@tylerjw and @AndyZe, please provide your feedback on this. Does this go in the direction you would have imagined?

P.S. This is just a concept, the code is not working!