### PR TITLE
Pass Down Command Data From An Arbitrary ROS2 Controller To The Hardware Interface

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -106,6 +106,19 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual InterfaceConfiguration state_interface_configuration() const = 0;
 
+  /// Get configuration for controller's optional command_data param.
+  /**
+   * Method used by the controller_manager to get the optional command_data used by the controller.
+   * Each controller can use individual method to determine interface names that in simples case
+   * have the following format: `<joint>/<command_data>`.
+   * The method is called only in `active` state, i.e., `on_configure` has to be
+   * called first.
+   *
+   * \returns configuration of command_data.
+   */
+  CONTROLLER_INTERFACE_PUBLIC
+  virtual std::vector<std::string> command_data_configuration() const { return std::vector<std::string>(); }
+
   CONTROLLER_INTERFACE_PUBLIC
   void assign_interfaces(
     std::vector<hardware_interface::LoanedCommandInterface> && command_interfaces,

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -499,7 +499,7 @@ private:
   std::vector<std::string> activate_request_, deactivate_request_;
   std::vector<std::string> to_chained_mode_request_, from_chained_mode_request_;
   std::vector<std::string> activate_command_interface_request_,
-    deactivate_command_interface_request_;
+    deactivate_command_interface_request_, activate_command_data_request_;
 
   struct SwitchParams
   {

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -880,7 +880,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     };
 
     const auto extract_command_data_for_controller =
-      [this](const ControllerSpec controller, std::vector<std::string> & request_data_list)
+      [](const ControllerSpec controller, std::vector<std::string> & request_data_list)
     {
       std::vector<std::string> command_data_names = controller.c->command_data_configuration();
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -532,6 +532,7 @@ void ControllerManager::clear_requests()
   activate_request_.clear();
   to_chained_mode_request_.clear();
   from_chained_mode_request_.clear();
+  activate_command_data_request_.clear();
   activate_command_interface_request_.clear();
   deactivate_command_interface_request_.clear();
 }
@@ -557,6 +558,14 @@ controller_interface::return_type ControllerManager::switch_controller(
     RCLCPP_FATAL(
       get_logger(),
       "The internal deactivate and activat requests command interface lists are not empty at the "
+      "switch_controller() call. This should never happen.");
+    throw std::runtime_error("CM's internal state is not correct. See the FATAL message above.");
+  }
+  if (!activate_command_data_request_.empty())
+  {
+    RCLCPP_FATAL(
+      get_logger(),
+      "The internal activate requests command data list is not empty at the "
       "switch_controller() call. This should never happen.");
     throw std::runtime_error("CM's internal state is not correct. See the FATAL message above.");
   }
@@ -801,6 +810,7 @@ controller_interface::return_type ControllerManager::switch_controller(
         deactivate_command_interface_request_.clear();
         activate_request_.clear();
         activate_command_interface_request_.clear();
+        activate_command_data_request_.clear();
         to_chained_mode_request_.clear();
         from_chained_mode_request_.clear();
         return controller_interface::return_type::ERROR;
@@ -869,9 +879,20 @@ controller_interface::return_type ControllerManager::switch_controller(
         command_interface_names.end());
     };
 
+    const auto extract_command_data_for_controller =
+      [this](const ControllerSpec controller, std::vector<std::string> & request_data_list)
+    {
+      std::vector<std::string> command_data_names = controller.c->command_data_configuration();
+
+      request_data_list.insert(
+        request_data_list.end(), command_data_names.begin(),
+        command_data_names.end());
+    };
+
     if (in_activate_list)
     {
       extract_interfaces_for_controller(controller, activate_command_interface_request_);
+      extract_command_data_for_controller(controller, activate_command_data_request_);
     }
     if (in_deactivate_list)
     {
@@ -929,7 +950,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     !activate_command_interface_request_.empty() || !deactivate_command_interface_request_.empty())
   {
     if (!resource_manager_->prepare_command_mode_switch(
-          activate_command_interface_request_, deactivate_command_interface_request_))
+          activate_command_interface_request_, deactivate_command_interface_request_, activate_command_data_request_))
     {
       RCLCPP_ERROR(
         get_logger(),
@@ -1058,7 +1079,7 @@ void ControllerManager::manage_switch()
 {
   // Ask hardware interfaces to change mode
   if (!resource_manager_->perform_command_mode_switch(
-        activate_command_interface_request_, deactivate_command_interface_request_))
+        activate_command_interface_request_, deactivate_command_interface_request_, activate_command_data_request_))
   {
     RCLCPP_ERROR(get_logger(), "Error while performing mode switch.");
   }

--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -73,12 +73,14 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   return_type prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   HARDWARE_INTERFACE_PUBLIC
   return_type perform_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   HARDWARE_INTERFACE_PUBLIC
   std::string get_name() const;

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -140,6 +140,14 @@ public:
     return return_type::OK;
   }
 
