### PR TITLE
Added available status and moved to fstrings in `hardware_interfaces`

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
@@ -39,14 +39,12 @@ class ListHardwareInterfacesVerb(VerbExtension):
             print('command interfaces')
             for command_interface in command_interfaces:
                 print(
-                    '\t%s [%s]'
-                    % (
-                        command_interface.name,
-                        'claimed' if command_interface.is_claimed else 'unclaimed',
-                    )
+                    f'\t{command_interface.name} '
+                    f'{"[available]" if command_interface.is_available else "[unavailable]"} '
+                    f'{"[claimed]" if command_interface.is_claimed else "[unclaimed]"}'
                 )
             print('state interfaces')
             for state_interface in state_interfaces:
-                print('\t', state_interface.name)
+                print(f'\t{state_interface.name}')
 
             return 0


### PR DESCRIPTION
This PR adds the feature requested in #685 by @destogl.

Summary:

* The command `ros2 control list_hardware_interfaces` now does output availability before claimed status in the command interface. Output structure mentioned below:

      command interfaces:
          name [availability status] [claim status]

      state interfaces:
          name
* Use of f-strings to print controller information.

