### PR TITLE
docs: Fix link to hardware_components

### DIFF
--- a/hardware_interface/doc/hardware_components_userdoc.rst
+++ b/hardware_interface/doc/hardware_components_userdoc.rst
@@ -4,7 +4,7 @@ Hardware Components
 -------------------
 Hardware components represent abstraction of physical hardware in ros2_control framework.
 There are three types of hardware Actuator, Sensor and System.
-For details on each type check `Hardware Components description <https://control.ros.org/master/doc/getting_started/getting_started.html#hardware-components>`_.
+For details on each type check :ref:`overview_hardware_components` description.
 
 Guidelines and Best Practices
 *****************************

--- a/hardware_interface/doc/hardware_components_userdoc.rst
+++ b/hardware_interface/doc/hardware_components_userdoc.rst
@@ -4,7 +4,7 @@ Hardware Components
 -------------------
 Hardware components represent abstraction of physical hardware in ros2_control framework.
 There are three types of hardware Actuator, Sensor and System.
-For details on each type check `Hardware Components description <https://ros-controls.github.io/control.ros.org/getting_started.html#hardware-components>`_.
+For details on each type check `Hardware Components description <https://control.ros.org/master/doc/getting_started/getting_started.html#hardware-components>`_.
 
 Guidelines and Best Practices
 *****************************


### PR DESCRIPTION
Fix the link to the hardware_components documentation to a working version.

The link that was there is obviously dead. I'm not sure whether linking to the master version is the correct solution to handle this, but at least it works.