### PR TITLE
Make output of joint limits nicer.

### DIFF
--- a/joint_limits/include/joint_limits/joint_limits.hpp
+++ b/joint_limits/include/joint_limits/joint_limits.hpp
@@ -67,15 +67,15 @@ struct JointLimits
   {
     std::stringstream ss_output;
 
-    ss_output << "  has position limits: " << (has_position_limits ? "true" : "false") << "["
+    ss_output << "  has position limits: " << (has_position_limits ? "true" : "false") << " ["
               << min_position << ", " << max_position << "]\n";
-    ss_output << "  has velocity limits: " << (has_velocity_limits ? "true" : "false") << "["
+    ss_output << "  has velocity limits: " << (has_velocity_limits ? "true" : "false") << " ["
               << max_velocity << "]\n";
     ss_output << "  has acceleration limits: " << (has_acceleration_limits ? "true" : "false")
               << " [" << max_acceleration << "]\n";
-    ss_output << "  has jerk limits: " << (has_jerk_limits ? "true" : "false") << "[" << max_jerk
+    ss_output << "  has jerk limits: " << (has_jerk_limits ? "true" : "false") << " [" << max_jerk
               << "]\n";
-    ss_output << "  has effort limits: " << (has_effort_limits ? "true" : "false") << "["
+    ss_output << "  has effort limits: " << (has_effort_limits ? "true" : "false") << " ["
               << max_effort << "]\n";
     ss_output << "  angle wraparound: " << (angle_wraparound ? "true" : "false");
 


### PR DESCRIPTION
Correct spaces in debug output for joint limits.

Does anybody has some idea what to add instead of `[]` to put values inside and make output a bit nicer? I find this currently hard to read. Should we add something like `(value: xy)`

The output now looks like as follows:
```
[ros2_control_node-3]   has position limits: false [nan, nan]
[ros2_control_node-3]   has velocity limits: true [1]
[ros2_control_node-3]   has acceleration limits: true [1]
[ros2_control_node-3]   has jerk limits: true [10]
[ros2_control_node-3]   has effort limits: false [nan]
[ros2_control_node-3]   angle wraparound: false
```
