### PR TITLE
[CI] Set `ref` input explicitely for action-ros-ci

### DIFF
--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           target-ros2-distro: ${{ inputs.ros_distro }}
           # build all packages listed in the meta package
+          ref: ${{ inputs.ref }} # otherwise the default branch is used for scheduled workflows
           package-name:
             controller_interface
             controller_manager


### PR DESCRIPTION
This closes #1253, see the details there.