### PR TITLE
Fix verbose output of list_hardware_components

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
@@ -65,17 +65,12 @@ class ListHardwareComponentsVerb(VerbExtension):
 
                 if args.verbose:
                     print("\tstate interfaces")
-                    for state_interface in component.command_interfaces:
+                    for state_interface in component.state_interfaces:
                         if state_interface.is_available:
                             available_str = f"{bcolors.OKBLUE}[available]{bcolors.ENDC}"
                         else:
                             available_str = f"{bcolors.WARNING}[unavailable]{bcolors.ENDC}"
 
-                        if state_interface.is_claimed:
-                            claimed_str = f"{bcolors.OKBLUE}[claimed]{bcolors.ENDC}"
-                        else:
-                            claimed_str = "[unclaimed]"
-
-                        print(f"\t\t{state_interface.name} {available_str} {claimed_str}")
+                        print(f"\t\t{state_interface.name} {available_str}")
 
         return 0


### PR DESCRIPTION
Fixes #999. Additionally, claimed state of state interfaces is always false -> removed output.

Using `ros2_control_demo_example_4`: 

Before
```
$ ros2 control list_hardware_components -v
Hardware Component 0
        name: RRBotSystemWithSensor
        type: system
        plugin name: ros2_control_demo_example_4/RRBotSystemWithSensorHardware
        state: id=3 label=active
        command interfaces
                joint1/position [available] [claimed]
                joint2/position [available] [claimed]
        state interfaces
                joint1/position [available] [claimed]
                joint2/position [available] [claimed]
```
After
```
$ ros2 control list_hardware_components -v
Hardware Component 0
        name: RRBotSystemWithSensor
        type: system
        plugin name: ros2_control_demo_example_4/RRBotSystemWithSensorHardware
        state: id=3 label=active
        command interfaces
                joint1/position [available] [claimed]
                joint2/position [available] [claimed]
        state interfaces
                joint1/position [available]
                joint2/position [available]
                tcp_fts_sensor/force.x [available]
                tcp_fts_sensor/torque.z [available]
```

