### PR TITLE
[docs] Remove joint_state_controller

### DIFF
--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -32,12 +32,12 @@ def generate_load_controller_launch_description(
     Examples # noqa: D416
     --------
       # Assuming the controller type and controller parameters are known to the controller_manager
-      generate_load_controller_launch_description('joint_state_controller')
+      generate_load_controller_launch_description('joint_state_broadcaster')
 
       # Passing controller type and controller parameter file to load
       generate_load_controller_launch_description(
-        'joint_state_controller',
-        controller_type='joint_state_controller/JointStateController',
+        'joint_state_broadcaster',
+        controller_type='joint_state_broadcaster/JointStateBroadcaster',
         controller_params_file=os.path.join(get_package_share_directory('my_pkg'),
                                             'config', 'controller_params.yaml')
         )

--- a/ros2controlcli/doc/userdoc.rst
+++ b/ros2controlcli/doc/userdoc.rst
@@ -73,7 +73,7 @@ Example output:
 
     $ ros2 control list_controller_types
     diff_drive_controller/DiffDriveController                              controller_interface::ControllerInterface
-    joint_state_controller/JointStateController                            controller_interface::ControllerInterface
+    joint_state_broadcaster/JointStateBroadcaster                          controller_interface::ControllerInterface
     joint_trajectory_controller/JointTrajectoryController                  controller_interface::ControllerInterface
 
 


### PR DESCRIPTION
I found remnants from the time before joint_state_controller got renamed to joint_state_broadcaster.