### PR TITLE
Fix CMake install so overriding works

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
-project(controller_interface)
+cmake_minimum_required(VERSION 3.16)
+project(controller_interface LANGUAGES CXX)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra)
 endif()
 
@@ -9,96 +9,80 @@ find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 
-add_library(
-  ${PROJECT_NAME}
-  SHARED
+add_library(controller_interface SHARED
   src/controller_interface_base.cpp
   src/controller_interface.cpp
   src/chainable_controller_interface.cpp
 )
-target_include_directories(
-  ${PROJECT_NAME}
-  PRIVATE
-  include
+target_compile_features(controller_interface PUBLIC cxx_std_17)
+target_include_directories(controller_interface PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/controller_interface>
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  hardware_interface
-  rclcpp_lifecycle
+target_link_libraries(controller_interface PUBLIC
+  hardware_interface::hardware_interface
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME} PRIVATE "CONTROLLER_INTERFACE_BUILDING_DLL")
+target_compile_definitions(controller_interface PRIVATE "CONTROLLER_INTERFACE_BUILDING_DLL")
 
-install(DIRECTORY include/
-  DESTINATION include
+if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
+  find_package(sensor_msgs REQUIRED)
+
+  ament_add_gmock(test_controller_interface test/test_controller_interface.cpp)
+  target_link_libraries(test_controller_interface
+    controller_interface
+  )
+
+  ament_add_gmock(test_controller_with_options test/test_controller_with_options.cpp)
+  target_link_libraries(test_controller_with_options
+    controller_interface
+  )
+
+  ament_add_gmock(test_chainable_controller_interface test/test_chainable_controller_interface.cpp)
+  target_link_libraries(test_chainable_controller_interface
+    controller_interface
+    hardware_interface::hardware_interface
+  )
+
+  ament_add_gmock(test_semantic_component_interface test/test_semantic_component_interface.cpp)
+  target_link_libraries(test_semantic_component_interface
+    controller_interface
+    hardware_interface::hardware_interface
+  )
+
+  ament_add_gmock(test_force_torque_sensor test/test_force_torque_sensor.cpp)
+  target_link_libraries(test_force_torque_sensor
+    controller_interface
+    hardware_interface::hardware_interface
+  )
+
+  ament_add_gmock(test_imu_sensor test/test_imu_sensor.cpp)
+  target_link_libraries(test_imu_sensor
+    controller_interface
+    hardware_interface::hardware_interface
+  )
+  ament_target_dependencies(test_imu_sensor
+    sensor_msgs
+  )
+endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION include/controller_interface
 )
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS controller_interface
+  EXPORT export_controller_interface
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_gmock REQUIRED)
-
-  find_package(hardware_interface REQUIRED)
-  find_package(sensor_msgs REQUIRED)
-
-  ament_add_gmock(test_controller_interface test/test_controller_interface.cpp)
-  target_link_libraries(test_controller_interface ${PROJECT_NAME})
-  target_include_directories(test_controller_interface PRIVATE include)
-
-  ament_add_gmock(test_controller_with_options test/test_controller_with_options.cpp)
-  target_link_libraries(test_controller_with_options ${PROJECT_NAME})
-  target_include_directories(test_controller_with_options PRIVATE include)
-
-  ament_add_gmock(test_chainable_controller_interface test/test_chainable_controller_interface.cpp)
-  target_link_libraries(test_chainable_controller_interface ${PROJECT_NAME})
-  target_include_directories(test_chainable_controller_interface PRIVATE include)
-  ament_target_dependencies(test_chainable_controller_interface hardware_interface)
-
-  ament_add_gmock(
-    test_semantic_component_interface
-    test/test_semantic_component_interface.cpp
-  )
-  target_include_directories(test_semantic_component_interface PRIVATE include)
-  ament_target_dependencies(
-    test_semantic_component_interface
-    hardware_interface
-  )
-
-  ament_add_gmock(
-    test_force_torque_sensor
-    test/test_force_torque_sensor.cpp
-  )
-  target_include_directories(test_force_torque_sensor PRIVATE include)
-  ament_target_dependencies(
-    test_force_torque_sensor
-    hardware_interface
-  )
-
-  ament_add_gmock(
-    test_imu_sensor
-    test/test_imu_sensor.cpp
-  )
-  target_include_directories(test_imu_sensor PRIVATE include)
-  ament_target_dependencies(
-    test_imu_sensor
-    hardware_interface
-    sensor_msgs
-  )
-endif()
-
+ament_export_targets(export_controller_interface HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   hardware_interface
   rclcpp_lifecycle
-  sensor_msgs
-)
-ament_export_include_directories(
-  include
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
 )
 ament_package()

--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -14,11 +14,8 @@
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>sensor_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -231,4 +231,3 @@ ament_export_dependencies(
   realtime_tools
 )
 ament_package()
-

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -1,198 +1,234 @@
-cmake_minimum_required(VERSION 3.5)
-project(controller_manager)
+cmake_minimum_required(VERSION 3.16)
+project(controller_manager LANGUAGES CXX)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra)
 endif()
