### PR TITLE
controller_manager: Add space to string literal concatenation

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -948,7 +948,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     {
       RCLCPP_WARN(
         get_logger(),
-        "Controller with name '%s' is not inactive so its following"
+        "Controller with name '%s' is not inactive so its following "
         "controllers do not have to be checked, because it cannot be activated.",
         controller_it->info.name.c_str());
       status = controller_interface::return_type::ERROR;


### PR DESCRIPTION
There is no space between the string literals, "following" and "controllers". This results in "followingcontrollers", which is not what we want.

Add a space to the first string to fix this.