### PR TITLE
😵Add missing field in the test structures.

### DIFF
--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -243,8 +243,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, list_hardware_components)
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 }
@@ -269,8 +269,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 
@@ -290,8 +290,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 
@@ -311,8 +311,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 
@@ -332,8 +332,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 
@@ -353,8 +353,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 
@@ -375,8 +375,8 @@ TEST_F(TestControllerManagerHWManagementSrvs, selective_activate_deactivate_comp
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 }
@@ -399,8 +399,8 @@ TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activati
     }),
     std::vector<std::vector<std::vector<bool>>>({
       // is claimed
-      {{false, false}, {false, false}},  // actuator
-      {{}, {false}},                     // sensor
+      {{false, false}, {false, false, false}},  // actuator
+      {{}, {false}},                            // sensor
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 }


### PR DESCRIPTION
Test were working, obviously by pure luck because I missed a filed. Funny that we didn't get any “memory corruption” error, but probably because of the complex structures I was using.

We have three state in the actuator, as can be seen from the "is_available" fields (always few lines above).
