### PR TITLE
Fix multiple calls to export reference interfaces

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1639,11 +1639,17 @@ void ControllerManager::list_controllers_srv_cb(
         }
       }
       // check reference interfaces only if controller is inactive or active
-      auto references = controllers[i].c->export_reference_interfaces();
-      controller_state.reference_interfaces.reserve(references.size());
-      for (const auto & reference : references)
+      if (controllers[i].c->is_chainable())
       {
-        controller_state.reference_interfaces.push_back(reference.get_interface_name());
+        auto references =
+          resource_manager_->get_controller_reference_interface_names(controllers[i].info.name);
+        controller_state.reference_interfaces.reserve(references.size());
+        for (const auto & reference : references)
+        {
+          const std::string prefix_name = controllers[i].c->get_node()->get_name();
+          const std::string interface_name = reference.substr(prefix_name.size() + 1);
+          controller_state.reference_interfaces.push_back(interface_name);
+        }
       }
     }
     response->controller.push_back(controller_state);

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -269,7 +269,9 @@ TEST_F(TestControllerManagerSrvs, list_chained_controllers_srv)
   ASSERT_EQ(result->controller[0].is_chainable, true);
   ASSERT_EQ(result->controller[0].is_chained, false);
   ASSERT_EQ(result->controller[0].reference_interfaces.size(), 2u);
-  ;
+  ASSERT_EQ("joint1/position", result->controller[0].reference_interfaces[0]);
+  ASSERT_EQ("joint1/velocity", result->controller[0].reference_interfaces[1]);
+
   ASSERT_EQ(result->controller[0].chain_connections.size(), 0u);
   // check test controller
   ASSERT_EQ(result->controller[1].state, "inactive");
@@ -300,6 +302,7 @@ TEST_F(TestControllerManagerSrvs, list_chained_controllers_srv)
     test_chainable_controller::TEST_CONTROLLER_NAME,
     result->controller[0].chain_connections[0].name);
   ASSERT_EQ(2u, result->controller[0].chain_connections[0].reference_interfaces.size());
+  ASSERT_EQ("test_chainable_controller_name", result->controller[0].chain_connections[0].name);
   ASSERT_EQ("joint1/position", result->controller[0].chain_connections[0].reference_interfaces[0]);
   ASSERT_EQ("joint1/velocity", result->controller[0].chain_connections[0].reference_interfaces[1]);
 }


### PR DESCRIPTION
Source: [ros2_control Working Group Meeting Notes](https://docs.google.com/document/d/1818AoYucI2z82awL_-8sAA5pMCV_g_wXCJiM6SQmhSQ/edit?usp=sharing)
> [Manuel/Denis] Chainable controllers: how to handle export of reference interfaces, on_export_reference_interfaces() is called through services -> multiple calls -> multiple CommandInterfaces are created and old ones are invalidated.
Example:  [admittance_controller](https://github.com/ros-controls/ros2_controllers/blob/334e4f2ace819c9912ccd4f5e63c342648b25fc5/admittance_controller/src/admittance_controller.cpp#L113-L145) CommandInterfaces of other controller can be invalidated by services call.


This PR addresses it by using similar information stored in the resource manager 

