### PR TITLE
Fix github links on control.ros.org

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/doc/index.rst
+
 .. _ros2_control_framework:
 
 #################

--- a/hardware_interface/doc/hardware_components_userdoc.rst
+++ b/hardware_interface/doc/hardware_components_userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/hardware_components_userdoc.rst
+
 .. _hardware_components_userdoc:
 
 Hardware Components

--- a/hardware_interface/doc/mock_components_userdoc.rst
+++ b/hardware_interface/doc/mock_components_userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/mock_components_userdoc.rst
+
 .. _mock_components_userdoc:
 
 Mock Components

--- a/hardware_interface/doc/writing_new_hardware_interface.rst
+++ b/hardware_interface/doc/writing_new_hardware_interface.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/writing_new_hardware_interface.rst
+
 .. _writing_new_hardware_interface:
 
 Writing a new hardware interface

--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/ros2controlcli/doc/userdoc.rst
+
 .. _ros2controlcli_userdoc:
 
 Command Line Interface


### PR DESCRIPTION
This is a companion PR to https://github.com/ros-controls/control.ros.org/pull/85. More details can be found there.