### PR TITLE
Fix wrong initialization order

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -142,13 +142,13 @@ ControllerManager::ControllerManager(
   const std::string & namespace_)
 : rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::make_unique<hardware_interface::ResourceManager>()),
+  diagnostics_updater_(this),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(
     kControllerInterfaceNamespace, kControllerInterfaceClassName)),
   chainable_loader_(
     std::make_shared<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>(
-      kControllerInterfaceNamespace, kChainableControllerInterfaceClassName)),
-  diagnostics_updater_(this)
+      kControllerInterfaceNamespace, kChainableControllerInterfaceClassName))
 {
   if (!get_parameter("update_rate", update_rate_))
   {
@@ -176,13 +176,13 @@ ControllerManager::ControllerManager(
   const std::string & namespace_)
 : rclcpp::Node(manager_node_name, namespace_, get_cm_node_options()),
   resource_manager_(std::move(resource_manager)),
+  diagnostics_updater_(this),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(
     kControllerInterfaceNamespace, kControllerInterfaceClassName)),
   chainable_loader_(
     std::make_shared<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>(
-      kControllerInterfaceNamespace, kChainableControllerInterfaceClassName)),
-  diagnostics_updater_(this)
+      kControllerInterfaceNamespace, kChainableControllerInterfaceClassName))
 {
   diagnostics_updater_.setHardwareID("ros2_control");
   diagnostics_updater_.add(


### PR DESCRIPTION
The members of the `ControllerManager` class were not initialized as defined in the header file. Hence, the compilation warning:

> "‘controller_manager::ControllerManager::chainable_loader_’ will be initialized after [-Wreorder]",
> "diagnostic_updater::Updater controller_manager::ControllerManager::diagnostics_updater_’ [-Wreorder]"
