### PR TITLE
Optimize list hardware components output and code for better readability.

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
@@ -47,9 +47,11 @@ class ListHardwareComponentsVerb(VerbExtension):
                 else:
                     plugin_name = f"{bcolors.WARNING}plugin name missing!{bcolors.ENDC}"
 
-                print(f"\tplugin name: {plugin_name}\n"
-                      f"\tstate: id={component.state.id} label={component.state.label}\n"
-                      f"\tcommand interfaces")
+                print(
+                    f"\tplugin name: {plugin_name}\n"
+                    f"\tstate: id={component.state.id} label={component.state.label}\n"
+                    f"\tcommand interfaces"
+                )
                 for cmd_interface in component.command_interfaces:
                     if cmd_interface.is_available:
                         available_str = f"{bcolors.OKBLUE}[available]{bcolors.ENDC}"

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
@@ -40,16 +40,16 @@ class ListHardwareComponentsVerb(VerbExtension):
 
             for idx, component in enumerate(hardware_components.component):
                 print(
-                    f"Hardware Component {idx}\n\tname: {component.name}\n\ttype: {component.type}"
+                    f"Hardware Component {idx+1}\n\tname: {component.name}\n\ttype: {component.type}"
                 )
                 if hasattr(component, "plugin_name"):
                     plugin_name = component.plugin_name
                 else:
                     plugin_name = f"{bcolors.WARNING}plugin name missing!{bcolors.ENDC}"
 
-                print(
-                    f"\tplugin name: {plugin_name}\n\tstate: id={component.state.id} label={component.state.label}\n\tcommand interfaces"
-                )
+                print(f"\tplugin name: {plugin_name}\n"
+                      f"\tstate: id={component.state.id} label={component.state.label}\n"
+                      f"\tcommand interfaces")
                 for cmd_interface in component.command_interfaces:
                     if cmd_interface.is_available:
                         available_str = f"{bcolors.OKBLUE}[available]{bcolors.ENDC}"


### PR DESCRIPTION
### Before
```
Hardware Component 0
    name: sr-bot
    type: system
    plugin name: mock_components/GenericSystem
    state: id=1 label=unconfigured
    command interfaces
         joint_a1/position [unavailable] [unclaimed]
         joint_a2/position [unavailable] [unclaimed]
         joint_a3/position [unavailable] [unclaimed]
         joint_a4/position [unavailable] [unclaimed]
         joint_a5/position [unavailable] [unclaimed]
         joint_a6/position [unavailable] [unclaimed]
```

### After
```
Hardware Component 1
    name: sr-bot
    type: system
    plugin name: mock_components/GenericSystem
    state: id=1 label=unconfigured
    command interfaces
         joint_a1/position [unavailable] [unclaimed]
         joint_a2/position [unavailable] [unclaimed]
         joint_a3/position [unavailable] [unclaimed]
         joint_a4/position [unavailable] [unclaimed]
         joint_a5/position [unavailable] [unclaimed]
         joint_a6/position [unavailable] [unclaimed]
```

Other changes are code readibility.