### PR TITLE
Opportunistically enable SCHED_FIFO

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -23,6 +23,7 @@ endforeach()
 
 add_library(${PROJECT_NAME} SHARED
   src/controller_manager.cpp
+  src/realtime.cpp
 )
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -5,6 +5,14 @@ Controller Manager
 Controller Manager is the main component in the ros2_control framework.
 It manages lifecycle of controllers, access to the hardware interfaces and offers services to the ROS-world.
 
+Determinism
+-----------
+
+For best performance when controlling hardware you want the controller manager to have as little jitter as possible in the main control loop.
+The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
+The main thread of Controller Manager attempts to configure ``SCHED_FIFO`` with a priority of ``50``.
+To enable this functionality install a RT kernel and run the Controller Manager with permissions to make syscalls to set its thread priorities.
+The two easiest options for this are using the [Real-time Ubuntu 22.04 LTS Beta](https://ubuntu.com/blog/real-time-ubuntu-released) or [linux-image-rt-amd64](https://packages.debian.org/bullseye/linux-image-rt-amd64) on Debian Bullseye.
 
 Parameters
 -----------

--- a/controller_manager/include/controller_manager/realtime.hpp
+++ b/controller_manager/include/controller_manager/realtime.hpp
@@ -1,0 +1,35 @@
+// Copyright 2022 PickNik Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTROLLER_MANAGER__REALTIME_HPP_
+#define CONTROLLER_MANAGER__REALTIME_HPP_
+
+namespace controller_manager
+{
+/**
+ * Detect if realtime kernel is present.
+ * \returns true if realtime kernel is detected
+ */
+bool has_realtime_kernel();
+
+/**
+ * Configure SCHED_FIFO thread priority for the thread that calls this function
+ * \param[in] priority the priority of this thread from 0-99
+ * \returns true if configuring scheduler succeeded
+ */
+bool configure_sched_fifo(int priority);
+
+}  // namespace controller_manager
+
+#endif  // CONTROLLER_MANAGER__REALTIME_HPP_

--- a/controller_manager/src/realtime.cpp
+++ b/controller_manager/src/realtime.cpp
@@ -1,0 +1,47 @@
+// Copyright 2022 PickNik Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "controller_manager/realtime.hpp"
+
+#include <cstring>
+#include <fstream>
+
+#include <sched.h>
+
+namespace controller_manager
+{
+bool has_realtime_kernel()
+{
+  std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
+  bool has_realtime = false;
+  if (realtime_file.is_open())
+  {
+    realtime_file >> has_realtime;
+  }
+  return has_realtime;
+}
+
+bool configure_sched_fifo(int priority)
+{
+  struct sched_param schedp;
+  memset(&schedp, 0, sizeof(schedp));
+  schedp.sched_priority = priority;
+  if (sched_setscheduler(0, SCHED_FIFO, &schedp))
+  {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace controller_manager

--- a/controller_manager/src/realtime.cpp
+++ b/controller_manager/src/realtime.cpp
@@ -14,10 +14,10 @@
 
 #include "controller_manager/realtime.hpp"
 
+#include <sched.h>
+
 #include <cstring>
 #include <fstream>
-
-#include <sched.h>
 
 namespace controller_manager
 {


### PR DESCRIPTION
Signed-off-by: Tyler Weaver <maybe@tylerjw.dev>

## Checklist

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.

## Description

To use this you need a RT Kernel. The two easiest ways are either:
* Ubuntu 22.04 LTS RT Beta: https://ubuntu.com/blog/real-time-ubuntu-released
* Debian bullseye with rt kernel installed: https://packages.debian.org/bullseye/linux-image-rt-amd64

If you choose to go the first route it is free for non-commercial use. For commercial use the pricing starts at $225/year/server. This is the easiest solution because you can just use Ubuntu 22.04 like you normally would. Note that you'll need to run ros2_control as root for it to be able to make these syscalls successfully.

For the second option we are running Ubuntu 22.04 in a docker container. In a docker container you can send syscalls to configure your threads if you enable the capacity CAP_SYS_ADMIN and run as root.

In my testing with these changes on a 4 core intel based NUC I'm seeing ~200us of jitter. There are a ton more things that could be done to make this even more deterministic but this small change is a huge improvement for locking down the loop rate of ros2_control.

Here is an example for how you might start docker to run this:

```bash
sudo docker run -it --rm \
  --net=host \
  --privileged \
  --cap-add=CAP_SYS_ADMIN \
  ros:rolling-ros-base /bin/bash
```