### PR TITLE
added InsertBraces option of clang formatting and update the needed m…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,4 +12,5 @@ DerivePointerAlignment: false
 PointerAlignment: Middle
 ReflowComments: true
 IncludeBlocks: Preserve
+InsertBraces: true
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
 
   # CPP hooks
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: v15.0.6
     hooks:
       - id: clang-format
 


### PR DESCRIPTION
After  the PR: https://github.com/ros-controls/ros2_control/pull/1193. I have added this [new Clang-format style option](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces) to have the similar styling in future.

Once the PR : https://github.com/ros-controls/ros2_control/pull/1193 is merged, I can apply this change to all the packages and  check for any missing one that are not addressed in the previous PR

