### PR TITLE
Fix wrong CLI output of controller states

### DIFF
--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -157,7 +157,7 @@ load_controller
       -h, --help            show this help message and exit
       --spin-time SPIN_TIME
                             Spin time in seconds to wait for discovery (only applies when not using an already running daemon)
-      --set_state {configured,active}
+      --set_state {inactive,active}
                             Set the state of the loaded controller
       -c CONTROLLER_MANAGER, --controller-manager CONTROLLER_MANAGER
                             Name of the controller manager ROS node

--- a/ros2controlcli/ros2controlcli/verb/load_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_controller.py
@@ -30,7 +30,7 @@ class LoadControllerVerb(VerbExtension):
         arg.completer = ControllerNameCompleter()
         arg = parser.add_argument(
             "--set-state",
-            choices=["configured", "active"],
+            choices=["inactive", "active"],
             help="Set the state of the loaded controller",
         )
         add_controller_mgr_parsers(parser)
@@ -64,6 +64,6 @@ class LoadControllerVerb(VerbExtension):
 
             print(
                 f"Successfully loaded controller {args.controller_name} into "
-                f'state { "inactive" if args.set_state == "configure" else "active" }'
+                f'state { "inactive" if args.set_state == "inactive" else "active" }'
             )
             return 0

--- a/ros2controlcli/ros2controlcli/verb/set_controller_state.py
+++ b/ros2controlcli/ros2controlcli/verb/set_controller_state.py
@@ -74,7 +74,7 @@ class SetControllerStateVerb(VerbExtension):
                     if not response.ok:
                         return "Error configuring controller, check controller_manager logs"
 
-                    print(f"successfully configured {args.controller_name}")
+                    print(f"Successfully configured {args.controller_name}")
                     return 0
 
                 elif matched_controller.state == "active":
@@ -84,7 +84,7 @@ class SetControllerStateVerb(VerbExtension):
                     if not response.ok:
                         return "Error stopping controller, check controller_manager logs"
 
-                    print(f"successfully deactivated {args.controller_name}")
+                    print(f"Successfully deactivated {args.controller_name}")
                     return 0
 
                 else:
@@ -109,5 +109,5 @@ class SetControllerStateVerb(VerbExtension):
                 if not response.ok:
                     return "Error activating controller, check controller_manager logs"
 
-                print(f"successfully activated {args.controller_name}")
+                print(f"Successfully activated {args.controller_name}")
                 return 0


### PR DESCRIPTION
- Change in [line 67 of ros2controlcli/ros2controlcli/verb/load_controller.py](https://github.com/ros-controls/ros2_control/pull/947/files#diff-ece6d773af98dbf80ab71ee2d8003a64d088cc968e0129e92a04535cb1a526d2L67-R67) fixes #786 
- I renamed the choices of load_controller.py to match set_controller_state: [inactive, active] 
