### PR TITLE
Move "realtime" to a small library

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -21,11 +21,17 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
 
-add_library(${PROJECT_NAME} SHARED
-  src/controller_manager.cpp
+add_library(realtime SHARED
   src/realtime.cpp
 )
+target_include_directories(realtime PRIVATE include)
+ament_target_dependencies(realtime ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+add_library(${PROJECT_NAME} SHARED
+  src/controller_manager.cpp
+)
 target_include_directories(${PROJECT_NAME} PRIVATE include)
+target_link_libraries(${PROJECT_NAME} realtime)
 ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -36,7 +42,7 @@ target_include_directories(ros2_control_node PRIVATE include)
 target_link_libraries(ros2_control_node ${PROJECT_NAME})
 ament_target_dependencies(ros2_control_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS realtime ${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
Move this bit of code to a small library so it can be linked against by other packages, without linking all of `controller_manager`. We're already making use of this in [MoveIt.](https://github.com/ros-planning/moveit2/pull/1464)

Here are some thoughts I had while working on this. I'd be interested to hear any feedback:

- Would it be better to move this to header-only (no library)? That seems easy
- The name `realtime` seems a bit too broad. Basically this searches for a realtime kernel then attempts to set thread priority. So I think a better name might be `thread_priority`.

@tylerjw