### PR TITLE
Issue #1235: improve transmission tests

### DIFF
--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -26,7 +26,11 @@
 #include "transmission_interface/differential_transmission_loader.hpp"
 #include "transmission_interface/transmission_loader.hpp"
 
+using testing::DoubleNear;
 using testing::SizeIs;
+
+// Floating-point value comparison threshold
+const double EPS = 1e-5;
 
 class TransmissionPluginLoader
 {
@@ -113,16 +117,16 @@ TEST(DifferentialTransmissionLoaderTest, FullSpec)
 
   const std::vector<double> & actuator_reduction =
     differential_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
-  EXPECT_EQ(2.0, joint_reduction[0]);
-  EXPECT_EQ(-2.0, joint_reduction[1]);
+  EXPECT_THAT(2.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
-  EXPECT_EQ(0.5, joint_offset[0]);
-  EXPECT_EQ(-0.5, joint_offset[1]);
+  EXPECT_THAT(0.5, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(-0.5, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
@@ -184,16 +188,16 @@ TEST(DifferentialTransmissionLoaderTest, only_mech_red_specified)
 
   const std::vector<double> & actuator_reduction =
     differential_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
@@ -247,16 +251,16 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
 
   const std::vector<double> & actuator_reduction =
     differential_transmission->get_actuator_reduction();
-  EXPECT_EQ(1.0, actuator_reduction[0]);
-  EXPECT_EQ(1.0, actuator_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
@@ -319,16 +323,16 @@ TEST(DifferentialTransmissionLoaderTest, mechanical_reduction_not_a_number)
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
     differential_transmission->get_actuator_reduction();
-  EXPECT_EQ(1.0, actuator_reduction[0]);
-  EXPECT_EQ(1.0, actuator_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
@@ -393,17 +397,17 @@ TEST(DifferentialTransmissionLoaderTest, offset_ill_defined)
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
     differential_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction = differential_transmission->get_joint_reduction();
-  EXPECT_EQ(2.0, joint_reduction[0]);
-  EXPECT_EQ(-2.0, joint_reduction[1]);
+  EXPECT_THAT(2.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(joint_reduction[1], EPS));
 
   // default kicks in for ill-defined values
   const std::vector<double> & joint_offset = differential_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(DifferentialTransmissionLoaderTest, mech_red_invalid_value)

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -29,7 +29,7 @@ using transmission_interface::DifferentialTransmission;
 using transmission_interface::Exception;
 using transmission_interface::JointHandle;
 // Floating-point value comparison threshold
-const double EPS = 1e-6;
+const double EPS = 1e-5;
 
 TEST(PreconditionsTest, ExceptionThrowing)
 {

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -79,12 +79,12 @@ TEST(PreconditionsTest, AccessorValidation)
 
   EXPECT_EQ(2u, trans.num_actuators());
   EXPECT_EQ(2u, trans.num_joints());
-  EXPECT_EQ(2.0, trans.get_actuator_reduction()[0]);
-  EXPECT_EQ(-2.0, trans.get_actuator_reduction()[1]);
-  EXPECT_EQ(4.0, trans.get_joint_reduction()[0]);
-  EXPECT_EQ(-4.0, trans.get_joint_reduction()[1]);
-  EXPECT_EQ(1.0, trans.get_joint_offset()[0]);
-  EXPECT_EQ(-1.0, trans.get_joint_offset()[1]);
+  EXPECT_THAT(2.0, DoubleNear(trans.get_actuator_reduction()[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(trans.get_actuator_reduction()[1], EPS));
+  EXPECT_THAT(4.0, DoubleNear(trans.get_joint_reduction()[0], EPS));
+  EXPECT_THAT(-4.0, DoubleNear(trans.get_joint_reduction()[1], EPS));
+  EXPECT_THAT(1.0, DoubleNear(trans.get_joint_offset()[0], EPS));
+  EXPECT_THAT(-1.0, DoubleNear(trans.get_joint_offset()[1], EPS));
 }
 
 void testConfigureWithBadHandles(std::string interface_name)

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -26,7 +26,11 @@
 #include "transmission_interface/four_bar_linkage_transmission_loader.hpp"
 #include "transmission_interface/transmission_loader.hpp"
 
+using testing::DoubleNear;
 using testing::SizeIs;
+
+// Floating-point value comparison threshold
+const double EPS = 1e-5;
 
 class TransmissionPluginLoader
 {
@@ -113,17 +117,17 @@ TEST(FourBarLinkageTransmissionLoaderTest, FullSpec)
 
   const std::vector<double> & actuator_reduction =
     four_bar_linkage_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction =
     four_bar_linkage_transmission->get_joint_reduction();
-  EXPECT_EQ(2.0, joint_reduction[0]);
-  EXPECT_EQ(-2.0, joint_reduction[1]);
+  EXPECT_THAT(2.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
-  EXPECT_EQ(0.5, joint_offset[0]);
-  EXPECT_EQ(-0.5, joint_offset[1]);
+  EXPECT_THAT(0.5, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(-0.5, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(FourBarLinkageTransmissionLoaderTest, only_mech_red_specified)
@@ -185,17 +189,17 @@ TEST(FourBarLinkageTransmissionLoaderTest, only_mech_red_specified)
 
   const std::vector<double> & actuator_reduction =
     four_bar_linkage_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction =
     four_bar_linkage_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(DifferentialTransmissionLoaderTest, offset_and_mech_red_not_specified)
@@ -249,17 +253,17 @@ TEST(DifferentialTransmissionLoaderTest, offset_and_mech_red_not_specified)
 
   const std::vector<double> & actuator_reduction =
     four_bar_linkage_transmission->get_actuator_reduction();
-  EXPECT_EQ(1.0, actuator_reduction[0]);
-  EXPECT_EQ(1.0, actuator_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction =
     four_bar_linkage_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(FourBarLinkageTransmissionLoaderTest, mechanical_reduction_not_a_number)
@@ -322,17 +326,17 @@ TEST(FourBarLinkageTransmissionLoaderTest, mechanical_reduction_not_a_number)
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
     four_bar_linkage_transmission->get_actuator_reduction();
-  EXPECT_EQ(1.0, actuator_reduction[0]);
-  EXPECT_EQ(1.0, actuator_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction =
     four_bar_linkage_transmission->get_joint_reduction();
-  EXPECT_EQ(1.0, joint_reduction[0]);
-  EXPECT_EQ(1.0, joint_reduction[1]);
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(1.0, DoubleNear(joint_reduction[1], EPS));
 
   const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(FourBarLinkageTransmissionLoaderTest, offset_ill_defined)
@@ -397,18 +401,18 @@ TEST(FourBarLinkageTransmissionLoaderTest, offset_ill_defined)
   // default kicks in for ill-defined values
   const std::vector<double> & actuator_reduction =
     four_bar_linkage_transmission->get_actuator_reduction();
-  EXPECT_EQ(50.0, actuator_reduction[0]);
-  EXPECT_EQ(-50.0, actuator_reduction[1]);
+  EXPECT_THAT(50.0, DoubleNear(actuator_reduction[0], EPS));
+  EXPECT_THAT(-50.0, DoubleNear(actuator_reduction[1], EPS));
 
   const std::vector<double> & joint_reduction =
     four_bar_linkage_transmission->get_joint_reduction();
-  EXPECT_EQ(2.0, joint_reduction[0]);
-  EXPECT_EQ(-2.0, joint_reduction[1]);
+  EXPECT_THAT(2.0, DoubleNear(joint_reduction[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(joint_reduction[1], EPS));
 
   // default kicks in for ill-defined values
   const std::vector<double> & joint_offset = four_bar_linkage_transmission->get_joint_offset();
-  EXPECT_EQ(0.0, joint_offset[0]);
-  EXPECT_EQ(0.0, joint_offset[1]);
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[0], EPS));
+  EXPECT_THAT(0.0, DoubleNear(joint_offset[1], EPS));
 }
 
 TEST(FourBarLinkageTransmissionLoaderTest, mech_red_invalid_value)

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -33,7 +33,7 @@ using transmission_interface::FourBarLinkageTransmission;
 using transmission_interface::JointHandle;
 
 // Floating-point value comparison threshold
-const double EPS = 1e-6;
+const double EPS = 1e-5;
 
 TEST(PreconditionsTest, ExceptionThrowing)
 {

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -83,12 +83,12 @@ TEST(PreconditionsTest, AccessorValidation)
 
   EXPECT_EQ(2u, trans.num_actuators());
   EXPECT_EQ(2u, trans.num_joints());
-  EXPECT_EQ(2.0, trans.get_actuator_reduction()[0]);
-  EXPECT_EQ(-2.0, trans.get_actuator_reduction()[1]);
-  EXPECT_EQ(4.0, trans.get_joint_reduction()[0]);
-  EXPECT_EQ(-4.0, trans.get_joint_reduction()[1]);
-  EXPECT_EQ(1.0, trans.get_joint_offset()[0]);
-  EXPECT_EQ(-1.0, trans.get_joint_offset()[1]);
+  EXPECT_THAT(2.0, DoubleNear(trans.get_actuator_reduction()[0], EPS));
+  EXPECT_THAT(-2.0, DoubleNear(trans.get_actuator_reduction()[1], EPS));
+  EXPECT_THAT(4.0, DoubleNear(trans.get_joint_reduction()[0], EPS));
+  EXPECT_THAT(-4.0, DoubleNear(trans.get_joint_reduction()[1], EPS));
+  EXPECT_THAT(1.0, DoubleNear(trans.get_joint_offset()[0], EPS));
+  EXPECT_THAT(-1.0, DoubleNear(trans.get_joint_offset()[1], EPS));
 }
 
 void testConfigureWithBadHandles(std::string interface_name)

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -26,7 +26,11 @@
 #include "transmission_interface/simple_transmission_loader.hpp"
 #include "transmission_interface/transmission_loader.hpp"
 
+using testing::DoubleNear;
 using testing::SizeIs;
+
+// Floating-point value comparison threshold
+const double EPS = 1e-5;
 
 class TransmissionPluginLoader
 {
@@ -229,8 +233,8 @@ TEST(SimpleTransmissionLoaderTest, FullSpec)
   transmission_interface::SimpleTransmission * simple_transmission =
     dynamic_cast<transmission_interface::SimpleTransmission *>(transmission.get());
   ASSERT_TRUE(nullptr != simple_transmission);
-  EXPECT_EQ(325.949, simple_transmission->get_actuator_reduction());
-  EXPECT_EQ(0.0, simple_transmission->get_joint_offset());
+  EXPECT_THAT(325.949, DoubleNear(simple_transmission->get_actuator_reduction(), EPS));
+  EXPECT_THAT(0.0, DoubleNear(simple_transmission->get_joint_offset(), EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, only_mech_red_specified)
@@ -275,8 +279,8 @@ TEST(SimpleTransmissionLoaderTest, only_mech_red_specified)
   transmission_interface::SimpleTransmission * simple_transmission =
     dynamic_cast<transmission_interface::SimpleTransmission *>(transmission.get());
   ASSERT_TRUE(nullptr != simple_transmission);
-  EXPECT_EQ(50.0, simple_transmission->get_actuator_reduction());
-  EXPECT_EQ(0.0, simple_transmission->get_joint_offset());
+  EXPECT_THAT(50.0, DoubleNear(simple_transmission->get_actuator_reduction(), EPS));
+  EXPECT_THAT(0.0, DoubleNear(simple_transmission->get_joint_offset(), EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
@@ -317,8 +321,8 @@ TEST(SimpleTransmissionLoaderTest, offset_and_mech_red_not_specified)
   transmission_interface::SimpleTransmission * simple_transmission =
     dynamic_cast<transmission_interface::SimpleTransmission *>(transmission.get());
   ASSERT_TRUE(nullptr != simple_transmission);
-  EXPECT_EQ(1.0, simple_transmission->get_actuator_reduction());
-  EXPECT_EQ(0.0, simple_transmission->get_joint_offset());
+  EXPECT_THAT(1.0, DoubleNear(simple_transmission->get_actuator_reduction(), EPS));
+  EXPECT_THAT(0.0, DoubleNear(simple_transmission->get_joint_offset(), EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, mechanical_reduction_not_a_number)
@@ -360,7 +364,7 @@ TEST(SimpleTransmissionLoaderTest, mechanical_reduction_not_a_number)
     dynamic_cast<transmission_interface::SimpleTransmission *>(transmission.get());
   ASSERT_TRUE(nullptr != simple_transmission);
   // default kicks in for ill-defined values
-  EXPECT_EQ(1.0, simple_transmission->get_actuator_reduction());
+  EXPECT_THAT(1.0, DoubleNear(simple_transmission->get_actuator_reduction(), EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, offset_ill_defined)
@@ -403,8 +407,8 @@ TEST(SimpleTransmissionLoaderTest, offset_ill_defined)
     dynamic_cast<transmission_interface::SimpleTransmission *>(transmission.get());
   ASSERT_TRUE(nullptr != simple_transmission);
   // default kicks in for ill-defined values
-  EXPECT_EQ(0.0, simple_transmission->get_joint_offset());
-  EXPECT_EQ(50.0, simple_transmission->get_actuator_reduction());
+  EXPECT_THAT(0.0, DoubleNear(simple_transmission->get_joint_offset(), EPS));
+  EXPECT_THAT(50.0, DoubleNear(simple_transmission->get_actuator_reduction(), EPS));
 }
 
 TEST(SimpleTransmissionLoaderTest, mech_red_invalid_value)

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -27,6 +27,8 @@ using transmission_interface::Exception;
 using transmission_interface::JointHandle;
 using transmission_interface::SimpleTransmission;
 
+using testing::DoubleNear;
+
 // Floating-point value comparison threshold
 const double EPS = 1e-5;
 
@@ -53,8 +55,8 @@ TEST(PreconditionsTest, AccessorValidation)
 
   EXPECT_EQ(1u, trans.num_actuators());
   EXPECT_EQ(1u, trans.num_joints());
-  EXPECT_EQ(2.0, trans.get_actuator_reduction());
-  EXPECT_EQ(-1.0, trans.get_joint_offset());
+  EXPECT_THAT(2.0, DoubleNear(trans.get_actuator_reduction(), EPS));
+  EXPECT_THAT(-1.0, DoubleNear(trans.get_joint_offset(), EPS));
 }
 
 TEST(PreconditionsTest, ConfigureFailsWithInvalidHandles)
@@ -127,7 +129,7 @@ protected:
 
       trans.actuator_to_joint();
       trans.joint_to_actuator();
-      EXPECT_NEAR(ref_val, a_val, EPS);
+      EXPECT_THAT(ref_val, DoubleNear(a_val, EPS));
     }
   }
 };
@@ -187,7 +189,7 @@ TEST_F(WhiteBoxTest, MoveJoint)
     trans.configure({joint_handle}, {actuator_handle});
 
     trans.actuator_to_joint();
-    EXPECT_NEAR(10.0, j_val, EPS);
+    EXPECT_THAT(10.0, DoubleNear(j_val, EPS));
   }
 
   // Velocity interface
@@ -197,7 +199,7 @@ TEST_F(WhiteBoxTest, MoveJoint)
     trans.configure({joint_handle}, {actuator_handle});
 
     trans.actuator_to_joint();
-    EXPECT_NEAR(0.1, j_val, EPS);
+    EXPECT_THAT(0.1, DoubleNear(j_val, EPS));
   }
 
   // Position interface
@@ -207,7 +209,7 @@ TEST_F(WhiteBoxTest, MoveJoint)
     trans.configure({joint_handle}, {actuator_handle});
 
     trans.actuator_to_joint();
-    EXPECT_NEAR(1.1, j_val, EPS);
+    EXPECT_THAT(1.1, DoubleNear(j_val, EPS));
   }
 
   // Mismatched interface is ignored
@@ -221,10 +223,10 @@ TEST_F(WhiteBoxTest, MoveJoint)
 
     trans.configure({joint_handle, joint_handle2}, {actuator_handle});
     trans.actuator_to_joint();
-    EXPECT_NEAR(unique_value, 13.37, EPS);
+    EXPECT_THAT(unique_value, DoubleNear(13.37, EPS));
 
     trans.configure({joint_handle}, {actuator_handle, actuator_handle2});
     trans.actuator_to_joint();
-    EXPECT_NEAR(unique_value, 13.37, EPS);
+    EXPECT_THAT(unique_value, DoubleNear(13.37, EPS));
   }
 }

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -28,7 +28,7 @@ using transmission_interface::JointHandle;
 using transmission_interface::SimpleTransmission;
 
 // Floating-point value comparison threshold
-const double EPS = 1e-6;
+const double EPS = 1e-5;
 
 TEST(PreconditionsTest, ExceptionThrownWithInvalidParameters)
 {


### PR DESCRIPTION
This PR replaces `EXPECT_EQ` with `EXPECT_THAT(..., DoubleNear(...))` for floats, as well as relaxes the used `EPS` from 1e-6 to 1e-5 as mentioned in #1235 . I also replaced the `EXPECT_NEAR` the same way for consistency. I skipped `test_transmission_parser.cpp` as I doesn't seem to be build, but I can adapt it in the same way if wanted.