-
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    ament_index_cpp
-    controller_interface
-    controller_manager_msgs
-    diagnostic_updater
-    hardware_interface
-    pluginlib
-    rclcpp
-    realtime_tools
-)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_core REQUIRED)
 find_package(backward_ros REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
-endforeach()
 
-add_library(${PROJECT_NAME} SHARED
+find_package(ament_index_cpp REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(controller_manager_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(realtime_tools REQUIRED)
+
+add_library(controller_manager SHARED
   src/controller_manager.cpp
 )
-target_include_directories(${PROJECT_NAME} PRIVATE include)
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_compile_features(controller_manager PUBLIC cxx_std_17)
+target_include_directories(controller_manager PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/controller_manager>
+)
+target_link_libraries(controller_manager PUBLIC
+  ament_index_cpp::ament_index_cpp
+  controller_interface::controller_interface
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+)
+
+ament_target_dependencies(controller_manager PUBLIC
+  controller_manager_msgs
+# TODO: Investigate why the INTERFACE library diagnostic_updater does
+#       not work with target_link_libraries
+  diagnostic_updater
+# TODO: Use target_link_libraries for realtime_tools once it is updated
+#       to install its targets correctly
+  realtime_tools
+)
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME} PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
+target_compile_definitions(controller_manager PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
 
 add_executable(ros2_control_node src/ros2_control_node.cpp)
-target_include_directories(ros2_control_node PRIVATE include)
-target_link_libraries(ros2_control_node
-  ${PROJECT_NAME}
-)
-ament_target_dependencies(ros2_control_node ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
-install(TARGETS ${PROJECT_NAME}
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
-
-install(TARGETS ros2_control_node
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-)
-
-install(DIRECTORY include/
-  DESTINATION include
+target_link_libraries(ros2_control_node PRIVATE
+  controller_manager
 )
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
+  # Plugin Libraries that are built and installed for use in testing
   add_library(test_controller SHARED test/test_controller/test_controller.cpp)
-  target_include_directories(test_controller PRIVATE include)
-  target_link_libraries(test_controller ${PROJECT_NAME})
+  target_link_libraries(test_controller PUBLIC controller_manager)
   target_compile_definitions(test_controller PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
-  pluginlib_export_plugin_description_file(
-    controller_interface test/test_controller/test_controller.xml)
-  install(TARGETS test_controller
+  pluginlib_export_plugin_description_file(controller_interface test/test_controller/test_controller.xml)
+  install(
+    TARGETS test_controller
     DESTINATION lib
   )
 
-  add_library(test_controller_failed_init SHARED test/test_controller_failed_init/test_controller_failed_init.cpp)
-  target_include_directories(test_controller_failed_init PRIVATE include)
-  target_link_libraries(test_controller_failed_init ${PROJECT_NAME})
+  add_library(test_controller_failed_init SHARED
+    test/test_controller_failed_init/test_controller_failed_init.cpp
+  )
+  target_link_libraries(test_controller_failed_init PUBLIC controller_manager)
   target_compile_definitions(test_controller_failed_init PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
   pluginlib_export_plugin_description_file(
     controller_interface test/test_controller_failed_init/test_controller_failed_init.xml)
-  install(TARGETS test_controller_failed_init
+  install(
+    TARGETS test_controller_failed_init
     DESTINATION lib
   )
 
-  add_library(test_chainable_controller SHARED test/test_chainable_controller/test_chainable_controller.cpp)
-  ament_target_dependencies(test_chainable_controller realtime_tools)
-  target_include_directories(test_chainable_controller PRIVATE include)
-  target_link_libraries(test_chainable_controller controller_manager)
+  add_library(test_chainable_controller SHARED
+    test/test_chainable_controller/test_chainable_controller.cpp
+  )
+  ament_target_dependencies(test_chainable_controller PUBLIC realtime_tools)
+  target_link_libraries(test_chainable_controller PUBLIC controller_manager)
   target_compile_definitions(test_chainable_controller PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
   pluginlib_export_plugin_description_file(
     controller_interface test/test_chainable_controller/test_chainable_controller.xml)
-  install(TARGETS test_chainable_controller
+  install(
+    TARGETS test_chainable_controller
     DESTINATION lib
   )
 
-  ament_add_gmock(
-    test_controller_manager
+  ament_add_gmock(test_controller_manager
     test/test_controller_manager.cpp
   )
-  target_include_directories(test_controller_manager PRIVATE include)
-  target_link_libraries(test_controller_manager ${PROJECT_NAME} test_controller)
-  ament_target_dependencies(test_controller_manager ros2_control_test_assets)
+  target_link_libraries(test_controller_manager
+    controller_manager
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_controller_manager_with_namespace.cpp
+  ament_add_gmock(test_controller_manager_with_namespace
     test/test_controller_manager_with_namespace.cpp
   )
-  target_include_directories(test_controller_manager_with_namespace.cpp PRIVATE include)
-  target_link_libraries(test_controller_manager_with_namespace.cpp ${PROJECT_NAME} test_controller)
-  ament_target_dependencies(test_controller_manager_with_namespace.cpp ros2_control_test_assets)
+  target_link_libraries(test_controller_manager_with_namespace
+    controller_manager
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_controller_manager_hardware_error_handling
+  ament_add_gmock(test_controller_manager_hardware_error_handling
     test/test_controller_manager_hardware_error_handling.cpp
   )
-  target_include_directories(test_controller_manager_hardware_error_handling PRIVATE include)
-  target_link_libraries(test_controller_manager_hardware_error_handling ${PROJECT_NAME} test_controller)
-  ament_target_dependencies(test_controller_manager_hardware_error_handling ros2_control_test_assets)
+  target_link_libraries(test_controller_manager_hardware_error_handling
+    controller_manager
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_load_controller
+  ament_add_gmock(test_load_controller
     test/test_load_controller.cpp
     APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}_$<CONFIG>
   )
-  target_include_directories(test_load_controller PRIVATE include)
-  target_link_libraries(test_load_controller ${PROJECT_NAME} test_controller test_controller_failed_init)
-  ament_target_dependencies(test_load_controller ros2_control_test_assets)
+  target_link_libraries(test_load_controller
+    controller_manager
+    test_controller
+    test_controller_failed_init
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_controllers_chaining_with_controller_manager
+  ament_add_gmock(test_controllers_chaining_with_controller_manager
     test/test_controllers_chaining_with_controller_manager.cpp
   )
-  target_include_directories(test_controllers_chaining_with_controller_manager PRIVATE include)
-  target_link_libraries(test_controllers_chaining_with_controller_manager controller_manager test_chainable_controller test_controller)
-  ament_target_dependencies(test_controllers_chaining_with_controller_manager ros2_control_test_assets)
+  target_link_libraries(test_controllers_chaining_with_controller_manager
+    controller_manager
+    test_chainable_controller
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_controller_manager_srvs
+  ament_add_gmock(test_controller_manager_srvs
     test/test_controller_manager_srvs.cpp
     APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}_$<CONFIG>
   )
-  target_include_directories(test_controller_manager_srvs PRIVATE include)
-  target_link_libraries(test_controller_manager_srvs ${PROJECT_NAME} test_controller test_chainable_controller)
-  ament_target_dependencies(
-    test_controller_manager_srvs
+  target_link_libraries(test_controller_manager_srvs
+    controller_manager
+    test_controller
+    test_chainable_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+  ament_target_dependencies(test_controller_manager_srvs
     controller_manager_msgs
-    ros2_control_test_assets
   )
 
-  add_library(test_controller_with_interfaces SHARED test/test_controller_with_interfaces/test_controller_with_interfaces.cpp)
-  target_include_directories(test_controller_with_interfaces PRIVATE include)
-  target_link_libraries(test_controller_with_interfaces ${PROJECT_NAME})
+  add_library(test_controller_with_interfaces SHARED
+    test/test_controller_with_interfaces/test_controller_with_interfaces.cpp
+  )
+  target_link_libraries(test_controller_with_interfaces PUBLIC
+    controller_manager
+  )
   target_compile_definitions(test_controller_with_interfaces PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
   pluginlib_export_plugin_description_file(
     controller_interface test/test_controller_with_interfaces/test_controller_with_interfaces.xml)
-  install(TARGETS test_controller_with_interfaces
+  install(
+    TARGETS test_controller_with_interfaces
     DESTINATION lib
   )
 
-  ament_add_gmock(
-    test_release_interfaces
+  ament_add_gmock(test_release_interfaces
     test/test_release_interfaces.cpp
     APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}_$<CONFIG>
   )
-  target_include_directories(test_release_interfaces PRIVATE include)
-  target_link_libraries(test_release_interfaces ${PROJECT_NAME} test_controller_with_interfaces)
-  ament_target_dependencies(test_release_interfaces ros2_control_test_assets)
+  target_link_libraries(test_release_interfaces
+    controller_manager
+    test_controller_with_interfaces
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_spawner_unspawner
+  ament_add_gmock(test_spawner_unspawner
     test/test_spawner_unspawner.cpp
   )
-  target_include_directories(test_spawner_unspawner PRIVATE include)
-  target_link_libraries(test_spawner_unspawner ${PROJECT_NAME} test_controller)
-  ament_target_dependencies(test_spawner_unspawner ros2_control_test_assets)
+  target_link_libraries(test_spawner_unspawner
+    controller_manager
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
-  ament_add_gmock(
-    test_hardware_management_srvs
+  ament_add_gmock(test_hardware_management_srvs
     test/test_hardware_management_srvs.cpp
   )
-  target_include_directories(test_hardware_management_srvs PRIVATE include)
-  target_link_libraries(test_hardware_management_srvs ${PROJECT_NAME} test_controller)
-  ament_target_dependencies(
-    test_hardware_management_srvs
+  target_link_libraries(test_hardware_management_srvs
+    controller_manager
+    test_controller
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+  ament_target_dependencies(test_hardware_management_srvs
     controller_manager_msgs
-    ros2_control_test_assets
   )
 endif()
 
-# Install Python modules
-ament_python_install_package(${PROJECT_NAME} SCRIPTS_DESTINATION lib/${PROJECT_NAME})
+install(
+  DIRECTORY include/
+  DESTINATION include/controller_manager
+)
+install(
+  TARGETS controller_manager
+  EXPORT export_controller_manager
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+install(
+  TARGETS ros2_control_node
+  RUNTIME DESTINATION lib/controller_manager
+)
 
-ament_export_libraries(
-  ${PROJECT_NAME}
+ament_python_install_package(controller_manager
+  SCRIPTS_DESTINATION lib/controller_manager
 )
-ament_export_include_directories(
-  include
-)
+ament_export_targets(export_controller_manager HAS_LIBRARY_TARGET)
 ament_export_dependencies(
-  ${THIS_PACKAGE_INCLUDE_DEPENDS}
+  ament_index_cpp
+  controller_interface
+  controller_manager_msgs
+  diagnostic_updater
+  hardware_interface
+  pluginlib
+  rclcpp
+  realtime_tools
 )
 ament_package()
+

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -28,6 +28,7 @@
   <depend>ros2run</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/controller_manager_msgs/CMakeLists.txt
+++ b/controller_manager_msgs/CMakeLists.txt
@@ -1,9 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(controller_manager_msgs)
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -1,64 +1,59 @@
-cmake_minimum_required(VERSION 3.5)
-project(hardware_interface)
+cmake_minimum_required(VERSION 3.16)
+project(hardware_interface LANGUAGES CXX)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra)
 endif()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    control_msgs
-    lifecycle_msgs
-    pluginlib
-    rclcpp_lifecycle
-    rcpputils
-    rcutils
-    tinyxml2_vendor
-    TinyXML2
-)
-
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
-endforeach()
+find_package(control_msgs REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
+find_package(TinyXML2 REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
-add_library(
-  ${PROJECT_NAME}
-  SHARED
+add_library(hardware_interface SHARED
   src/actuator.cpp
   src/component_parser.cpp
   src/resource_manager.cpp
   src/sensor.cpp
   src/system.cpp
 )
-target_include_directories(
-  ${PROJECT_NAME}
-  PUBLIC
-  include
+target_compile_features(hardware_interface PUBLIC cxx_std_17)
+target_include_directories(hardware_interface PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/hardware_interface>
 )
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(hardware_interface PUBLIC
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  rcpputils::rcpputils
+  rcutils::rcutils
+  tinyxml2::tinyxml2
+)
+ament_target_dependencies(hardware_interface PUBLIC
+  control_msgs
+  lifecycle_msgs
+)
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME} PRIVATE "HARDWARE_INTERFACE_BUILDING_DLL")
+target_compile_definitions(hardware_interface PRIVATE "HARDWARE_INTERFACE_BUILDING_DLL")
 
-# Mock components
-add_library(
-  mock_components
-  SHARED
+add_library(mock_components SHARED
   src/mock_components/generic_system.cpp
 )
-target_include_directories(
-  mock_components
-  PUBLIC
-  include
+target_compile_features(mock_components PUBLIC cxx_std_17)
+target_include_directories(mock_components PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/hardware_interface>
 )
-target_link_libraries(
-  mock_components
-  ${PROJECT_NAME}
-)
-ament_target_dependencies(
-  mock_components
-  pluginlib
-  rcpputils
+target_link_libraries(mock_components PUBLIC
+  hardware_interface
+  pluginlib::pluginlib
+  rcpputils::rcpputils
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -66,28 +61,21 @@ ament_target_dependencies(
 target_compile_definitions(mock_components PRIVATE "HARDWARE_INTERFACE_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(
-  ${PROJECT_NAME} mock_components_plugin_description.xml)
+  hardware_interface mock_components_plugin_description.xml)
 
-# Fake components
-add_library(
-  fake_components
-  SHARED
+add_library(fake_components SHARED
   src/mock_components/generic_system.cpp
   src/mock_components/fake_generic_system.cpp
 )
-target_include_directories(
-  fake_components
-  PUBLIC
-  include
+target_compile_features(fake_components PUBLIC cxx_std_17)
+target_include_directories(fake_components PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/hardware_interface>
 )
-target_link_libraries(
-  fake_components
-  ${PROJECT_NAME}
-)
-ament_target_dependencies(
-  fake_components
-  pluginlib
-  rcpputils
+target_link_libraries(fake_components PUBLIC
+  hardware_interface
+  pluginlib::pluginlib
+  rcpputils::rcpputils
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -95,23 +83,7 @@ ament_target_dependencies(
 target_compile_definitions(fake_components PRIVATE "HARDWARE_INTERFACE_BUILDING_DLL")
 
 pluginlib_export_plugin_description_file(
-  ${PROJECT_NAME} fake_components_plugin_description.xml)
-
-
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
-
-install(
-  TARGETS
-  fake_components
-  mock_components
-  ${PROJECT_NAME}
-  RUNTIME DESTINATION bin
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-)
+  hardware_interface fake_components_plugin_description.xml)
 
 if(BUILD_TESTING)
 
@@ -123,28 +95,28 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_macros rcpputils)
 
   ament_add_gmock(test_joint_handle test/test_handle.cpp)
-  target_link_libraries(test_joint_handle ${PROJECT_NAME})
+  target_link_libraries(test_joint_handle hardware_interface)
   ament_target_dependencies(test_joint_handle rcpputils)
 
   ament_add_gmock(test_component_interfaces test/test_component_interfaces.cpp)
-  target_link_libraries(test_component_interfaces ${PROJECT_NAME})
+  target_link_libraries(test_component_interfaces hardware_interface)
 
   ament_add_gmock(test_component_parser test/test_component_parser.cpp)
-  target_link_libraries(test_component_parser ${PROJECT_NAME})
+  target_link_libraries(test_component_parser hardware_interface)
   ament_target_dependencies(test_component_parser ros2_control_test_assets)
 
   add_library(test_components SHARED
     test/test_components/test_actuator.cpp
     test/test_components/test_sensor.cpp
     test/test_components/test_system.cpp)
-  target_link_libraries(test_components ${PROJECT_NAME})
+  target_link_libraries(test_components hardware_interface)
   ament_target_dependencies(test_components
     pluginlib)
   install(TARGETS test_components
     DESTINATION lib
   )
   pluginlib_export_plugin_description_file(
-    ${PROJECT_NAME} test/test_components/test_components.xml)
+    hardware_interface test/test_components/test_components.xml)
 
   add_library(test_hardware_components SHARED
   test/test_hardware_components/test_single_joint_actuator.cpp
@@ -152,36 +124,53 @@ if(BUILD_TESTING)
   test/test_hardware_components/test_two_joint_system.cpp
   test/test_hardware_components/test_system_with_command_modes.cpp
   )
-  target_link_libraries(test_hardware_components ${PROJECT_NAME})
+  target_link_libraries(test_hardware_components hardware_interface)
   ament_target_dependencies(test_hardware_components
     pluginlib)
   install(TARGETS test_hardware_components
     DESTINATION lib
   )
   pluginlib_export_plugin_description_file(
-    ${PROJECT_NAME} test/test_hardware_components/test_hardware_components.xml
+    hardware_interface test/test_hardware_components/test_hardware_components.xml
   )
 
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
-  target_link_libraries(test_resource_manager ${PROJECT_NAME})
+  target_link_libraries(test_resource_manager hardware_interface)
   ament_target_dependencies(test_resource_manager ros2_control_test_assets)
 
   ament_add_gmock(test_generic_system test/mock_components/test_generic_system.cpp)
   target_include_directories(test_generic_system PRIVATE include)
-  target_link_libraries(test_generic_system ${PROJECT_NAME})
+  target_link_libraries(test_generic_system hardware_interface)
   ament_target_dependencies(test_generic_system
     pluginlib
     ros2_control_test_assets
   )
 endif()
 
-ament_export_include_directories(
-  include
+install(
+  DIRECTORY include/
+  DESTINATION include/hardware_interface
 )
-ament_export_libraries(
-  fake_components
-  mock_components
-  ${PROJECT_NAME}
+install(
+  TARGETS
+    fake_components
+    mock_components
+    hardware_interface
+  EXPORT export_hardware_interface
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
 )
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_export_targets(export_hardware_interface HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  control_msgs
+  lifecycle_msgs
+  pluginlib
+  rclcpp_lifecycle
+  rcpputils
+  rcutils
+  TinyXML2
+  tinyxml2_vendor
+)
 ament_package()

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -1,12 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
-project(joint_limits)
+cmake_minimum_required(VERSION 3.16)
+project(joint_limits LANGUAGES CXX)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra)
 endif()
 
@@ -14,40 +9,49 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 
-install(DIRECTORY include/
-  DESTINATION include
+add_library(joint_limits INTERFACE)
+target_compile_features(joint_limits INTERFACE cxx_std_17)
+target_include_directories(joint_limits INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/joint_limits>
+)
+target_link_libraries(joint_limits INTERFACE
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(launch_testing_ament_cmake)
-  find_package(rclcpp)
-  find_package(rclcpp_lifecycle)
+  find_package(launch_testing_ament_cmake REQUIRED)
 
   ament_add_gtest_executable(joint_limits_rosparam_test test/joint_limits_rosparam_test.cpp)
-  target_include_directories(joint_limits_rosparam_test PRIVATE include)
-  ament_target_dependencies(joint_limits_rosparam_test rclcpp rclcpp_lifecycle)
+  target_link_libraries(joint_limits_rosparam_test joint_limits)
 
   add_launch_test(test/joint_limits_rosparam.launch.py)
   install(
-    TARGETS
-    joint_limits_rosparam_test
-    DESTINATION lib/${PROJECT_NAME}
+    TARGETS joint_limits_rosparam_test
+    DESTINATION lib/joint_limits
   )
   install(
-    FILES
-    test/joint_limits_rosparam.yaml
-    DESTINATION share/${PROJECT_NAME}/test
+    FILES test/joint_limits_rosparam.yaml
+    DESTINATION share/joint_limits/test
   )
-
 endif()
 
+install(
+  DIRECTORY include/
+  DESTINATION include/joint_limits
+)
+install(TARGETS joint_limits
+  EXPORT export_joint_limits
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_joint_limits HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rclcpp
+  rclcpp_lifecycle
 )
-
-ament_export_include_directories(
-  include
-)
-
 ament_package()

--- a/ros2_control/CMakeLists.txt
+++ b/ros2_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ros2_control)
 
 find_package(ament_cmake REQUIRED)

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -1,14 +1,25 @@
-cmake_minimum_required(VERSION 3.5)
-project(ros2_control_test_assets)
+cmake_minimum_required(VERSION 3.16)
+project(ros2_control_test_assets LANGUAGES CXX)
 
 find_package(ament_cmake REQUIRED)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
+add_library(ros2_control_test_assets INTERFACE)
+target_compile_features(ros2_control_test_assets INTERFACE cxx_std_17)
+target_include_directories(ros2_control_test_assets INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/ros2_control_test_assets>
 )
 
-ament_export_include_directories(
-  include
+install(
+  DIRECTORY include/
+  DESTINATION include/ros2_control_test_assets
 )
+install(TARGETS ros2_control_test_assets
+  EXPORT export_ros2_control_test_assets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_targets(export_ros2_control_test_assets HAS_LIBRARY_TARGET)
 ament_package()

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -1,98 +1,80 @@
-cmake_minimum_required(VERSION 3.5)
-project(transmission_interface)
+cmake_minimum_required(VERSION 3.16)
+project(transmission_interface LANGUAGES CXX)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-    hardware_interface
-    pluginlib
-    rclcpp
-)
-
 find_package(ament_cmake REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
-endforeach()
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
-
-add_library(${PROJECT_NAME} SHARED
+add_library(transmission_interface SHARED
   src/simple_transmission_loader.cpp
   src/four_bar_linkage_transmission_loader.cpp
   src/differential_transmission_loader.cpp
 )
-target_include_directories(${PROJECT_NAME} PUBLIC include)
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_include_directories(transmission_interface PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/transmission_interface>
+)
+target_link_libraries(transmission_interface PUBLIC
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+)
+pluginlib_export_plugin_description_file(transmission_interface ros2_control_plugins.xml)
 
-pluginlib_export_plugin_description_file(${PROJECT_NAME} ros2_control_plugins.xml)
+if(BUILD_TESTING)
+  find_package(ament_cmake_gmock REQUIRED)
 
-install(TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
+  ament_add_gmock(test_simple_transmission
+    test/simple_transmission_test.cpp
+  )
+  target_link_libraries(test_simple_transmission transmission_interface)
+
+  ament_add_gmock(test_differential_transmission
+    test/differential_transmission_test.cpp
+  )
+  target_link_libraries(test_differential_transmission transmission_interface)
+
+  ament_add_gmock(test_four_bar_linkage_transmission
+    test/four_bar_linkage_transmission_test.cpp
+  )
+  target_link_libraries(test_four_bar_linkage_transmission transmission_interface)
+
+  ament_add_gmock(test_simple_transmission_loader
+    test/simple_transmission_loader_test.cpp
+  )
+  target_link_libraries(test_simple_transmission_loader transmission_interface)
+
+  ament_add_gmock(test_four_bar_linkage_transmission_loader
+    test/four_bar_linkage_transmission_loader_test.cpp
+  )
+  target_link_libraries(test_four_bar_linkage_transmission_loader transmission_interface)
+
+  ament_add_gmock(test_differential_transmission_loader
+    test/differential_transmission_loader_test.cpp
+  )
+  target_link_libraries(test_differential_transmission_loader transmission_interface)
+endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION include/transmission_interface
+)
+install(TARGETS transmission_interface
+  EXPORT export_transmission_interface
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_gmock REQUIRED)
-
-  ament_add_gmock(
-    test_simple_transmission
-    test/simple_transmission_test.cpp
-  )
-  target_include_directories(test_simple_transmission PUBLIC include hardware_interface)
-  ament_target_dependencies(test_simple_transmission hardware_interface)
-
-  ament_add_gmock(
-    test_differential_transmission
-    test/differential_transmission_test.cpp
-  )
-  target_include_directories(test_differential_transmission PUBLIC include hardware_interface)
-  ament_target_dependencies(test_differential_transmission hardware_interface)
-
-  ament_add_gmock(
-    test_four_bar_linkage_transmission
-    test/four_bar_linkage_transmission_test.cpp
-  )
-  target_include_directories(test_four_bar_linkage_transmission PUBLIC include hardware_interface)
-  ament_target_dependencies(test_four_bar_linkage_transmission hardware_interface)
-
-  ament_add_gmock(
-    test_simple_transmission_loader
-    test/simple_transmission_loader_test.cpp
-  )
-  target_include_directories(test_simple_transmission_loader PUBLIC include hardware_interface)
-  ament_target_dependencies(test_simple_transmission_loader hardware_interface)
-
-  ament_add_gmock(
-    test_four_bar_linkage_transmission_loader
-    test/four_bar_linkage_transmission_loader_test.cpp
-  )
-  target_include_directories(test_four_bar_linkage_transmission_loader PUBLIC include hardware_interface)
-  ament_target_dependencies(test_four_bar_linkage_transmission_loader hardware_interface)
-
-  ament_add_gmock(
-    test_differential_transmission_loader
-    test/differential_transmission_loader_test.cpp
-  )
-  target_include_directories(test_differential_transmission_loader PUBLIC include hardware_interface)
-  ament_target_dependencies(test_differential_transmission_loader hardware_interface)
-endif()
-
-ament_export_include_directories(
-  include
-)
+ament_export_targets(export_transmission_interface HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   hardware_interface
+  pluginlib
+  rclcpp
 )
-
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
-
 ament_package()


### PR DESCRIPTION
- Fix overriding of install: hardware_interface
- Fix overriding of install: controller_interface
- Fix overriding of install: ros2_control_test_assets
- Fix overriding of install: controller_manager
- Fix overriding of install: controller_manager_msgs
- Fix overriding of install: joint_limits
- Fix overriding of install: transmission_interface
- Upgrade CMake version

# Description

This is related to:
- https://github.com/ros-controls/kinematics_interface/pull/13

Here are the colcon docs on overriding: https://colcon.readthedocs.io/en/released/user/overriding-packages.html#how-to-make-it-easier-for-your-users-to-override

Here is the ament_cmake user guide: https://docs.ros.org/en/rolling/How-To-Guides/Ament-CMake-Documentation.html

These changes have been tested locally and are in line with the changes we have been making to CMake for MoveIt. There are a few goals here:
- Standardize the way we use CMake to be more declarative and modern
- Correctly use the ament tooling so building a source copy of this repo on a machine with a binary install works (also called overriding)

One thing I did not do is turn on `-Werror` or increase the warning set when building this library. Given the time I'll follow up with PRs that fix the warnings and turn on `-Werror`.