### PR TITLE
[Controllers] Enable services for setting the log-level in controller per default

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -115,7 +115,7 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual return_type init(
     const std::string & controller_name, const std::string & namespace_ = "",
-    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions());
+    const rclcpp::NodeOptions & node_options = rclcpp::NodeOptions().enable_logger_service(true));
 
   /// Custom configure method to read additional parameters for controller-nodes
   /*


### PR DESCRIPTION
This is very useful when debugging and now supported in rolling and iron.

For more info see:
https://docs.ros.org/en/rolling/Tutorials/Demos/Logging-and-logger-configuration.html#logger-level-configuration-externally