### PR TITLE
Corrected the site link to a valid one.

### DIFF
--- a/ros2controlcli/README.rst
+++ b/ros2controlcli/README.rst
@@ -1,3 +1,3 @@
 Read the `Docs`_ for example usage and command line arguments.
 
-.. _Docs: https://ros-controls.github.io/control.ros.org/ros2_control/ros2controlcli/doc/userdoc.html
+.. _Docs: https://control.ros.org/master/doc/ros2_control/ros2controlcli/doc/userdoc.html


### PR DESCRIPTION
The previous ```Docs``` link pointed to the broken site.
