### PR TITLE
[HW interface] Resource manager publish all Command-/StateInterface values

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -267,6 +267,8 @@ ControllerManager::ControllerManager(
     std::make_shared<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>(
       kControllerInterfaceNamespace, kChainableControllerInterfaceClassName))
 {
+  executor_->add_node(resource_manager_->get_publisher_node());
+
   if (!get_parameter("update_rate", update_rate_))
   {
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");
@@ -308,6 +310,8 @@ ControllerManager::ControllerManager(
     std::make_shared<pluginlib::ClassLoader<controller_interface::ChainableControllerInterface>>(
       kControllerInterfaceNamespace, kChainableControllerInterfaceClassName))
 {
+  executor_->add_node(resource_manager_->get_publisher_node());
+
   if (!get_parameter("update_rate", update_rate_))
   {
     RCLCPP_WARN(get_logger(), "'update_rate' parameter not set, using default value.");

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -258,7 +258,7 @@ ControllerManager::ControllerManager(
   const std::string & namespace_, const rclcpp::NodeOptions & options)
 : rclcpp::Node(manager_node_name, namespace_, options),
   resource_manager_(std::make_unique<hardware_interface::ResourceManager>(
-    update_rate_, this->get_node_clock_interface())),
+    update_rate_, this->get_node_clock_interface(), get_fully_qualified_name())),
   diagnostics_updater_(this),
   executor_(executor),
   loader_(std::make_shared<pluginlib::ClassLoader<controller_interface::ControllerInterface>>(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -12,6 +12,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
   rcpputils
   rcutils
+  realtime_tools
   TinyXML2
   tinyxml2_vendor
 )

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -20,6 +20,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "control_msgs/msg/dynamic_interface_values.hpp"
+#include "control_msgs/msg/single_interface_value.hpp"
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/hardware_component_info.hpp"
 #include "hardware_interface/hardware_info.hpp"
@@ -31,6 +33,7 @@
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/duration.hpp"
+#include "rclcpp/executor.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/time.hpp"
 
@@ -76,6 +79,10 @@ public:
   ResourceManager(const ResourceManager &) = delete;
 
   ~ResourceManager();
+
+  void create_interface_value_publisher();
+
+  rclcpp::Node::SharedPtr get_publisher_node() const;
 
   /// Load resources from on a given URDF.
   /**
@@ -377,6 +384,13 @@ public:
    */
   HardwareReadWriteStatus read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
+  std::vector<control_msgs::msg::SingleInterfaceValue> get_all_state_interface_values() const;
+
+  void publish_all_state_interface_values() const;
+
+  std::vector<control_msgs::msg::SingleInterfaceValue> get_all_command_interface_values() const;
+
+  void publish_all_command_interface_values() const;
   /// Write all loaded hardware components.
   /**
    * Writes to all active hardware components.
@@ -409,6 +423,12 @@ private:
   mutable std::recursive_mutex resource_interfaces_lock_;
   mutable std::recursive_mutex claimed_command_interfaces_lock_;
   mutable std::recursive_mutex resources_lock_;
+
+  std::string interface_values_publisher_name_;
+  std::string interface_values_topic_name_;
+  rclcpp::Node::SharedPtr interface_value_publisher_node_;
+  rclcpp::Publisher<control_msgs::msg::DynamicInterfaceValues>::SharedPtr
+    interface_values_publisher_;
 
   std::unique_ptr<ResourceStorage> resource_storage_;
 

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "control_msgs/msg/dynamic_interface_values.hpp"
-#include "control_msgs/msg/single_interface_value.hpp"
+#include "control_msgs/msg/interface_value.hpp"
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/hardware_component_info.hpp"
 #include "hardware_interface/hardware_info.hpp"
@@ -33,9 +33,9 @@
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/duration.hpp"
-#include "rclcpp/executor.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/time.hpp"
+#include "realtime_tools/realtime_publisher.h"
 
 namespace hardware_interface
 {
@@ -384,13 +384,7 @@ public:
    */
   HardwareReadWriteStatus read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
-  std::vector<control_msgs::msg::SingleInterfaceValue> get_all_state_interface_values() const;
-
-  void publish_all_state_interface_values() const;
-
-  std::vector<control_msgs::msg::SingleInterfaceValue> get_all_command_interface_values() const;
-
-  void publish_all_command_interface_values() const;
+  void publish_all_interface_values() const;
   /// Write all loaded hardware components.
   /**
    * Writes to all active hardware components.
@@ -424,11 +418,11 @@ private:
   mutable std::recursive_mutex claimed_command_interfaces_lock_;
   mutable std::recursive_mutex resources_lock_;
 
-  std::string interface_values_publisher_name_;
-  std::string interface_values_topic_name_;
   rclcpp::Node::SharedPtr interface_value_publisher_node_;
   rclcpp::Publisher<control_msgs::msg::DynamicInterfaceValues>::SharedPtr
     interface_values_publisher_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<control_msgs::msg::DynamicInterfaceValues>>
+    rt_interface_values_publisher_;
 
   std::unique_ptr<ResourceStorage> resource_storage_;
 

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -54,7 +54,8 @@ public:
   /// Default constructor for the Resource Manager.
   ResourceManager(
     unsigned int update_rate = 100,
-    rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface = nullptr);
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface = nullptr,
+    const std::string & fully_qualified_ctrl_mng_node_name = "");
 
   /// Constructor for the Resource Manager.
   /**
@@ -74,13 +75,12 @@ public:
   explicit ResourceManager(
     const std::string & urdf, bool validate_interfaces = true, bool activate_all = false,
     unsigned int update_rate = 100,
-    rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface = nullptr);
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface = nullptr,
+    const std::string & fully_qualified_ctrl_mng_node_name = "");
 
   ResourceManager(const ResourceManager &) = delete;
 
   ~ResourceManager();
-
-  void create_interface_value_publisher();
 
   rclcpp::Node::SharedPtr get_publisher_node() const;
 
@@ -384,7 +384,6 @@ public:
    */
   HardwareReadWriteStatus read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
-  void publish_all_interface_values() const;
   /// Write all loaded hardware components.
   /**
    * Writes to all active hardware components.
@@ -408,6 +407,24 @@ public:
   bool state_interface_exists(const std::string & key) const;
 
 private:
+  /**
+   * We want to publish the values of all available State-/CommandInterfaces. In order to do this we
+   * need to have a node which publishes the values. This function creates a node relative to the
+   * ControllerManager's namespace and name, as well as a RealtimePublisher for publishing the
+   * values.
+   *
+   * \param[in] fully_qualified_ctrl_mng_node_name the full qualified name of the controller manager
+   * e.g. /namespace/controller_manager_1
+   */
+  void create_interface_value_publisher(const std::string & fully_qualified_ctrl_mng_node_name);
+
+  /**
+   * Get all the values from the available State-/CommandInterface and publish them on the
+   * "~/interface_values" topic as diagnosis topic.
+   *
+   */
+  void publish_all_interface_values() const;
+
   void validate_storage(const std::vector<hardware_interface::HardwareInfo> & hardware_info) const;
 
   void release_command_interface(const std::string & key);

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -14,6 +14,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rcpputils</depend>
+  <depend>realtime_tools</depend>
   <depend>tinyxml2_vendor</depend>
 
   <build_depend>rcutils</build_depend>

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1352,7 +1352,7 @@ void ResourceManager::publish_all_interface_values() const
   interface_values.states = state_interface_values;
   interface_values.commands = command_interface_values;
 
-  rt_interface_values_publisher_->lock();
+  rt_interface_values_publisher_->trylock();
   rt_interface_values_publisher_->msg_ = interface_values;
   rt_interface_values_publisher_->unlockAndPublish();
 }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1352,9 +1352,11 @@ void ResourceManager::publish_all_interface_values() const
   interface_values.states = state_interface_values;
   interface_values.commands = command_interface_values;
 
-  rt_interface_values_publisher_->trylock();
-  rt_interface_values_publisher_->msg_ = interface_values;
-  rt_interface_values_publisher_->unlockAndPublish();
+  if(rt_interface_values_publisher_->trylock())
+  {
+    rt_interface_values_publisher_->msg_ = interface_values;
+    rt_interface_values_publisher_->unlockAndPublish();
+  }
 }
 
 // CM API: Called in "update"-thread


### PR DESCRIPTION
This adds publishing of all the values of the command-/stateInterfaces by the resource manager. Provides a kind of diagnostic interface. The values are published to `/resource_manager_publisher_node/interface_values`.
This PR depends on this [PR from the control_msgs repos](https://github.com/ros-controls/control_msgs/pull/98).
