### PR TITLE
Deprecate and rename `start` and `stop` nomenclature toward user to `activate` and `deactivate` #ABI-breaking

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -78,16 +78,16 @@ def reload_controller_libraries(node, controller_manager_name, force_kill):
                           ReloadControllerLibraries, request)
 
 
-def switch_controllers(node, controller_manager_name, stop_controllers,
-                       start_controllers, strict, start_asap, timeout):
+def switch_controllers(node, controller_manager_name, deactivate_controllers,
+                       activate_controllers, strict, activate_asap, timeout):
     request = SwitchController.Request()
-    request.start_controllers = start_controllers
-    request.stop_controllers = stop_controllers
+    request.activate_controllers = activate_controllers
+    request.deactivate_controllers = deactivate_controllers
     if strict:
         request.strictness = SwitchController.Request.STRICT
     else:
         request.strictness = SwitchController.Request.BEST_EFFORT
-    request.start_asap = start_asap
+    request.activate_asap = activate_asap
     request.timeout = rclpy.duration.Duration(seconds=timeout).to_msg()
     return service_caller(node, f'{controller_manager_name}/switch_controller',
                           SwitchController, request)

--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -27,7 +27,7 @@ def generate_load_controller_launch_description(controller_name,
 
     Returns a list of LaunchDescription actions adding the 'controller_manager_name' and
     'unload_on_kill' LaunchArguments and a Node action that runs the controller_manager
-    spawner node to load and start a controller
+    spawner node to load and activate a controller
 
     Examples # noqa: D416
     --------

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -133,7 +133,10 @@ def main(args=None):
         '--load-only', help='Only load the controller and leave unconfigured.',
         action='store_true', required=False)
     parser.add_argument(
-        '--stopped', help='Load and configure the controller, however do not start them',
+        '--stopped', help='Load and configure the controller, however do not activate them',
+        action='store_true', required=False)
+    parser.add_argument(
+        '--inactive', help='Load and configure the controller, however do not activate them',
         action='store_true', required=False)
     parser.add_argument(
         '-t', '--controller-type',
@@ -193,7 +196,7 @@ def main(args=None):
                 node.get_logger().info('Failed to configure controller')
                 return 1
 
-            if not args.stopped:
+            if not args.stopped and not args.inactive:
                 ret = switch_controllers(
                     node,
                     controller_manager_name,
@@ -203,11 +206,13 @@ def main(args=None):
                     True,
                     5.0)
                 if not ret.ok:
-                    node.get_logger().info('Failed to start controller')
+                    node.get_logger().info('Failed to activate controller')
                     return 1
 
-                node.get_logger().info(bcolors.OKGREEN + 'Configured and started ' +
+                node.get_logger().info(bcolors.OKGREEN + 'Configured and activated ' +
                                        bcolors.OKCYAN + controller_name + bcolors.ENDC)
+            elif args.stopped:
+                node.get_logger.warn('"--stopped" flag is deprecated use "--inactive" instead')
 
         if not args.unload_on_kill:
             return 0
@@ -217,8 +222,8 @@ def main(args=None):
             while True:
                 time.sleep(1)
         except KeyboardInterrupt:
-            if not args.stopped:
-                node.get_logger().info('Interrupt captured, stopping and unloading controller')
+            if not args.stopped and not args.inactive:
+                node.get_logger().info('Interrupt captured, deactivating and unloading controller')
                 ret = switch_controllers(
                     node,
                     controller_manager_name,
@@ -228,10 +233,13 @@ def main(args=None):
                     True,
                     5.0)
                 if not ret.ok:
-                    node.get_logger().info('Failed to stop controller')
+                    node.get_logger().info('Failed to deactivate controller')
                     return 1
 
-                node.get_logger().info('Stopped controller')
+                node.get_logger().info('Deactivated controller')
+
+            elif args.stopped:
+                node.get_logger.warn('"--stopped" flag is deprecated use "--inactive" instead')
 
             ret = unload_controller(
                 node, controller_manager_name, controller_name)

--- a/controller_manager/controller_manager/unspawner.py
+++ b/controller_manager/controller_manager/unspawner.py
@@ -50,7 +50,7 @@ def main(args=None):
             True,
             True,
             5.0)
-        node.get_logger().info('Stopped controller')
+        node.get_logger().info('Deactivated controller')
 
         ret = unload_controller(node, controller_manager_name, controller_name)
         if not ret.ok:

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1516,7 +1516,7 @@ void ControllerManager::switch_controller_service_cb(
   {
     RCLCPP_WARN(
       get_logger(),
-      "'start_controllers' field is deprecated, use 'activate_controllers field instead!");
+      "'start_controllers' field is deprecated, use 'activate_controllers' field instead!");
     activate_controllers.insert(
       activate_controllers.end(), request->start_controllers.begin(),
       request->start_controllers.end());
@@ -1525,16 +1525,23 @@ void ControllerManager::switch_controller_service_cb(
   {
     RCLCPP_WARN(
       get_logger(),
-      "'stop_controllers' field is deprecated, use 'deactivate_controllers field instead!");
+      "'stop_controllers' field is deprecated, use 'deactivate_controllers' field instead!");
     deactivate_controllers.insert(
       deactivate_controllers.end(), request->stop_controllers.begin(),
       request->stop_controllers.end());
   }
 
-  response->ok =
-    switch_controller(
-      activate_controllers, deactivate_controllers, request->strictness, request->activate_asap,
-      request->timeout) == controller_interface::return_type::OK;
+  auto activate_asap = request->activate_asap;
+  if (request->start_asap)
+  {
+    RCLCPP_WARN(
+      get_logger(), "'start_asap' field is deprecated, use 'activate_asap' field instead!");
+    activate_asap = request->start_asap;
+  }
+
+  response->ok = switch_controller(
+                   activate_controllers, deactivate_controllers, request->strictness, activate_asap,
+                   request->timeout) == controller_interface::return_type::OK;
   // END: remove when deprecated removed
 
   RCLCPP_DEBUG(get_logger(), "switching service finished");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -654,9 +654,9 @@ controller_interface::return_type ControllerManager::switch_controller(
     {
       RCLCPP_WARN(
         get_logger(),
-        "Could not activate controller with name '%s'. (Check above warnings for more details.) "
+        "Could not activate controller with name '%s'. Check above warnings for more details. "
         "Check the state of the controllers and their required interfaces using "
-        "`ros2 control list_controllers -v` to get more information.",
+        "`ros2 control list_controllers -v` CLI to get more information.",
         (*ctrl_it).c_str());
       if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
       {
@@ -690,7 +690,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     if (!is_controller_active(controller_it->c))
     {
       RCLCPP_WARN(
-        get_logger(), "Controller with name '%s' can not be deactivated since is not active.",
+        get_logger(), "Controller with name '%s' can not be deactivated since it is not active.",
         controller_it->info.name.c_str());
       ret = controller_interface::return_type::ERROR;
     }
@@ -703,9 +703,9 @@ controller_interface::return_type ControllerManager::switch_controller(
     {
       RCLCPP_WARN(
         get_logger(),
-        "Could not deactivate controller with name '%s'. (Check above warnings for more details.)"
+        "Could not deactivate controller with name '%s'. Check above warnings for more details. "
         "Check the state of the controllers and their required interfaces using "
-        "`ros2 control list_controllers -v` to get more information.",
+        "`ros2 control list_controllers -v` CLI to get more information.",
         (*ctrl_it).c_str());
       if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
       {
@@ -1503,9 +1503,39 @@ void ControllerManager::switch_controller_service_cb(
   std::lock_guard<std::mutex> guard(services_lock_);
   RCLCPP_DEBUG(get_logger(), "switching service locked");
 
-  response->ok = switch_controller(
-                   request->start_controllers, request->stop_controllers, request->strictness,
-                   request->start_asap, request->timeout) == controller_interface::return_type::OK;
+  //   response->ok = switch_controller(
+  //     request->activate_controllers, request->deactivate_controllers, request->strictness,
+  //     request->activate_asap, request->timeout) == controller_interface::return_type::OK;
+  // TODO(destogl): remove this after deprecated fields are removed from service and use the
+  // commented three lines above
+  // BEGIN: remove when deprecated removed
+  auto activate_controllers = request->activate_controllers;
+  auto deactivate_controllers = request->deactivate_controllers;
+
+  if (!request->start_controllers.empty())
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "'start_controllers' field is deprecated, use 'activate_controllers field instead!");
+    activate_controllers.insert(
+      activate_controllers.end(), request->start_controllers.begin(),
+      request->start_controllers.end());
+  }
+  if (!request->stop_controllers.empty())
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "'stop_controllers' field is deprecated, use 'deactivate_controllers field instead!");
+    deactivate_controllers.insert(
+      deactivate_controllers.end(), request->stop_controllers.begin(),
+      request->stop_controllers.end());
+  }
+
+  response->ok =
+    switch_controller(
+      activate_controllers, deactivate_controllers, request->strictness, request->activate_asap,
+      request->timeout) == controller_interface::return_type::OK;
+  // END: remove when deprecated removed
 
   RCLCPP_DEBUG(get_logger(), "switching service finished");
 }

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -10,12 +10,6 @@
 #      controller name, a controller that failed to activate, etc. )
 #    * BEST_EFFORT means that even when something goes wrong with on controller,
 #      the service will still try to activate/stop the remaining controllers
-#    * FORCE_ACTIVATE means that if interfaces that controller to activate are used by another
-#      controller that is running, the latter controller will be deactivated. Other behavior will
-#      be as BEST_EFFORT.
-#    * MANAGE_CONTROLLERS_CHAIN means that if controller in a chain need to activated and following
-#      controller(s) is not activate it will be activated. The same for deactivation, even if
-#      preceding controller(s) are not in the deactivate request, they will be deactivated.
 #  * activate the controllers as soon as their hardware dependencies are ready, will
 #    wait for all interfaces to be ready otherwise
 #  * the timeout before aborting pending controllers. Zero for infinite
@@ -32,8 +26,6 @@ string[] stop_controllers  # DEPRECATED: Use deactivate_controllers filed instea
 int32 strictness
 int32 BEST_EFFORT=1
 int32 STRICT=2
-int32 FORCE_ACTIVATE=3
-int32 MANAGE_CONTROLLERS_CHAIN=10
 bool activate_asap
 builtin_interfaces/Duration timeout
 ---

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -1,16 +1,22 @@
-# The SwitchController service allows you stop a number of controllers
-# and start a number of controllers, all in one single timestep of the
-# controller_manager control loop.
+# The SwitchController service allows you deactivate a number of controllers
+# and activate a number of controllers, all in one single timestep of the
+# controller manager's control loop.
 
 # To switch controllers, specify
-#  * the list of controller names to start,
-#  * the list of controller names to stop, and
+#  * the list of controller names to activate,
+#  * the list of controller names to deactivate, and
 #  * the strictness (BEST_EFFORT or STRICT)
 #    * STRICT means that switching will fail if anything goes wrong (an invalid
-#      controller name, a controller that failed to start, etc. )
+#      controller name, a controller that failed to activate, etc. )
 #    * BEST_EFFORT means that even when something goes wrong with on controller,
-#      the service will still try to start/stop the remaining controllers
-#  * start the controllers as soon as their hardware dependencies are ready, will
+#      the service will still try to activate/stop the remaining controllers
+#    * FORCE_ACTIVATE means that if interfaces that controller to activate are used by another
+#      controller that is running, the latter controller will be deactivated. Other behavior will
+#      be as BEST_EFFORT.
+#    * MANAGE_CONTROLLERS_CHAIN means that if controller in a chain need to activated and following
+#      controller(s) is not activate it will be activated. The same for deactivation, even if
+#      preceding controller(s) are not in the deactivate request, they will be deactivated.
+#  * activate the controllers as soon as their hardware dependencies are ready, will
 #    wait for all interfaces to be ready otherwise
 #  * the timeout before aborting pending controllers. Zero for infinite
 
@@ -19,12 +25,16 @@
 # specified strictness.
 
 
-string[] start_controllers
-string[] stop_controllers
+string[] activate_controllers
+string[] deactivate_controllers
+string[] start_controllers  # DEPRECATED: Use activate_controllers filed instead
+string[] stop_controllers  # DEPRECATED: Use deactivate_controllers filed instead
 int32 strictness
 int32 BEST_EFFORT=1
 int32 STRICT=2
-bool start_asap
+int32 FORCE_ACTIVATE=3
+int32 MANAGE_CONTROLLERS_CHAIN=10
+bool activate_asap
 builtin_interfaces/Duration timeout
 ---
 bool ok

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -21,11 +21,12 @@
 
 string[] activate_controllers
 string[] deactivate_controllers
-string[] start_controllers  # DEPRECATED: Use activate_controllers filed instead
-string[] stop_controllers  # DEPRECATED: Use deactivate_controllers filed instead
+string[] start_controllers       # DEPRECATED: Use activate_controllers filed instead
+string[] stop_controllers        # DEPRECATED: Use deactivate_controllers filed instead
 int32 strictness
 int32 BEST_EFFORT=1
 int32 STRICT=2
+bool start_asap                 # DEPRECATED: Use activate_asap filed instead
 bool activate_asap
 builtin_interfaces/Duration timeout
 ---

--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -109,7 +109,7 @@ load_controller
 .. code-block:: console
 
     $ ros2 control load_controller -h
-    usage: ros2 control load_controller [-h] [--spin-time SPIN_TIME] [--set_state {configure,start}] [-c CONTROLLER_MANAGER] [--include-hidden-nodes] controller_name
+    usage: ros2 control load_controller [-h] [--spin-time SPIN_TIME] [--set_state {configure,activate}] [-c CONTROLLER_MANAGER] [--include-hidden-nodes] controller_name
 
     Load a controller in a controller manager
 
@@ -120,7 +120,7 @@ load_controller
       -h, --help            show this help message and exit
       --spin-time SPIN_TIME
                             Spin time in seconds to wait for discovery (only applies when not using an already running daemon)
-      --set_state {configure,start}
+      --set_state {configured,active}
                             Set the state of the loaded controller
       -c CONTROLLER_MANAGER, --controller-manager CONTROLLER_MANAGER
                             Name of the controller manager ROS node
@@ -153,13 +153,13 @@ set_controller_state
 .. code-block:: console
 
     $ ros2 control set_controller_state -h
-    usage: ros2 control set_controller_state [-h] [--spin-time SPIN_TIME] [-c CONTROLLER_MANAGER] [--include-hidden-nodes] controller_name {configure,start,stop}
+    usage: ros2 control set_controller_state [-h] [--spin-time SPIN_TIME] [-c CONTROLLER_MANAGER] [--include-hidden-nodes] controller_name {inactive,active}
 
     Adjust the state of the controller
 
     positional arguments:
       controller_name       Name of the controller to be changed
-      {configure,start,stop}
+      {inactive,active}
                             State in which the controller should be changed to
 
     optional arguments:
@@ -177,7 +177,7 @@ switch_controllers
 .. code-block:: console
 
     $ ros2 control switch_controllers -h
-    usage: ros2 control switch_controllers [-h] [--spin-time SPIN_TIME] [--stop [STOP [STOP ...]]] [--start [START [START ...]]] [--strict] [--start-asap] [--switch-timeout SWITCH_TIMEOUT] [-c CONTROLLER_MANAGER]
+    usage: ros2 control switch_controllers [-h] [--spin-time SPIN_TIME] [--deactivate [CTRL1 [CTRL2 ...]]] [--activate [CTRL1 [CTRL2 ...]]] [--strict] [--activate-asap] [--switch-timeout SWITCH_TIMEOUT] [-c CONTROLLER_MANAGER]
                                           [--include-hidden-nodes]
 
     Switch controllers in a controller manager
@@ -186,12 +186,12 @@ switch_controllers
     -h, --help            show this help message and exit
     --spin-time SPIN_TIME
     Spin time in seconds to wait for discovery (only applies when not using an already running daemon)
-    --stop [STOP [STOP ...]]
-    Name of the controllers to be stopped
-    --start [START [START ...]]
-    Name of the controllers to be started
+    --deactivate [CTRL1 [CTRL2 ...]]
+    Name of the controllers to be deactivate
+    --activate [CTRL1 [CTRL2 ...]]
+    Name of the controllers to be activated
     --strict              Strict switch
-    --start-asap          Start asap controllers
+    --activate-asap       Activate asap controllers
     --switch-timeout SWITCH_TIMEOUT
     Timeout for switching controllers
     -c CONTROLLER_MANAGER, --controller-manager CONTROLLER_MANAGER

--- a/ros2controlcli/ros2controlcli/verb/load_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_controller.py
@@ -30,7 +30,7 @@ class LoadControllerVerb(VerbExtension):
         arg.completer = ControllerNameCompleter()
         arg = parser.add_argument(
             '--set-state',
-            choices=['configure', 'start'],
+            choices=['configured', 'active'],
             help='Set the state of the loaded controller',
         )
         add_controller_mgr_parsers(parser)
@@ -50,12 +50,17 @@ class LoadControllerVerb(VerbExtension):
             if not response.ok:
                 return 'Error configuring controller'
 
+            # TODO(destogl): remove in humble+
             if args.set_state == 'start':
+                print('Setting state "start" is deprecated "activate" instead!')
+                args.set_state == 'activate'
+
+            if args.set_state == 'active':
                 response = switch_controllers(
                     node, args.controller_manager, [], [args.controller_name], True, True, 5.0
                 )
                 if not response.ok:
-                    return 'Error starting controller, check controller_manager logs'
+                    return 'Error activating controller, check controller_manager logs'
 
             print(f'Sucessfully loaded controller {args.controller_name} into '
                   f'state { "inactive" if args.set_state == "configure" else "active" }')

--- a/ros2controlcli/ros2controlcli/verb/switch_controllers.py
+++ b/ros2controlcli/ros2controlcli/verb/switch_controllers.py
@@ -30,18 +30,33 @@ class SwitchControllersVerb(VerbExtension):
             '--stop',
             nargs='*',
             default=[],
-            help='Name of the controllers to be stopped',
+            help='Name of the controllers to be deactivated',
+        )
+        arg.completer = LoadedControllerNameCompleter(['active'])
+        arg = parser.add_argument(
+            '--deactivate',
+            nargs='*',
+            default=[],
+            help='Name of the controllers to be deactivated',
         )
         arg.completer = LoadedControllerNameCompleter(['active'])
         arg = parser.add_argument(
             '--start',
             nargs='*',
             default=[],
-            help='Name of the controllers to be started',
+            help='Name of the controllers to be activated',
+        )
+        arg.completer = LoadedControllerNameCompleter(['inactive'])
+        arg = parser.add_argument(
+            '--activate',
+            nargs='*',
+            default=[],
+            help='Name of the controllers to be activated',
         )
         arg.completer = LoadedControllerNameCompleter(['inactive'])
         parser.add_argument('--strict', action='store_true', help='Strict switch')
         parser.add_argument('--start-asap', action='store_true', help='Start asap controllers')
+        parser.add_argument('--activate-asap', action='store_true', help='Start asap controllers')
         parser.add_argument(
             '--switch-timeout',
             default=5.0,
@@ -52,12 +67,22 @@ class SwitchControllersVerb(VerbExtension):
         add_controller_mgr_parsers(parser)
 
     def main(self, *, args):
+        if (args.stop):
+            print('"--stop" flag is deprecated, use "--deactivate" instead!')
+            args.deactivate = args.stop
+        if (args.start):
+            print('"--start" flag is deprecated, use "--activate" instead!')
+            args.activate = args.start
+        if (args.start_asap):
+            print('"--start-asap" flag is deprecated, use "--activate-asap" instead!')
+            args.activate_asap = args.start_asap
+
         with NodeStrategy(args) as node:
             response = switch_controllers(
                 node,
                 args.controller_manager,
-                args.stop,
-                args.start,
+                args.deactivate,
+                args.activate,
                 args.strict,
                 args.start_asap,
                 args.switch_timeout,


### PR DESCRIPTION
- Rename fileds and deprecated old nomenclature.
- New defines from SwitchController.srv
