### PR TITLE
Remove log-level argument from spawner script

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -184,13 +184,6 @@ def main(args=None):
         default=10,
         type=int,
     )
-    parser.add_argument(
-        "--log-level",
-        help="Log level for spawner node",
-        required=False,
-        choices=["debug", "info", "warn", "error", "fatal"],
-        default="info",
-    )
 
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]
     args = parser.parse_args(command_line_args)
@@ -200,15 +193,6 @@ def main(args=None):
     param_file = args.param_file
     controller_type = args.controller_type
     controller_manager_timeout = args.controller_manager_timeout
-    log_level = args.log_level
-
-    loglevel_to_severity = {
-        "debug": rclpy.logging.LoggingSeverity.DEBUG,
-        "info": rclpy.logging.LoggingSeverity.INFO,
-        "warn": rclpy.logging.LoggingSeverity.WARN,
-        "error": rclpy.logging.LoggingSeverity.ERROR,
-        "fatal": rclpy.logging.LoggingSeverity.FATAL,
-    }
 
     if param_file and not os.path.isfile(param_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
@@ -218,7 +202,6 @@ def main(args=None):
         prefixed_controller_name = controller_namespace + "/" + controller_name
 
     node = Node("spawner_" + controller_name)
-    rclpy.logging.set_logger_level("spawner_" + controller_name, loglevel_to_severity[log_level])
 
     if not controller_manager_name.startswith("/"):
         spawner_namespace = node.get_namespace()


### PR DESCRIPTION
This change is to partially revert the changes in [PR 972](https://github.com/ros-controls/ros2_control/pull/972) which added a log-level argument to the spawner to control the output of the spawner node using the logging level. It turns out that using standard ros-args conventions for the 'ros2 run' command to set the logging level was sufficient.

So instead of adding a new way to set the logging level of the spawner with:

ros2 run controller_manager spawner <controller> --log-level WARN

the old way using ros-args was sufficient:

ros2 run controller_manager spawner <controller> --ros-args --log-level WARN

I have tested that this works.