+  virtual return_type prepare_command_mode_switch(
+    const std::vector<std::string> & /*start_interfaces*/,
+    const std::vector<std::string> & /*stop_interfaces*/,
+    const std::vector<std::string> & /*command_data*/)
+  {
+    return return_type::OK;
+  }
+
   // Perform switching to the new command interface.
   /**
    * Perform the mode-switching for the new command interface combination.
@@ -155,6 +163,14 @@ public:
   virtual return_type perform_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
+  {
+    return return_type::OK;
+  }
+
+  virtual return_type perform_command_mode_switch(
+    const std::vector<std::string> & /*start_interfaces*/,
+    const std::vector<std::string> & /*stop_interfaces*/,
+    const std::vector<std::string> & /*command_data*/)
   {
     return return_type::OK;
   }

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -318,7 +318,8 @@ public:
    */
   bool prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   /// Notify the hardware components that realtime hardware mode switching should occur.
   /**
@@ -333,7 +334,8 @@ public:
    */
   bool perform_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   /// Sets state of hardware component.
   /**

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -72,12 +72,14 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   return_type prepare_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   HARDWARE_INTERFACE_PUBLIC
   return_type perform_command_mode_switch(
     const std::vector<std::string> & start_interfaces,
-    const std::vector<std::string> & stop_interfaces);
+    const std::vector<std::string> & stop_interfaces,
+    const std::vector<std::string> & command_data);
 
   HARDWARE_INTERFACE_PUBLIC
   std::string get_name() const;

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -141,6 +141,14 @@ public:
     return return_type::OK;
   }
 
+  virtual return_type prepare_command_mode_switch(
+    const std::vector<std::string> & /*start_interfaces*/,
+    const std::vector<std::string> & /*stop_interfaces*/,
+    const std::vector<std::string> & /*command_data*/)
+  {
+    return return_type::OK;
+  }
+
   // Perform switching to the new command interface.
   /**
    * Perform the mode-switching for the new command interface combination.
@@ -156,6 +164,14 @@ public:
   virtual return_type perform_command_mode_switch(
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/)
+  {
+    return return_type::OK;
+  }
+
+  virtual return_type perform_command_mode_switch(
+    const std::vector<std::string> & /*start_interfaces*/,
+    const std::vector<std::string> & /*stop_interfaces*/,
+    const std::vector<std::string> & /*command_data*/)
   {
     return return_type::OK;
   }

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -200,16 +200,26 @@ std::vector<CommandInterface> Actuator::export_command_interfaces()
 
 return_type Actuator::prepare_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
-  return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces);
+  if (command_data.empty())
+  {
+    return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces);
+  }
+  return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces, command_data);
 }
 
 return_type Actuator::perform_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
