### PR TITLE
[ros2_control_node] Automatically detect if RT kernel is used and opportunistically enable SCHED_FIFO (#748)

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(rclcpp REQUIRED)
 
 add_library(controller_manager SHARED
   src/controller_manager.cpp
+  src/realtime.cpp
 )
 target_include_directories(controller_manager PRIVATE include)
 ament_target_dependencies(controller_manager

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -5,6 +5,14 @@ Controller Manager
 Controller Manager is the main component in the ros2_control framework.
 It manages lifecycle of controllers, access to the hardware interfaces and offers services to the ROS-world.
 
+Determinism
+-----------
+
+For best performance when controlling hardware you want the controller manager to have as little jitter as possible in the main control loop.
+The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
+The main thread of Controller Manager attempts to configure ``SCHED_FIFO`` with a priority of ``50``.
+To enable this functionality install a RT kernel and run the Controller Manager with permissions to make syscalls to set its thread priorities.
+The two easiest options for this are using the [Real-time Ubuntu 22.04 LTS Beta](https://ubuntu.com/blog/real-time-ubuntu-released) or [linux-image-rt-amd64](https://packages.debian.org/bullseye/linux-image-rt-amd64) on Debian Bullseye.
 
 Helper scripts
 --------------

--- a/controller_manager/include/controller_manager/realtime.hpp
+++ b/controller_manager/include/controller_manager/realtime.hpp
@@ -1,0 +1,35 @@
+// Copyright 2022 PickNik Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTROLLER_MANAGER__REALTIME_HPP_
+#define CONTROLLER_MANAGER__REALTIME_HPP_
+
+namespace controller_manager
+{
+/**
+ * Detect if realtime kernel is present.
+ * \returns true if realtime kernel is detected
+ */
+bool has_realtime_kernel();
+
+/**
+ * Configure SCHED_FIFO thread priority for the thread that calls this function
+ * \param[in] priority the priority of this thread from 0-99
+ * \returns true if configuring scheduler succeeded
+ */
+bool configure_sched_fifo(int priority);
+
+}  // namespace controller_manager
+
+#endif  // CONTROLLER_MANAGER__REALTIME_HPP_

--- a/controller_manager/src/realtime.cpp
+++ b/controller_manager/src/realtime.cpp
@@ -1,0 +1,47 @@
+// Copyright 2022 PickNik Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "controller_manager/realtime.hpp"
+
+#include <sched.h>
+
+#include <cstring>
+#include <fstream>
+
+namespace controller_manager
+{
+bool has_realtime_kernel()
+{
+  std::ifstream realtime_file("/sys/kernel/realtime", std::ios::in);
+  bool has_realtime = false;
+  if (realtime_file.is_open())
+  {
+    realtime_file >> has_realtime;
+  }
+  return has_realtime;
+}
+
+bool configure_sched_fifo(int priority)
+{
+  struct sched_param schedp;
+  memset(&schedp, 0, sizeof(schedp));
+  schedp.sched_priority = priority;
+  if (sched_setscheduler(0, SCHED_FIFO, &schedp))
+  {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace controller_manager

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -19,9 +19,19 @@
 #include <thread>
 
 #include "controller_manager/controller_manager.hpp"
+#include "controller_manager/realtime.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;
+
+namespace
+{
+// Reference: https://man7.org/linux/man-pages/man2/sched_setparam.2.html
+// This value is used when configuring the main loop to use SCHED_FIFO scheduling
+// We use a midpoint RT priority to allow maximum flexibility to users
+int const kSchedPriority = 50;
+
+}  // namespace
 
 int main(int argc, char ** argv)
 {
@@ -33,32 +43,44 @@ int main(int argc, char ** argv)
 
   auto cm = std::make_shared<controller_manager::ControllerManager>(executor, manager_node_name);
 
-  // TODO(anyone): Due to issues with the MutliThreadedExecutor, this control loop does not rely on
-  // the executor (see issue #260).
-  // When the MutliThreadedExecutor issues are fixed (ros2/rclcpp#1168), this loop should be
-  // converted back to a timer.
+  RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
+
   std::thread cm_thread([cm]() {
-    RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
+    if (controller_manager::has_realtime_kernel())
+    {
+      if (!controller_manager::configure_sched_fifo(kSchedPriority))
+      {
+        RCLCPP_WARN(cm->get_logger(), "Could not enable FIFO RT scheduling policy");
+      }
+    }
+    else
+    {
+      RCLCPP_INFO(cm->get_logger(), "RT kernel is recommended for better performance");
+    }
 
-    rclcpp::Time current_time = cm->now();
-    rclcpp::Time previous_time = current_time;
-    rclcpp::Time end_period = current_time;
+    // for calculating sleep time
+    auto const period = std::chrono::nanoseconds(1'000'000'000 / cm->get_update_rate());
+    std::chrono::system_clock::time_point next_iteration_time =
+      std::chrono::system_clock::time_point(std::chrono::nanoseconds(cm->now().nanoseconds()));
 
-    // Use nanoseconds to avoid chrono's rounding
-    rclcpp::Duration period(std::chrono::nanoseconds(1000000000 / cm->get_update_rate()));
+    // for calculating the measured period of the loop
+    rclcpp::Time previous_time = cm->now();
 
     while (rclcpp::ok())
     {
-      // wait until we hit the end of the period
-      end_period += period;
-      std::this_thread::sleep_for(std::chrono::nanoseconds((end_period - cm->now()).nanoseconds()));
-
-      // execute "real-time" update loop
-      cm->read();
-      current_time = cm->now();
-      cm->update(current_time, current_time - previous_time);
+      // calculate measured period
+      auto const current_time = cm->now();
+      auto const measured_period = current_time - previous_time;
       previous_time = current_time;
+
+      // execute update loop
+      cm->read();
+      cm->update(cm->now(), measured_period);
       cm->write();
+
+      // wait until we hit the end of the period
+      next_iteration_time += period;
+      std::this_thread::sleep_until(next_iteration_time);
     }
   });
 


### PR DESCRIPTION
Backport of #748