### PR TITLE
Remove deprecated parameters and warning about getting robot description from parameter.

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -281,10 +281,6 @@ ControllerManager::ControllerManager(
   }
   else
   {
-    RCLCPP_WARN(
-      get_logger(),
-      "[Deprecated] Passing the robot description parameter directly to the control_manager node "
-      "is deprecated. Use '~/robot_description' topic from 'robot_state_publisher' instead.");
     init_resource_manager(robot_description_);
   }
 
@@ -410,56 +406,15 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       State::PRIMARY_STATE_UNCONFIGURED, hardware_interface::lifecycle_state_names::UNCONFIGURED));
 
   // inactive (configured)
-  // BEGIN: Keep old functionality on for backwards compatibility (Remove at the end of 2023)
-  std::vector<std::string> configure_components_on_start = std::vector<std::string>({});
-  get_parameter("configure_components_on_start", configure_components_on_start);
-  if (!configure_components_on_start.empty())
-  {
-    RCLCPP_WARN(
-      get_logger(),
-      "Parameter 'configure_components_on_start' is deprecated. "
-      "Use 'hardware_components_initial_state.inactive' instead, to set component's initial "
-      "state to 'inactive'. Don't use this parameters in combination with the new "
-      "'hardware_components_initial_state' parameter structure.");
-    set_components_to_state(
-      "configure_components_on_start",
-      rclcpp_lifecycle::State(
-        State::PRIMARY_STATE_INACTIVE, hardware_interface::lifecycle_state_names::INACTIVE));
-  }
-  // END: Keep old functionality on humble backwards compatibility (Remove at the end of 2023)
-  else
-  {
-    set_components_to_state(
-      "hardware_components_initial_state.inactive",
-      rclcpp_lifecycle::State(
-        State::PRIMARY_STATE_INACTIVE, hardware_interface::lifecycle_state_names::INACTIVE));
-  }
+  set_components_to_state(
+    "hardware_components_initial_state.inactive",
+    rclcpp_lifecycle::State(
+      State::PRIMARY_STATE_INACTIVE, hardware_interface::lifecycle_state_names::INACTIVE));
 
-  // BEGIN: Keep old functionality on for backwards compatibility (Remove at the end of 2023)
-  std::vector<std::string> activate_components_on_start = std::vector<std::string>({});
-  get_parameter("activate_components_on_start", activate_components_on_start);
-  rclcpp_lifecycle::State active_state(
-    State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
-  if (!activate_components_on_start.empty())
+  // activate all other components
+  for (const auto & [component, state] : components_to_activate)
   {
-    RCLCPP_WARN(
-      get_logger(),
-      "Parameter 'activate_components_on_start' is deprecated. "
-      "Components are activated per default. Don't use this parameters in combination with the new "
-      "'hardware_components_initial_state' parameter structure.");
-    for (const auto & component : activate_components_on_start)
-    {
-      resource_manager_->set_component_state(component, active_state);
-    }
-  }
-  // END: Keep old functionality on humble for backwards compatibility (Remove at the end of 2023)
-  else
-  {
-    // activate all other components
-    for (const auto & [component, state] : components_to_activate)
-    {
-      resource_manager_->set_component_state(component, active_state);
-    }
+    resource_manager_->set_component_state(component, active_state);
   }
 }
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -272,16 +272,7 @@ ControllerManager::ControllerManager(
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
   }
 
-  robot_description_ = "";
-  get_parameter("robot_description", robot_description_);
-  if (robot_description_.empty())
-  {
-    subscribe_to_robot_description_topic();
-  }
-  else
-  {
-    init_resource_manager(robot_description_);
-  }
+  subscribe_to_robot_description_topic();
 
   diagnostics_updater_.setHardwareID("ros2_control");
   diagnostics_updater_.add(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -273,7 +273,6 @@ ControllerManager::ControllerManager(
   }
 
   robot_description_ = "";
-  // TODO(destogl): remove support at the end of 2023
   get_parameter("robot_description", robot_description_);
   if (robot_description_.empty())
   {

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -411,6 +411,8 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       State::PRIMARY_STATE_INACTIVE, hardware_interface::lifecycle_state_names::INACTIVE));
 
   // activate all other components
+  rclcpp_lifecycle::State active_state(
+    State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
   for (const auto & [component, state] : components_to_activate)
   {
     resource_manager_->set_component_state(component, active_state);

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1279,37 +1279,6 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
   return to.back().c;
 }
 
-void ControllerManager::manage_switch()
-{
-  // Ask hardware interfaces to change mode
-  if (!resource_manager_->perform_command_mode_switch(
-        activate_command_interface_request_, deactivate_command_interface_request_))
-  {
-    RCLCPP_ERROR(get_logger(), "Error while performing mode switch.");
-  }
-
-  std::vector<ControllerSpec> & rt_controller_list =
-    rt_controllers_wrapper_.update_and_get_used_by_rt_list();
-
-  deactivate_controllers(rt_controller_list, deactivate_request_);
-
-  switch_chained_mode(to_chained_mode_request_, true);
-  switch_chained_mode(from_chained_mode_request_, false);
-
-  // activate controllers once the switch is fully complete
-  if (!switch_params_.activate_asap)
-  {
-    activate_controllers(rt_controller_list, activate_request_);
-  }
-  else
-  {
-    // activate controllers as soon as their required joints are done switching
-    activate_controllers_asap(rt_controller_list, activate_request_);
-  }
-
-  // TODO(destogl): move here "do_switch = false"
-}
-
 void ControllerManager::deactivate_controllers(
   const std::vector<ControllerSpec> & rt_controller_list,
   const std::vector<std::string> controllers_to_deactivate)
@@ -1519,8 +1488,6 @@ void ControllerManager::activate_controllers(
       async_controller_threads_.at(controller_name)->activate();
     }
   }
