### PR TITLE
Ensure instantiation of hardware classes work for python bindings

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -80,6 +80,10 @@ if(BUILD_TESTING)
   target_include_directories(test_macros PRIVATE include)
   ament_target_dependencies(test_macros rcpputils)
 
+  ament_add_gmock(test_inst_hardwares test/test_inst_hardwares.cpp)
+  target_link_libraries(test_inst_hardwares hardware_interface)
+  ament_target_dependencies(test_inst_hardwares rcpputils)
+  
   ament_add_gmock(test_joint_handle test/test_handle.cpp)
   target_link_libraries(test_joint_handle hardware_interface)
   ament_target_dependencies(test_joint_handle rcpputils)

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -83,7 +83,7 @@ if(BUILD_TESTING)
   ament_add_gmock(test_inst_hardwares test/test_inst_hardwares.cpp)
   target_link_libraries(test_inst_hardwares hardware_interface)
   ament_target_dependencies(test_inst_hardwares rcpputils)
-  
+
   ament_add_gmock(test_joint_handle test/test_handle.cpp)
   target_link_libraries(test_joint_handle hardware_interface)
   ament_target_dependencies(test_joint_handle rcpputils)

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -36,7 +36,7 @@ class System final
 {
 public:
   System() = default;
-  
+
   HARDWARE_INTERFACE_PUBLIC
   explicit System(std::unique_ptr<SystemInterface> impl);
 

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -35,6 +35,8 @@ class SystemInterface;
 class System final
 {
 public:
+  System() = default;
+  
   HARDWARE_INTERFACE_PUBLIC
   explicit System(std::unique_ptr<SystemInterface> impl);
 

--- a/hardware_interface/test/test_inst_hardwares.cpp
+++ b/hardware_interface/test/test_inst_hardwares.cpp
@@ -14,12 +14,12 @@
 
 #include <gmock/gmock.h>
 
-#include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/actuator.hpp"
-#include "hardware_interface/sensor_interface.hpp"
+#include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/sensor.hpp"
-#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/sensor_interface.hpp"
 #include "hardware_interface/system.hpp"
+#include "hardware_interface/system_interface.hpp"
 
 class TestInstantiationHardwares : public ::testing::Test
 {
@@ -27,19 +27,8 @@ protected:
   static void SetUpTestCase() {}
 };
 
-TEST_F(TestInstantiationHardwares,build_actuator)
-{
-  hardware_interface::Actuator anActuator;
-}
+TEST_F(TestInstantiationHardwares, build_actuator) { hardware_interface::Actuator anActuator; }
 
-TEST_F(TestInstantiationHardwares,build_sensor)
-{
-  hardware_interface::Sensor aSensor;
-}
+TEST_F(TestInstantiationHardwares, build_sensor) { hardware_interface::Sensor aSensor; }
 
-TEST_F(TestInstantiationHardwares,build_system)
-{
-  hardware_interface::System aSystem;
-}
-
- 
+TEST_F(TestInstantiationHardwares, build_system) { hardware_interface::System aSystem; }

--- a/hardware_interface/test/test_inst_hardwares.cpp
+++ b/hardware_interface/test/test_inst_hardwares.cpp
@@ -21,23 +21,23 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/system.hpp"
 
-class TestInstanciationHardwares : public ::testing::Test
+class TestInstantiationHardwares : public ::testing::Test
 {
 protected:
   static void SetUpTestCase() {}
 };
 
-TEST_F(TestInstanciationHardwares,build_actuator)
+TEST_F(TestInstantiationHardwares,build_actuator)
 {
   hardware_interface::Actuator anActuator;
 }
 
-TEST_F(TestInstanciationHardwares,build_sensor)
+TEST_F(TestInstantiationHardwares,build_sensor)
 {
   hardware_interface::Sensor aSensor;
 }
 
-TEST_F(TestInstanciationHardwares,build_system)
+TEST_F(TestInstantiationHardwares,build_system)
 {
   hardware_interface::System aSystem;
 }

--- a/hardware_interface/test/test_inst_hardwares.cpp
+++ b/hardware_interface/test/test_inst_hardwares.cpp
@@ -1,0 +1,45 @@
+// Copyright 2023 LAAS CNRS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/actuator.hpp"
+#include "hardware_interface/sensor_interface.hpp"
+#include "hardware_interface/sensor.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/system.hpp"
+
+class TestInstanciationHardwares : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase() {}
+};
+
+TEST_F(TestInstanciationHardwares,build_actuator)
+{
+  hardware_interface::Actuator anActuator;
+}
+
+TEST_F(TestInstanciationHardwares,build_sensor)
+{
+  hardware_interface::Sensor aSensor;
+}
+
+TEST_F(TestInstanciationHardwares,build_system)
+{
+  hardware_interface::System aSystem;
+}
+
+ 


### PR DESCRIPTION
This PR fixes #1057 by adding a default constructor to ```System```