### PR TITLE
[CI] Increase timeout for controller_managers_srv test

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -141,6 +141,7 @@ if(BUILD_TESTING)
     test_chainable_controller
     ros2_control_test_assets::ros2_control_test_assets
   )
+  set_tests_properties(test_controller_manager_srvs PROPERTIES TIMEOUT 120)
   ament_target_dependencies(test_controller_manager_srvs
     controller_manager_msgs
   )


### PR DESCRIPTION
Since #1180 the CI runs into the default 60s timeout of the test, see e.g., [here](https://github.com/ros-controls/ros2_control/actions/runs/7232444769/job/19706646832#step:4:35028).

I'd increase it to 120s, let's see if this is sufficient.