### PR TITLE
[CI] codecov updates

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -1,8 +1,6 @@
 name: Coverage Build
 on:
   workflow_dispatch:
-    branches:
-      - master
   push:
     branches:
       - master
@@ -31,11 +29,8 @@ jobs:
           package-name:
             controller_interface
             controller_manager
-            controller_manager_msgs
             hardware_interface
-            ros2controlcli
-            ros2_control
-            ros2_control_test_assets
+            joint_limits_interface
             transmission_interface
 
           vcs-repo-file-url: |

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -30,7 +30,6 @@ jobs:
             controller_interface
             controller_manager
             hardware_interface
-            joint_limits_interface
             transmission_interface
 
           vcs-repo-file-url: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ros2_control
 
 [![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![codecov](https://codecov.io/gh/ros-controls/ros2_control/graph/badge.svg?token=idvm1zJXOf)](https://codecov.io/gh/ros-controls/ros2_control)
 
 This package is a part of the ros2_control framework.
 For more, please check the [documentation](https://control.ros.org/).

--- a/codecov.yml
+++ b/codecov.yml
@@ -22,5 +22,4 @@ flags:
       - controller_interface
       - controller_manager
       - hardware_interface
-      - joint_limits_interface
       - transmission_interface

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,6 +14,8 @@ fixes:
 comment:
   layout: "diff, flags, files"
   behavior: default
+ignore:
+  - "**/test"
 flags:
   unittests:
     paths:
@@ -21,5 +23,4 @@ flags:
       - controller_manager
       - hardware_interface
       - joint_limits_interface
-      - test_robot_hardware
       - transmission_interface


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_controllers/pull/804

- Update of the packages
- Exclude test folders from stats
- Add codecov badge to readme
- Remove the invalid `branches` key from the `workflow_displatch`

Do we want to activate codecov also for humble?