### PR TITLE
Try using SCHED_FIFO on any kernel

### DIFF
--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -11,10 +11,9 @@ Determinism
 -----------
 
 For best performance when controlling hardware you want the controller manager to have as little jitter as possible in the main control loop.
-The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
-The two easiest kernel options are the `Real-time Ubuntu 22.04 LTS Beta <https://ubuntu.com/blog/real-time-ubuntu-released>`_ or `linux-image-rt-amd64 <https://packages.debian.org/bullseye/linux-image-rt-amd64>`_ on Debian Bullseye.
 
-If you have a realtime kernel installed, the main thread of Controller Manager attempts to configure ``SCHED_FIFO`` with a priority of ``50``.
+Independent of the kernel installed, the main thread of Controller Manager attempts to
+configure ``SCHED_FIFO`` with a priority of ``50``.
 By default, the user does not have permission to set such a high priority.
 To give the user such permissions, add a group named realtime and add the user controlling your robot to this group:
 
@@ -35,6 +34,16 @@ Afterwards, add the following limits to the realtime group in ``/etc/security/li
     @realtime hard memlock 102400
 
 The limits will be applied after you log out and in again.
+
+The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
+Alternatives to the standard kernel include
+
+- `Real-time Ubuntu 22.04 LTS Beta <https://ubuntu.com/blog/real-time-ubuntu-released>`_ on Ubuntu 22.04
+- `linux-image-rt-amd64 <https://packages.debian.org/bullseye/linux-image-rt-amd64>`_ on Debian Bullseye
+- lowlatency kernel (``sudo apt install linux-lowlatency``) on any ubuntu
+
+Though installing a realtime-kernel will definitely get the best results when it comes to low
+jitter, using a lowlatency kernel can improve things a lot with being really easy to install.
 
 Parameters
 -----------

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -53,7 +53,9 @@ int main(int argc, char ** argv)
         RCLCPP_WARN(
           cm->get_logger(),
           "Could not enable FIFO RT scheduling policy. Consider setting up your user to do FIFO RT "
-          "scheduling. See [https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html] for details.");
+          "scheduling. See "
+          "[https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html] "
+          "for details.");
       }
 
       // for calculating sleep time

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -48,16 +48,12 @@ int main(int argc, char ** argv)
   std::thread cm_thread(
     [cm]()
     {
-      if (realtime_tools::has_realtime_kernel())
+      if (!realtime_tools::configure_sched_fifo(kSchedPriority))
       {
-        if (!realtime_tools::configure_sched_fifo(kSchedPriority))
-        {
-          RCLCPP_WARN(cm->get_logger(), "Could not enable FIFO RT scheduling policy");
-        }
-      }
-      else
-      {
-        RCLCPP_INFO(cm->get_logger(), "RT kernel is recommended for better performance");
+        RCLCPP_WARN(
+          cm->get_logger(),
+          "Could not enable FIFO RT scheduling policy. Consider setting up your user to do FIFO RT "
+          "scheduling. See [https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html] for details.");
       }
 
       // for calculating sleep time


### PR DESCRIPTION
A while back, we did some deeper investigation of cycle-time effects of different kernel / scheduling setups (https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/60f08359f6484d1671e12bab6e01fc49eb0fadc8/ur_robot_driver/doc/real_time_benchmarking.md).

Based on this, using `SCHED_FIFO` is beneficial on any system, not only real-time kernels. Thus, I suggest alwats trying FIFO scheduling in the CM.

I've swapped the user setup before the kernel setup in the userdocs for two reasons:
- Since the CM now will put a warning about FIFO scheduling in every run, the method of avoiding this warning should be put first
- Users might be repelled from installing another kernel, especially installing an RT-kernel. (At least that's our experience from issue reports). This should not necessarily stop them from setting up their ROS user to use `SCHED_FIFO`.