### PR TITLE
[ControllerInterface] Avoid warning about conversion from `int64_t` to `unsigned int`

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -85,7 +85,7 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
   // Other solution is to add check into the LifecycleNode if a transition is valid to trigger
   if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
   {
-    update_rate_ = get_node()->get_parameter("update_rate").as_int();
+    update_rate_ = static_cast<unsigned int>(get_node()->get_parameter("update_rate").as_int());
     is_async_ = get_node()->get_parameter("is_async").as_bool();
   }
 


### PR DESCRIPTION


Without this there is a warning. For what I found the best way is to do static cast.

```
ros2_control/controller_interface/src/controller_interface_base.cpp:88:67: warning: conversion from ‘int64_t’{aka ‘long int’} to ‘unsigned int’ may change value [-Wconversion]
88 |     update_rate_ = get_node()->get_parameter("update_rate").as_int();
```

#GitHub-Programming-Rocks