-  return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
+  if (command_data.empty())
+  {
+    return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
+  }
+  return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces, command_data);
 }
 
 std::string Actuator::get_name() const { return impl_->get_name(); }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -905,7 +905,8 @@ std::unordered_map<std::string, HardwareComponentInfo> ResourceManager::get_comp
 // CM API: Called in "callback/slow"-thread
 bool ResourceManager::prepare_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
   auto interfaces_to_string = [&]()
   {
@@ -927,7 +928,7 @@ bool ResourceManager::prepare_command_mode_switch(
 
   for (auto & component : resource_storage_->actuators_)
   {
-    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
+    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces, command_data))
     {
       RCUTILS_LOG_ERROR_NAMED(
         "resource_manager", "Component '%s' did not accept new command resource combination: \n %s",
@@ -937,7 +938,7 @@ bool ResourceManager::prepare_command_mode_switch(
   }
   for (auto & component : resource_storage_->systems_)
   {
-    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
+    if (return_type::OK != component.prepare_command_mode_switch(start_interfaces, stop_interfaces, command_data))
     {
       RCUTILS_LOG_ERROR_NAMED(
         "resource_manager", "Component '%s' did not accept new command resource combination: \n %s",
@@ -951,11 +952,12 @@ bool ResourceManager::prepare_command_mode_switch(
 // CM API: Called in "update"-thread
 bool ResourceManager::perform_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
   for (auto & component : resource_storage_->actuators_)
   {
-    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces))
+    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces, command_data))
     {
       RCUTILS_LOG_ERROR_NAMED(
         "resource_manager", "Component '%s' could not perform switch",
@@ -965,7 +967,7 @@ bool ResourceManager::perform_command_mode_switch(
   }
   for (auto & component : resource_storage_->systems_)
   {
-    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces))
+    if (return_type::OK != component.perform_command_mode_switch(start_interfaces, stop_interfaces, command_data))
     {
       RCUTILS_LOG_ERROR_NAMED(
         "resource_manager", "Component '%s' could not perform switch",

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -196,16 +196,26 @@ std::vector<CommandInterface> System::export_command_interfaces()
 
 return_type System::prepare_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
-  return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces);
+  if (command_data.empty())
+  {
+    return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces);
+  }
+  return impl_->prepare_command_mode_switch(start_interfaces, stop_interfaces, command_data);
 }
 
 return_type System::perform_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
-  const std::vector<std::string> & stop_interfaces)
+  const std::vector<std::string> & stop_interfaces,
+  const std::vector<std::string> & command_data)
 {
-  return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
+  if (command_data.empty())
+  {
+    return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
+  }
+  return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces, command_data);
 }
 
 std::string System::get_name() const { return impl_->get_name(); }

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -505,9 +505,9 @@ TEST(TestComponentInterfaces, dummy_actuator)
   }
 
   EXPECT_EQ(
-    hardware_interface::return_type::OK, actuator_hw.prepare_command_mode_switch({""}, {""}));
+    hardware_interface::return_type::OK, actuator_hw.prepare_command_mode_switch({""}, {""}, {""}));
   EXPECT_EQ(
-    hardware_interface::return_type::OK, actuator_hw.perform_command_mode_switch({""}, {""}));
+    hardware_interface::return_type::OK, actuator_hw.perform_command_mode_switch({""}, {""}, {""}));
 }
 
 TEST(TestComponentInterfaces, dummy_sensor)
@@ -661,8 +661,8 @@ TEST(TestComponentInterfaces, dummy_system)
     ASSERT_EQ(hardware_interface::return_type::ERROR, system_hw.write(TIME, PERIOD));
   }
 
-  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch({}, {}));
-  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.perform_command_mode_switch({}, {}));
+  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch({}, {}, {}));
+  EXPECT_EQ(hardware_interface::return_type::OK, system_hw.perform_command_mode_switch({}, {}, {}));
 }
 
 TEST(TestComponentInterfaces, dummy_command_mode_system)
@@ -680,20 +680,20 @@ TEST(TestComponentInterfaces, dummy_command_mode_system)
   // Only calls with (one_key, two_keys) should return OK
   EXPECT_EQ(
     hardware_interface::return_type::ERROR,
-    system_hw.prepare_command_mode_switch(one_key, one_key));
+    system_hw.prepare_command_mode_switch(one_key, one_key, {}));
   EXPECT_EQ(
     hardware_interface::return_type::ERROR,
-    system_hw.perform_command_mode_switch(one_key, one_key));
+    system_hw.perform_command_mode_switch(one_key, one_key, {}));
   EXPECT_EQ(
-    hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch(one_key, two_keys));
+    hardware_interface::return_type::OK, system_hw.prepare_command_mode_switch(one_key, two_keys, {}));
   EXPECT_EQ(
-    hardware_interface::return_type::OK, system_hw.perform_command_mode_switch(one_key, two_keys));
-  EXPECT_EQ(
-    hardware_interface::return_type::ERROR,
-    system_hw.prepare_command_mode_switch(two_keys, one_key));
+    hardware_interface::return_type::OK, system_hw.perform_command_mode_switch(one_key, two_keys, {}));
   EXPECT_EQ(
     hardware_interface::return_type::ERROR,
-    system_hw.perform_command_mode_switch(two_keys, one_key));
+    system_hw.prepare_command_mode_switch(two_keys, one_key, {}));
+  EXPECT_EQ(
+    hardware_interface::return_type::ERROR,
+    system_hw.perform_command_mode_switch(two_keys, one_key, {}));
 }
 
 TEST(TestComponentInterfaces, dummy_actuator_read_error_behavior)

