### PR TITLE
Added test for spawner argument --load-only

### DIFF
--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -282,6 +282,5 @@ TEST_F(TestLoadController, spawner_test_load_only_in_arg)
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
   auto ctrl_2 = cm_->get_loaded_controllers()[0];
   ASSERT_EQ(ctrl_2.info.name, "ctrl_2");
-  ASSERT_EQ(ctrl_2.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(ctrl_2.c->get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 }

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -274,3 +274,14 @@ TEST_F(TestLoadController, unload_on_kill)
 
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 0ul);
 }
+
+TEST_F(TestLoadController, spawner_test_load_only_in_arg)
+{
+  EXPECT_EQ(call_spawner("ctrl_2 -c test_controller_manager --load-only "), 0);
+
+  ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
+  auto ctrl_2 = cm_->get_loaded_controllers()[0];
+  ASSERT_EQ(ctrl_2.info.name, "ctrl_2");
+  ASSERT_EQ(ctrl_2.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(ctrl_2.c->get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}


### PR DESCRIPTION
Regarding Issue  #957. As far as i  can see the test for the type_controller argument of the spawner is already implemented. I added a test for testing the --load-only argument for the spawner. I am not sure if it is complete, Feedback is appreciated. I am plannung to add test for all the other arguments. Maybe with an INSTANTIATE_TEST_SUITE_P? 