### PR TITLE
Use explicit duration type for time_point to be compatible with macOS

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -62,8 +62,9 @@ int main(int argc, char ** argv)
 
       // for calculating sleep time
       auto const period = std::chrono::nanoseconds(1'000'000'000 / cm->get_update_rate());
-      std::chrono::system_clock::time_point next_iteration_time =
-        std::chrono::system_clock::time_point(std::chrono::nanoseconds(cm->now().nanoseconds()));
+      auto const cm_now = std::chrono::nanoseconds(cm->now().nanoseconds());
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
+        next_iteration_time{cm_now};
 
       // for calculating the measured period of the loop
       rclcpp::Time previous_time = cm->now();


### PR DESCRIPTION
On macOS, `std::chrono::system_clock::time_point` has `std::chrono::milliseconds` for its duration so compilation fails.

Changing the declaration to one with an explicit duration template parameter `std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>`  helps remove the system dependent implementation of `std::chrono::system_clock`.