### PR TITLE
 ResourceManager doesn't always log an error on shutdown anymore (backport #867 to humble)

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -262,7 +262,7 @@ public:
   {
     bool result = trigger_and_print_hardware_state_transition(
       std::bind(&HardwareT::shutdown, &hardware), "shutdown", hardware.get_name(),
-      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+      lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
 
     if (result)
     {


### PR DESCRIPTION
The patch couldn't be cherry-picjed without issues becasue of changes in the unit tests.

Nevertheless this fix should be packported as it will probably not break any user but rather won't confuse users anymore with false error messages.