### PR TITLE
[Doc] Correct type of update_rate parameter

### DIFF
--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -57,7 +57,7 @@ robot_description (mandatory; string)
   String with the URDF string as robot description.
   This is usually result of the parsed description files by ``xacro`` command.
 
-update_rate (mandatory; double)
+update_rate (mandatory; integer)
   The frequency of controller manager's real-time update loop.
   This loop reads states from hardware, updates controller and writes commands to hardware.
 


### PR DESCRIPTION
I don't see value in having it to be double. Never saw its use as double. So here I a correction of the docs.

closes #850 