### PR TITLE
spawner.py: Fix python logging on deprecation warning

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -239,7 +239,7 @@ def main(args=None):
                 node.get_logger().info('Deactivated controller')
 
             elif args.stopped:
-                node.get_logger.warn('"--stopped" flag is deprecated use "--inactive" instead')
+                node.get_logger().warn('"--stopped" flag is deprecated use "--inactive" instead')
 
             ret = unload_controller(
                 node, controller_manager_name, controller_name)


### PR DESCRIPTION
This was an error introduced in abd5d6e6c8264706b58dddc877063f884cf34a58