### PR TITLE
Report inactive controllers as a diagnostics warning instead of an error

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2558,7 +2558,7 @@ void ControllerManager::controller_activity_diagnostic_callback(
   }
   else
   {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Not all controllers are active");
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Not all controllers are active");
   }
 }
 


### PR DESCRIPTION
See #1183 

