### PR TITLE
Compute the actual update period for each controller and parse it

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2057,7 +2057,9 @@ controller_interface::return_type ControllerManager::update(
 
       if (controller_go)
       {
-        auto controller_ret = loaded_controller.c->update(time, controller_period);
+        const auto controller_actual_period =
+          (time - *loaded_controller.next_update_cycle_time) + controller_period;
+        auto controller_ret = loaded_controller.c->update(time, controller_actual_period);
 
         if (
           *loaded_controller.next_update_cycle_time ==

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -60,8 +60,9 @@ controller_interface::InterfaceConfiguration TestController::state_interface_con
 }
 
 controller_interface::return_type TestController::update(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
+  update_period_ = period.seconds();
   ++internal_counter;
 
   // set value to hardware to produce and test different behaviors there

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -77,6 +77,7 @@ public:
   // enables external setting of values to command interfaces - used for simulation of hardware
   // errors
   double set_first_command_interface_value_to;
+  double update_period_ = 0;
 };
 
 }  // namespace test_controller


### PR DESCRIPTION
Right now, the period is the desired controller update period, however, it make sense to have the actual update period in the update cycles of the controller, and the desired can be computed inside the controller always using the update_rate available through `get_update_rate` method.

This is changed as it is brought up at the ros2_control workshop