### PR TITLE
ControllerManager: catch exception by reference

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -313,7 +313,7 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
       controller = chainable_loader_->createSharedInstance(controller_type);
     }
   }
-  catch (const pluginlib::CreateClassException& e)
+  catch (const pluginlib::CreateClassException & e)
   {
     RCLCPP_ERROR(
       get_logger(), "Error happened during creation of controller '%s' with type '%s':\n%s",

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -313,7 +313,7 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
       controller = chainable_loader_->createSharedInstance(controller_type);
     }
   }
-  catch (const pluginlib::CreateClassException e)
+  catch (const pluginlib::CreateClassException& e)
   {
     RCLCPP_ERROR(
       get_logger(), "Error happened during creation of controller '%s' with type '%s':\n%s",


### PR DESCRIPTION
This will fix a warning issued by GCC:
`
 warning: catching polymorphic type ‘const class pluginlib::CreateClassException’ by value [-Wcatch-value=]

  310 |   catch (const pluginlib::CreateClassException e)

`