### PR TITLE
Add -Wconversion flag to protect future developments

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(controller_interface LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wconversion)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(controller_manager LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wconversion)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(hardware_interface LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wconversion)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -367,7 +367,7 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
     component.command_interfaces.push_back(parse_interfaces_from_xml(command_interfaces_it));
     component.command_interfaces.back().data_type =
       parse_data_type_attribute(command_interfaces_it);
-    component.command_interfaces.back().size = parse_size_attribute(command_interfaces_it);
+    component.command_interfaces.back().size = static_cast<int>(parse_size_attribute(command_interfaces_it));
     command_interfaces_it = command_interfaces_it->NextSiblingElement(kCommandInterfaceTag);
   }
 
@@ -377,7 +377,7 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   {
     component.state_interfaces.push_back(parse_interfaces_from_xml(state_interfaces_it));
     component.state_interfaces.back().data_type = parse_data_type_attribute(state_interfaces_it);
-    component.state_interfaces.back().size = parse_size_attribute(state_interfaces_it);
+    component.state_interfaces.back().size = static_cast<int>(parse_size_attribute(state_interfaces_it));
     state_interfaces_it = state_interfaces_it->NextSiblingElement(kStateInterfaceTag);
   }
 

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(joint_limits LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra)
+  add_compile_options(-Wall -Wextra -Wconversion)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(transmission_interface LANGUAGES CXX)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wconversion)
 endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/transmission_interface/test/random_generator_utils.hpp
+++ b/transmission_interface/test/random_generator_utils.hpp
@@ -31,7 +31,7 @@ struct RandomDoubleGenerator
 public:
   RandomDoubleGenerator(double min_val, double max_val) : min_val_(min_val), max_val_(max_val)
   {
-    srand(time(nullptr));
+    srand(static_cast<unsigned int>(time(nullptr)));
   }
   double operator()()
   {


### PR DESCRIPTION
When working on `joint_limits`, I faced an issue with a `rclcpp::Duration` that I constructed using **seconds** and **nanoseconds**, but by mistake used a `float 0.005` for the seconds. Since the awaited arguments are `ints`, the `float` conversion led to a NULL duration which I did not realize for a too long time.

There was no compilation warning, as `-Wall` does not include  `-Wconversion`, supposedly to avoid too many warnings.
With that flag the warning looks like this 

```
rolling-ctrl-ws/src/ros2_control/joint_limits/test/test_simple_joint_limiter.cpp:224:29: warning: conversion from ‘double’ to ‘int32_t’ {aka ‘int’} changes value from ‘5.0000000000000001e-3’ to ‘0’ [-Wfloat-conversion]
  224 |     rclcpp::Duration period(0.005, 0);
```

I tested in `ros_control` package to add `-Wconversion` compilation flag which created only 2 warnings, that could be easily fixed with explicit cast. 

Hence, for protecting future developments from risky mistakes with conversions, I suggest to add this flag in all packages of the repo. I will provide a similar PR for `ros2_controllers` that were definitively affected by exactly the same Time-at-zero issue.
