### PR TITLE
[ControllerManager] Fix all warnings from the latets features.

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2501,20 +2501,23 @@ bool ControllerManager::controller_sorting(
       // If there is no common parent, then they belong to 2 different sets
       auto following_ctrls_b = get_following_controller_names(ctrl_b.info.name, controllers);
       if (following_ctrls_b.empty()) return true;
-      auto find_first_element = [&](const auto & controllers_list)
+      auto find_first_element = [&](const auto & controllers_list) -> long int
       {
         auto it = std::find_if(
           controllers.begin(), controllers.end(),
           std::bind(controller_name_compare, std::placeholders::_1, controllers_list.back()));
         if (it != controllers.end())
         {
-          int dist = std::distance(controllers.begin(), it);
-          return dist;
+          return std::distance(controllers.begin(), it);
         }
+        return 0;
       };
-      const int ctrl_a_chain_first_controller = find_first_element(following_ctrls);
-      const int ctrl_b_chain_first_controller = find_first_element(following_ctrls_b);
-      if (ctrl_a_chain_first_controller < ctrl_b_chain_first_controller) return true;
+      const auto ctrl_a_chain_first_controller = find_first_element(following_ctrls);
+      const auto ctrl_b_chain_first_controller = find_first_element(following_ctrls_b);
+      if (ctrl_a_chain_first_controller < ctrl_b_chain_first_controller)
+      {
+        return true;
+      }
     }
 
     // If the ctrl_a's state interface is the one exported by the ctrl_b then ctrl_b should be

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2501,7 +2501,7 @@ bool ControllerManager::controller_sorting(
       // If there is no common parent, then they belong to 2 different sets
       auto following_ctrls_b = get_following_controller_names(ctrl_b.info.name, controllers);
       if (following_ctrls_b.empty()) return true;
-      auto find_first_element = [&](const auto & controllers_list) -> long int
+      auto find_first_element = [&](const auto & controllers_list) -> size_t
       {
         auto it = std::find_if(
           controllers.begin(), controllers.end(),

--- a/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
+++ b/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp
@@ -33,7 +33,7 @@ TestControllerFailedInit::on_init()
 
 controller_interface::return_type TestControllerFailedInit::init(
   const std::string & /* controller_name */, const std::string & /* urdf */,
-  unsigned int cm_update_rate, const std::string & /*namespace_*/,
+  unsigned int /*cm_update_rate*/, const std::string & /*namespace_*/,
   const rclcpp::NodeOptions & /*node_options*/)
 {
   return controller_interface::return_type::ERROR;

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -486,7 +486,7 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
     time += rclcpp::Duration::from_seconds(0.01);
     if (update_counter % cm_update_rate == 0)
     {
-      const auto no_of_secs_passed = update_counter / cm_update_rate;
+      const double no_of_secs_passed = static_cast<double>(update_counter) / cm_update_rate;
       // NOTE: here EXPECT_NEAR is used because it is observed that in the first iteration of whole
       // cycle of cm_update_rate counts, there is one count missing, but in rest of the 9 cycles it
       // is clearly tracking, so adding 1 here won't affect the final count.
@@ -495,7 +495,7 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
       // cycles it will have 369 instead of 370.
       EXPECT_NEAR(
         test_controller->internal_counter - initial_counter,
-        (controller_update_rate * no_of_secs_passed), 1);
+        (static_cast<double>(controller_update_rate) * no_of_secs_passed), 1.0);
     }
   }
 }

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -493,9 +493,11 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
       // For instance, a controller with update rate 37 Hz, seems to have 36 in the first update
       // cycle and then on accumulating 37 on every other update cycle so at the end of the 10
       // cycles it will have 369 instead of 370.
-      EXPECT_NEAR(
+      EXPECT_THAT(
         test_controller->internal_counter - initial_counter,
-        (static_cast<double>(controller_update_rate) * no_of_secs_passed), 1.0);
+        testing::AnyOf(
+          testing::Eq(controller_update_rate * no_of_secs_passed),
+          testing::Eq((controller_update_rate * no_of_secs_passed) - 1)));
     }
   }
 }

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -807,7 +807,7 @@ TEST_F(TestControllerManagerSrvs, list_sorted_complex_chained_controllers)
   ASSERT_EQ(result->controller[1].name, TEST_CHAINED_CONTROLLER_7);
   ASSERT_EQ(result->controller[2].name, TEST_CHAINED_CONTROLLER_6);
 
