### PR TITLE
Add missing build_export_depends to controller_interface

### DIFF
--- a/controller_interface/package.xml
+++ b/controller_interface/package.xml
@@ -14,6 +14,9 @@
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>rclcpp_lifecycle</build_export_depend>
+
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>sensor_msgs</test_depend>
 


### PR DESCRIPTION
These missing dependencies are not currently causing buildfarm problems because downstream packages have test dependencies on these, so they're getting installed anyway.

In an effort to streamline the buildfarm, we're considering disabling the tests in packaging jobs and dropping the unused dependencies. Test builds with this configuration have uncovered a few packaging bugs, and this is one of them.

To avoid regressing this package when we make this change, please release this change soon.

Thanks!