### PR TITLE
Added spawner colors to `command_interfaces` based on availability and claimed status 

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from controller_manager import list_hardware_interfaces
+from controller_manager.spawner import bcolors
 
 from ros2cli.node.direct import add_arguments
 from ros2cli.node.strategy import NodeStrategy
@@ -38,11 +39,17 @@ class ListHardwareInterfacesVerb(VerbExtension):
             )
             print('command interfaces')
             for command_interface in command_interfaces:
-                print(
-                    f'\t{command_interface.name} '
-                    f'{"[available]" if command_interface.is_available else "[unavailable]"} '
-                    f'{"[claimed]" if command_interface.is_claimed else "[unclaimed]"}'
-                )
+                if command_interface.is_available:
+                    if command_interface.is_claimed:
+                        print(f'\t{bcolors.OKBLUE}{command_interface.name} '
+                              f'[available] [claimed]{bcolors.ENDC}')
+                    else:
+                        print(f'\t{bcolors.OKCYAN}{command_interface.name} '
+                              f'[available] [unclaimed]{bcolors.ENDC}')
+                else:
+                    print(f'\t{bcolors.WARNING}{command_interface.name} '
+                          f'[unavailable] [unclaimed]{bcolors.ENDC}')
+
             print('state interfaces')
             for state_interface in state_interfaces:
                 print(f'\t{state_interface.name}')


### PR DESCRIPTION
This PR adds the feature requested in #686 by @destogl.

Summary:

* The command `ros2 control list_hardware_interfaces` now does have coloured output for `command_interfaces` based on availability and claimed status. Output structure mentioned below:

    * If the interface is available and claimed, the chosen colour is `bcolors.OKBLUE`.
    * If the interface is available and unclaimed, the chosen colour is `bcolors.OKCYAN`.
    * Else it is implied that the interface is unavailable and unclaimed, so the chosen colour is `bcolors.WARNING`.

* The colours are chosen in such a way that only unclaimed and unavailable statuses get appealed to by the eye, as `colors.OKBLUE` is less bright when compared to the others. Example output is shown below:

<img src="https://user-images.githubusercontent.com/45683974/176996565-c5c7e6e4-ae6c-4c85-8db3-99ed48867a65.png"/>
