### PR TITLE
[CI] Increase timeout further for controller_managers_srv test

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -141,7 +141,7 @@ if(BUILD_TESTING)
     test_chainable_controller
     ros2_control_test_assets::ros2_control_test_assets
   )
-  set_tests_properties(test_controller_manager_srvs PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_controller_manager_srvs PROPERTIES TIMEOUT 240)
   ament_target_dependencies(test_controller_manager_srvs
     controller_manager_msgs
   )


### PR DESCRIPTION
The increased timeout from #1224 is not sufficient, see [this job](https://github.com/ros-controls/ros2_control/actions/runs/7356297755/job/20026214699).