-  auto get_ctrl_pos = [result](const std::string & controller_name) -> long int
+  auto get_ctrl_pos = [result](const std::string & controller_name) -> int64_t
   {
     auto it = std::find_if(
       result->controller.begin(), result->controller.end(),
@@ -1016,7 +1016,7 @@ TEST_F(TestControllerManagerSrvs, list_sorted_independent_chained_controllers)
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(10u, result->controller.size());
 
-  auto get_ctrl_pos = [result](const std::string & controller_name) -> long int
+  auto get_ctrl_pos = [result](const std::string & controller_name) -> int64_t
   {
     auto it = std::find_if(
       result->controller.begin(), result->controller.end(),

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -807,7 +807,7 @@ TEST_F(TestControllerManagerSrvs, list_sorted_complex_chained_controllers)
   ASSERT_EQ(result->controller[1].name, TEST_CHAINED_CONTROLLER_7);
   ASSERT_EQ(result->controller[2].name, TEST_CHAINED_CONTROLLER_6);
 
-  auto get_ctrl_pos = [result](const std::string & controller_name) -> int
+  auto get_ctrl_pos = [result](const std::string & controller_name) -> long int
   {
     auto it = std::find_if(
       result->controller.begin(), result->controller.end(),
@@ -1016,7 +1016,7 @@ TEST_F(TestControllerManagerSrvs, list_sorted_independent_chained_controllers)
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(10u, result->controller.size());
 
-  auto get_ctrl_pos = [result](const std::string & controller_name) -> int
+  auto get_ctrl_pos = [result](const std::string & controller_name) -> long int
   {
     auto it = std::find_if(
       result->controller.begin(), result->controller.end(),


### PR DESCRIPTION
I have fixed following warnings:

```
src/ros2_control/controller_manager/src/controller_manager.cpp:2509:35: warning: conversion from ‘std::__iterator_traits<__gnu_cxx::__normal_iterator<const controller_manager::ControllerSpec*, std::vector<controller_manager::ControllerSpec> >, void>::difference_type’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
2509 |           int dist = std::distance(controllers.begin(), it);
```

```
src/ros2_control/controller_manager/test/test_controller_failed_init/test_controller_failed_init.cpp:36:16: warning: unused parameter ‘cm_update_rate’ [-Wunused-parameter]
36 |   unsigned int cm_update_rate, const std::string & /*namespace_*/,
```


```
src/ros2_control/controller_manager/test/test_controller_manager.cpp:486:33: warning: conversion from ‘long unsigned int’ to ‘double’ may change value [-Wconversion]
486 |         (controller_update_rate * no_of_secs_passed), 1);
```

```
src/ros2_control/controller_manager/test/test_controller_manager_srvs.cpp:816:25: warning: conversion from ‘std::__iterator_traits<__gnu_cxx::__normal_iterator<controller_manager_msgs::msg::ControllerState_<std::allocator<void> >*, std::vector<controller_manager_msgs::msg::ControllerState_<std::allocator<void> >, std::allocator<controller_manager_msgs::msg::ControllerState_<std::allocator<void> > > > >, void>::difference_type’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
816 |     return std::distance(result->controller.begin(), it);
```


```
src/ros2_control/controller_manager/test/test_controller_manager_srvs.cpp:1025:25: warning: conversion from ‘std::__iterator_traits<__gnu_cxx::__normal_iterator<controller_manager_msgs::msg::ControllerState_<std::allocator<void> >*, std::vector<controller_manager_msgs::msg::ControllerState_<std::allocator<void> >, std::allocator<controller_manager_msgs::msg::ControllerState_<std::allocator<void> > > > >, void>::difference_type’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
1025 |     return std::distance(result->controller.begin(), it);
```

```
src/ros2_control/controller_manager/src/controller_manager.cpp:2513:67: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
2513 |       const int ctrl_a_chain_first_controller = find_first_element(following_ctrls);
```

```
src/ros2_control/controller_manager/src/controller_manager.cpp:2514:67: warning: conversion from ‘long int’ to ‘int’ may change value [-Wconversion]
2514 |       const int ctrl_b_chain_first_controller = find_first_element(following_ctrls_b);
```

```
src/ros2_control/controller_manager/src/controller_manager.cpp:2512:7: warning: control reaches end of non-void function [-Wreturn-type]
```

```
src/ros2_control/controller_manager/test/test_controller_manager.cpp:486:56: warning: conversion from ‘long unsigned int’ to ‘double’ may change value [-Wconversion]
486 |         (static_cast<double>(controller_update_rate) * no_of_secs_passed), 1.0);
```

@saikishor please check the changes one more time! I ahve added some default values to return lambda. The tests are passing, but maybe this cases are not covered.