--- a/hardware_interface/test/test_resource_manager.cpp
+++ b/hardware_interface/test/test_resource_manager.cpp
@@ -373,8 +373,8 @@ TEST_F(ResourceManagerTest, default_prepare_perform_switch)
   // Activate components to get all interfaces available
   activate_components(rm);
 
-  EXPECT_TRUE(rm.prepare_command_mode_switch({""}, {""}));
-  EXPECT_TRUE(rm.perform_command_mode_switch({""}, {""}));
+  EXPECT_TRUE(rm.prepare_command_mode_switch({""}, {""}, {""}));
+  EXPECT_TRUE(rm.perform_command_mode_switch({""}, {""}, {""}));
 }
 
 const auto hardware_resources_command_modes =
@@ -411,30 +411,30 @@ TEST_F(ResourceManagerTest, custom_prepare_perform_switch)
   std::vector<std::string> legal_keys_position = {"joint1/position", "joint2/position"};
   std::vector<std::string> legal_keys_velocity = {"joint1/velocity", "joint2/velocity"};
   // Default behavior for empty key lists
-  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, empty_keys, empty_keys));
 
   // Default behavior when given irrelevant keys
-  EXPECT_TRUE(rm.prepare_command_mode_switch(irrelevant_keys, irrelevant_keys));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(irrelevant_keys, empty_keys));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, irrelevant_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(irrelevant_keys, irrelevant_keys, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(irrelevant_keys, empty_keys, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, irrelevant_keys, empty_keys));
 
   // The test hardware interface has a criteria that both joints must change mode
-  EXPECT_FALSE(rm.prepare_command_mode_switch(illegal_single_key, illegal_single_key));
-  EXPECT_FALSE(rm.prepare_command_mode_switch(illegal_single_key, empty_keys));
-  EXPECT_FALSE(rm.prepare_command_mode_switch(empty_keys, illegal_single_key));
+  EXPECT_FALSE(rm.prepare_command_mode_switch(illegal_single_key, illegal_single_key, empty_keys));
+  EXPECT_FALSE(rm.prepare_command_mode_switch(illegal_single_key, empty_keys, empty_keys));
+  EXPECT_FALSE(rm.prepare_command_mode_switch(empty_keys, illegal_single_key, empty_keys));
 
   // Test legal start keys
-  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_position, legal_keys_position));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_velocity, legal_keys_velocity));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_position, empty_keys));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, legal_keys_position));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_velocity, empty_keys));
-  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, legal_keys_velocity));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_position, legal_keys_position, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_velocity, legal_keys_velocity, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_position, empty_keys, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, legal_keys_position, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(legal_keys_velocity, empty_keys, empty_keys));
+  EXPECT_TRUE(rm.prepare_command_mode_switch(empty_keys, legal_keys_velocity, empty_keys));
 
   // Test rejection from perform_command_mode_switch, test hardware rejects empty start sets
-  EXPECT_TRUE(rm.perform_command_mode_switch(legal_keys_position, legal_keys_position));
-  EXPECT_FALSE(rm.perform_command_mode_switch(empty_keys, empty_keys));
-  EXPECT_FALSE(rm.perform_command_mode_switch(empty_keys, legal_keys_position));
+  EXPECT_TRUE(rm.perform_command_mode_switch(legal_keys_position, legal_keys_position, empty_keys));
+  EXPECT_FALSE(rm.perform_command_mode_switch(empty_keys, empty_keys, empty_keys));
+  EXPECT_FALSE(rm.perform_command_mode_switch(empty_keys, legal_keys_position, empty_keys));
 }
 
 TEST_F(ResourceManagerTest, resource_status)


### PR DESCRIPTION
Adds desired feature from https://github.com/ros-controls/ros2_controllers/issues/568

This is a PR to the master branch as opposed to the last one which was a PR to the Humble branch.