### PR TITLE
Bump version in formatting action

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.9
     - name: Install system hooks
       run: sudo apt install -qq clang-format-12 cppcheck
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual


### PR DESCRIPTION
This avoids warning when executing formatting action: "Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python@v2, pre-commit/action@v2.0.3"

For example: https://github.com/ros-controls/ros2_control/actions/runs/3855204458