-  // All controllers activated, switching done
-  switch_params_.do_switch = false;
 }
 
 void ControllerManager::activate_controllers_asap(
@@ -1975,6 +1942,38 @@ void ControllerManager::read(const rclcpp::Time & time, const rclcpp::Duration &
     deactivate_controllers(rt_controller_list, stop_request);
     // TODO(destogl): do auto-start of broadcasters
   }
+}
+
+void ControllerManager::manage_switch()
+{
+  // Ask hardware interfaces to change mode
+  if (!resource_manager_->perform_command_mode_switch(
+    activate_command_interface_request_, deactivate_command_interface_request_))
+  {
+    RCLCPP_ERROR(get_logger(), "Error while performing mode switch.");
+  }
+
+  std::vector<ControllerSpec> & rt_controller_list =
+  rt_controllers_wrapper_.update_and_get_used_by_rt_list();
+
+  deactivate_controllers(rt_controller_list, deactivate_request_);
+
+  switch_chained_mode(to_chained_mode_request_, true);
+  switch_chained_mode(from_chained_mode_request_, false);
+
+  // activate controllers once the switch is fully complete
+  if (!switch_params_.activate_asap)
+  {
+    activate_controllers(rt_controller_list, activate_request_);
+  }
+  else
+  {
+    // activate controllers as soon as their required joints are done switching
+    activate_controllers_asap(rt_controller_list, activate_request_);
+  }
+
+  // All controllers switched --> switching done
+  switch_params_.do_switch = false;
 }
 
 controller_interface::return_type ControllerManager::update(

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -205,7 +205,8 @@ public:
 TEST_F(TestControllerManagerHWManagementSrvs, list_hardware_components)
 {
   // Default status after start:
-  // checks if "configure_components_on_start" and "activate_components_on_start" are correctly read
+  // checks if "hardware_components_initial_state.unconfigured" and 
+  // "hardware_components_initial_state.inactive" are correctly read
 
   list_hardware_components_and_check(
     // actuator, sensor, system
@@ -391,8 +392,8 @@ public:
 
 TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activation_of_all_hardware)
 {
-  // "configure_components_on_start" and "activate_components_on_start" are not set (empty)
-  // therefore all hardware components are active
+  // "hardware_components_initial_state.unconfigured" and "hardware_components_initial_state.inactive" 
+  // are not set (empty). Therefore, all hardware components are active.
   list_hardware_components_and_check(
     // actuator, sensor, system
     std::vector<uint8_t>(
@@ -412,62 +413,3 @@ TEST_F(TestControllerManagerHWManagementSrvsWithoutParams, test_default_activati
       {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
     }));
 }
-
-// BEGIN: Remove at the end of 2023
-class TestControllerManagerHWManagementSrvsOldParameters
-: public TestControllerManagerHWManagementSrvs
-{
-public:
-  void SetUp() override
-  {
-    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-    cm_ = std::make_shared<controller_manager::ControllerManager>(
-      std::make_unique<hardware_interface::ResourceManager>(), executor_, TEST_CM_NAME);
-    run_updater_ = false;
-
-    cm_->set_parameter(
-      rclcpp::Parameter("robot_description", ros2_control_test_assets::minimal_robot_urdf));
-    cm_->set_parameter(rclcpp::Parameter(
-      "activate_components_on_start", std::vector<std::string>({TEST_ACTUATOR_HARDWARE_NAME})));
-    cm_->set_parameter(rclcpp::Parameter(
-      "configure_components_on_start", std::vector<std::string>({TEST_SENSOR_HARDWARE_NAME})));
-
-    std::string robot_description = "";
-    cm_->get_parameter("robot_description", robot_description);
-    if (robot_description.empty())
-    {
-      throw std::runtime_error(
-        "Unable to initialize resource manager, no robot description found.");
-    }
-
-    cm_->init_resource_manager(robot_description);
-
-    SetUpSrvsCMExecutor();
-  }
-};
-
-TEST_F(TestControllerManagerHWManagementSrvsOldParameters, list_hardware_components)
-{
-  // Default status after start:
-  // checks if "configure_components_on_start" and "activate_components_on_start" are correctly read
-
-  list_hardware_components_and_check(
-    // actuator, sensor, system
-    std::vector<uint8_t>(
-      {LFC_STATE::PRIMARY_STATE_ACTIVE, LFC_STATE::PRIMARY_STATE_INACTIVE,
-       LFC_STATE::PRIMARY_STATE_UNCONFIGURED}),
-    std::vector<std::string>({ACTIVE, INACTIVE, UNCONFIGURED}),
-    std::vector<std::vector<std::vector<bool>>>({
-      // is available
-      {{true, true}, {true, true, true}},  // actuator
-      {{}, {true}},                        // sensor
-      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
-    }),
-    std::vector<std::vector<std::vector<bool>>>({
-      // is claimed
-      {{false, false}, {false, false, false}},  // actuator
-      {{}, {false}},                            // sensor
-      {{false, false, false, false}, {false, false, false, false, false, false, false}},  // system
-    }));
-}
-// END: Remove at the end of 2023


### PR DESCRIPTION
1. Some time ago we agreed that getting a robot description from a parameter is not deprecated and we should support both.
2. Also removing deprecated parameters from master, as it is end of 2023.