### PR TITLE
Docs: Use branch name substitution for all links

### DIFF
--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/controller_manager/doc/userdoc.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/controller_manager/doc/userdoc.rst
 
 .. _controller_manager_userdoc:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/doc/index.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/doc/index.rst
 
 .. _ros2_control_framework:
 

--- a/hardware_interface/doc/hardware_components_userdoc.rst
+++ b/hardware_interface/doc/hardware_components_userdoc.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/hardware_components_userdoc.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/doc/hardware_components_userdoc.rst
 
 .. _hardware_components_userdoc:
 

--- a/hardware_interface/doc/mock_components_userdoc.rst
+++ b/hardware_interface/doc/mock_components_userdoc.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/mock_components_userdoc.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/doc/mock_components_userdoc.rst
 
 .. _mock_components_userdoc:
 

--- a/hardware_interface/doc/writing_new_hardware_interface.rst
+++ b/hardware_interface/doc/writing_new_hardware_interface.rst
@@ -139,6 +139,6 @@ That's it! Enjoy writing great controllers!
 Useful External References
 ---------------------------
 
-- `Templates and scripts for generating controllers shell <https://stoglrobotics.github.io/ros_team_workspace/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_ 
+- `Templates and scripts for generating controllers shell <https://stoglrobotics.github.io/ros_team_workspace/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_
 
   .. NOTE:: The script is currently only recommended to use for Foxy, not compatible with the API from Galactic and onwards.

--- a/hardware_interface/doc/writing_new_hardware_interface.rst
+++ b/hardware_interface/doc/writing_new_hardware_interface.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/hardware_interface/doc/writing_new_hardware_interface.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/doc/writing_new_hardware_interface.rst
 
 .. _writing_new_hardware_interface:
 
@@ -30,7 +30,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
    1. Take care that you use header guards. ROS2-style is using ``#ifndef`` and ``#define`` preprocessor directives. (For more information on this, a search engine is your friend :) ).
 
    2. Include ``"hardware_interface/$interface_type$_interface.hpp"`` and ``visibility_control.h`` if you are using one.
-      ``$interface_type$`` can be ``Actuator``, ``Sensor`` or ``System`` depending on the type of hardware you are using. for more details about each type check `Hardware Components description <https://control.ros.org/master/doc/getting_started/getting_started.html#hardware-components>`_.
+      ``$interface_type$`` can be ``Actuator``, ``Sensor`` or ``System`` depending on the type of hardware you are using. for more details about each type check :ref:`Hardware Components description <overview_hardware_components>`.
 
    3. Define a unique namespace for your hardware_interface. This is usually the package name written in ``snake_case``.
 
@@ -39,7 +39,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
       class HardwareInterfaceName : public hardware_interface::$InterfaceType$Interface
 
    5. Add a constructor without parameters and the following public methods implementing ``LifecycleNodeInterface``: ``on_configure``, ``on_cleanup``, ``on_shutdown``, ``on_activate``, ``on_deactivate``, ``on_error``; and overriding ``$InterfaceType$Interface`` definition: ``on_init``, ``export_state_interfaces``, ``export_command_interfaces``, ``prepare_command_mode_switch`` (optional), ``perform_command_mode_switch`` (optional), ``read``, ``write``.
-   For further explanation of hardware-lifecycle check the `pull request <https://github.com/ros-controls/ros2_control/pull/559/files#diff-2bd171d85b028c1b15b03b27d4e6dcbb87e52f705042bf111840e7a28ab268fc>`_ and for exact definitions of methods check the ``"hardware_interface/$interface_type$_interface.hpp"`` header or `doxygen documentation <https://control.ros.org/master/doc/api/namespacehardware__interface.html>`_ for *Actuator*, *Sensor* or *System*.
+   For further explanation of hardware-lifecycle check the `pull request <https://github.com/ros-controls/ros2_control/pull/559/files#diff-2bd171d85b028c1b15b03b27d4e6dcbb87e52f705042bf111840e7a28ab268fc>`_ and for exact definitions of methods check the ``"hardware_interface/$interface_type$_interface.hpp"`` header or `doxygen documentation <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/api/namespacehardware__interface.html>`_ for *Actuator*, *Sensor* or *System*.
 
 4. **Adding definitions into source file (.cpp)**
 
@@ -79,7 +79,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
 5. **Writing export definition for pluginlib**
 
    1. Create the ``<my_hardware_interface_package>.xml`` file in the package and add a definition of the library and hardware interface's class which has to be visible for the pluginlib.
-      The easiest way to do that is to check definition for mock components in the `hardware_interface mock_components <https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/mock_components_plugin_description.xml>`_ section.
+      The easiest way to do that is to check definition for mock components in the :ref:`hardware_interface mock_components <mock_components_userdoc>` section.
 
    2. Usually, the plugin name is defined by the package (namespace) and the class name, e.g.,
       ``<my_hardware_interface_package>/<RobotHardwareInterfaceName>``.
@@ -90,7 +90,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
 
    1. Create the folder ``test`` in your package, if it does not exist already, and add a file named ``test_load_<robot_hardware_interface_name>.cpp``.
 
-   2. You can copy the ``load_generic_system_2dof`` content defined in the `test_generic_system.cpp <https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/test/mock_components/test_generic_system.cpp#L402-L407>`_ package.
+   2. You can copy the ``load_generic_system_2dof`` content defined in the `test_generic_system.cpp <https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/test/mock_components/test_generic_system.cpp#L402-L407>`_ package.
 
    3. Change the name of the copied test and in the last line, where hardware interface type is specified put the name defined in ``<my_hardware_interface_package>.xml`` file, e.g., ``<my_hardware_interface_package>/<RobotHardwareInterfaceName>``.
 
@@ -115,7 +115,7 @@ The following is a step-by-step guide to create source files, basic tests, and c
    7. In the test section add the following dependencies: ``ament_cmake_gmock``, ``hardware_interface``.
 
    8. Add compile definitions for the tests using the ``ament_add_gmock`` directive.
-      For details, see how it is done for mock hardware in the `ros2_control <https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/CMakeLists.txt>`_ package.
+      For details, see how it is done for mock hardware in the `ros2_control <https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/CMakeLists.txt>`_ package.
 
    9. (optional) Add your hardware interface`s library into ``ament_export_libraries`` before ``ament_package()``.
 
@@ -139,4 +139,6 @@ That's it! Enjoy writing great controllers!
 Useful External References
 ---------------------------
 
-- `Templates and scripts for generating controllers shell <https://stoglrobotics.github.io/ros_team_workspace/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_ **NOTE**: The script is currently only recommended to use for Foxy, not compatible with the API from Galactic and onwards.
+- `Templates and scripts for generating controllers shell <https://stoglrobotics.github.io/ros_team_workspace/master/use-cases/ros2_control/setup_robot_hardware_interface.html>`_ 
+
+  .. NOTE:: The script is currently only recommended to use for Foxy, not compatible with the API from Galactic and onwards.

--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -1,4 +1,4 @@
-:github_url: https://github.com/ros-controls/ros2_control/blob/|github_branch|/ros2controlcli/doc/userdoc.rst
+:github_url: https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/ros2controlcli/doc/userdoc.rst
 
 .. _ros2controlcli_userdoc:
 


### PR DESCRIPTION
Using branch name substitutions now for every link. 

For details see https://github.com/ros-controls/control.ros.org/pull/98