### PR TITLE
controller_manager_srvs tests: Add text to assertions

### DIFF
--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -91,11 +91,17 @@ public:
     const std::string & name, const std::string & type, const std::string & plugin_name,
     const uint8_t state_id, const std::string & state_label)
   {
-    EXPECT_EQ(component.name, name);
-    EXPECT_EQ(component.type, type);
-    EXPECT_EQ(component.plugin_name, plugin_name);
-    EXPECT_EQ(component.state.id, state_id);
-    EXPECT_EQ(component.state.label, state_label);
+    EXPECT_EQ(component.name, name) << "Component has unexpected name.";
+    EXPECT_EQ(component.type, type)
+      << "Component " << name << " from plugin " << plugin_name << " has wrong type.";
+    EXPECT_EQ(component.plugin_name, plugin_name)
+      << "Component " << name << " (" << type << ") has unexpected plugin_name.";
+    EXPECT_EQ(component.state.id, state_id)
+      << "Component " << name << " (" << type << ") from plugin " << plugin_name
+      << " has wrong state_id.";
+    EXPECT_EQ(component.state.label, state_label)
+      << "Component " << name << " (" << type << ") from plugin " << plugin_name
+      << " has wrong state_label.";
   }
 
   void list_hardware_components_and_check(
@@ -124,8 +130,9 @@ public:
       {
         auto it = std::find(interface_names.begin(), interface_names.end(), interfaces[i].name);
         EXPECT_NE(it, interface_names.end());
-        EXPECT_EQ(interfaces[i].is_available, is_available_status[i]);
-        EXPECT_EQ(interfaces[i].is_claimed, is_claimed_status[i]);
+        EXPECT_EQ(interfaces[i].is_available, is_available_status[i])
+          << "At " << interfaces[i].name;
+        EXPECT_EQ(interfaces[i].is_claimed, is_claimed_status[i]) << "At " << interfaces[i].name;
       }
     };
 


### PR DESCRIPTION
This should make debugging failed tests easier.

With this test a flip in a test matrix such as

https://github.com/ros-controls/ros2_control/blob/5065d0c22faa021aadceea3c42407a9b9e724eb7/controller_manager/test/test_hardware_management_srvs.cpp#L230-L247

will produce a test output such as

```
/home/mauch/robot_folders/checkout/ros2_control/colcon_ws/src/ros2_control/controller_manager/test/test_hardware_management_srvs.cpp:133: Failure                                                                                           
Expected equality of these values:                                                                                                                                                                                                          
  interfaces[i].is_available                                                                                                                                                                                                                
    Which is: true                                                                                                                                                                                                                          
  is_available_status[i]                                                                                                                                                                                                                    
    Which is: false                                                                                                                                                                                                                         
At joint1/velocity                                                                                                                                                                                                                          
[  FAILED  ] TestControllerManagerHWManagementSrvs.list_hardware_components (104 ms)
```

while without this change it would only have been

```
/home/mauch/robot_folders/checkout/ros2_control/colcon_ws/src/ros2_control/controller_manager/test/test_hardware_management_srvs.cpp:133: Failure                                                                                           
Expected equality of these values:                                                                                                                                                                                                          
  interfaces[i].is_available                                                                                                                                                                                                                
    Which is: true                                                                                                                                                                                                                          
  is_available_status[i]                                                                                                                                                                                                                    
    Which is: false                                                                                                                                                                                                                                                                                                            
[  FAILED  ] TestControllerManagerHWManagementSrvs.list_hardware_components (104 ms)
```

which makes debugging this a lot harder, since the referenced line is from the reused function instead of the actual calling block.