### PR TITLE
[Humble] Revert "Add diagnostics (backport #820) (#922)"

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -9,7 +9,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
     ament_index_cpp
     controller_interface
     controller_manager_msgs
-    diagnostic_updater
     hardware_interface
     pluginlib
     rclcpp

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -40,7 +40,6 @@
 #include "controller_manager_msgs/srv/switch_controller.hpp"
 #include "controller_manager_msgs/srv/unload_controller.hpp"
 
-#include "diagnostic_updater/diagnostic_updater.hpp"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/resource_manager.hpp"
 
@@ -349,9 +348,6 @@ private:
   controller_interface::return_type check_preceeding_controllers_for_deactivate(
     const std::vector<ControllerSpec> & controllers, int strictness,
     const ControllersListIterator controller_it);
-
-  void controller_activity_diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  diagnostic_updater::Updater diagnostics_updater_;
 
   std::shared_ptr<rclcpp::Executor> executor_;
 

--- a/controller_manager/package.xml
+++ b/controller_manager/package.xml
@@ -15,7 +15,6 @@
   <depend>backward_ros</depend>
   <depend>controller_interface</depend>
   <depend>controller_manager_msgs</depend>
-  <depend>diagnostic_updater</depend>
   <depend>hardware_interface</depend>
   <depend>launch</depend>
   <depend>launch_ros</depend>


### PR DESCRIPTION
This fixes the most frequent cause of the segfault described in #979.

In Humble accessing the state of a lifecycle node [is not thread-safe](https://github.com/ros2/rclcpp/issues/1746), and because the diagnostic updater that was added in #922 gets the node state within a timer callback separately from the main `update()` cycle, it eventually causes the controller manager to crash.

Removing the diagnostic updater prevents this situation from happening. We can add it back in once [this PR to resolve the underlying thread safety issue in Humble rclcpp](https://github.com/ros2/rclcpp/pull/2183) has been merged.

This reverts commit dca10f44cc38b91db9ebaa26418880abba974996.