### PR TITLE
Fix hardware interface CLI description

### DIFF
--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -82,7 +82,7 @@ list_hardware_interfaces
     $ ros2 control list_hardware_interfaces -h
     usage: ros2 control list_hardware_interfaces [-h] [--spin-time SPIN_TIME] [-c CONTROLLER_MANAGER] [--include-hidden-nodes]
 
-    Output the list of loaded controllers, their type and status
+    Output the list of available command and state interfaces
 
     optional arguments:
       -h, --help            show this help message and exit

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
@@ -22,7 +22,7 @@ from ros2controlcli.api import add_controller_mgr_parsers
 
 
 class ListHardwareInterfacesVerb(VerbExtension):
-    """Output the list of loaded controllers, their type and status."""
+    """Output the list of available command and state interfaces."""
 
     def add_arguments(self, parser, cli_name):
         add_arguments(parser)


### PR DESCRIPTION
This should give a more correct output of `ros2 control` cli.