### PR TITLE
Fix AttributeError: 'Parameter' object attribute 'name' is read-only

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -219,7 +219,7 @@ def main(args=None):
         else:
             if controller_type:
                 parameter = Parameter()
-                Parameter.name = prefixed_controller_name + ".type"
+                parameter.name = prefixed_controller_name + ".type"
                 parameter.value = get_parameter_value(string_value=controller_type)
 
                 response = call_set_parameters(


### PR DESCRIPTION
Controller Manager Spawner dies. Bug introduced in https://github.com/ros-controls/ros2_control/pull/910
```
[spawner-5] [INFO] [1677569381.689833939] [spawner_joint_state_broadcaster]: Set controller type to "joint_state_broadcaster/JointStateBroadcaster" for joint_state_broadcaster
[gzserver-1] [INFO] [1677569381.690260863] [controller_manager]: Loading controller 'joint_state_broadcaster'
[gzserver-1] [INFO] [1677569381.696931235] [controller_manager]: Setting use_sim_time=True for joint_state_broadcaster to match controller manager (see ros2_control#325 for details)
[spawner-5] [INFO] [1677569381.704335963] [spawner_joint_state_broadcaster]: Loaded joint_state_broadcaster
[spawner-5] Traceback (most recent call last):
[spawner-5]   File "/home/user/exchange/humble/sim_ws/install/controller_manager/lib/controller_manager/spawner", line 33, in <module>
[spawner-5]     sys.exit(load_entry_point('controller-manager==2.23.0', 'console_scripts', 'spawner')())
[spawner-5]   File "/home/user/exchange/humble/sim_ws/install/controller_manager/local/lib/python3.10/dist-packages/controller_manager/spawner.py", line 212, in main
[spawner-5]     load_parameter_file(node=node, node_name=prefixed_controller_name, parameter_file=param_file,
[spawner-5]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2param/api/__init__.py", line 159, in load_parameter_file
[spawner-5]     load_parameter_dict(node=node, node_name=node_name, parameter_dict=param_dict)
[spawner-5]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2param/api/__init__.py", line 117, in load_parameter_dict
[spawner-5]     parameters = parse_parameter_dict(namespace='', parameter_dict=parameter_dict)
[spawner-5]   File "/opt/ros/humble/lib/python3.10/site-packages/ros2param/api/__init__.py", line 108, in parse_parameter_dict
[spawner-5]     parameter = Parameter()
[spawner-5]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rcl_interfaces/msg/_parameter.py", line 80, in __init__
[spawner-5]     self.name = kwargs.get('name', str())
[spawner-5] AttributeError: 'Parameter' object attribute 'name' is read-only
[ERROR] [spawner-5]: process has died [pid 39835, exit code 1, cmd '/home/user/exchange/humble/sim_ws/install/controller_manager/lib/controller_manager/spawner joint_state_broadcaster --controller-manager controller_manager --controller-type joint_state_broadcaster/JointStateBroadcaster --param-file /home/user/exchange/humble/sim_ws/install/pmb2_controller_configuration/share/pmb2_controller_configuration/config/joint_state_broadcaster.yaml --ros-args'].
```