### PR TITLE
Fix rqt controller manager 

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -47,57 +47,75 @@ def service_caller(node, service_name, service_type, request, service_timeout=10
         raise RuntimeError(f"Exception while calling service: {future.exception()}")
 
 
-def configure_controller(node, controller_manager_name, controller_name):
+def configure_controller(node, controller_manager_name, controller_name, service_timeout=10.0):
     request = ConfigureController.Request()
     request.name = controller_name
     return service_caller(
-        node, f"{controller_manager_name}/configure_controller", ConfigureController, request
+        node,
+        f"{controller_manager_name}/configure_controller",
+        ConfigureController,
+        request,
+        service_timeout,
     )
 
 
-def list_controllers(node, controller_manager_name):
+def list_controllers(node, controller_manager_name, service_timeout=10.0):
     request = ListControllers.Request()
     return service_caller(
-        node, f"{controller_manager_name}/list_controllers", ListControllers, request
+        node,
+        f"{controller_manager_name}/list_controllers",
+        ListControllers,
+        request,
+        service_timeout,
     )
 
 
-def list_controller_types(node, controller_manager_name):
+def list_controller_types(node, controller_manager_name, service_timeout=10.0):
     request = ListControllerTypes.Request()
     return service_caller(
-        node, f"{controller_manager_name}/list_controller_types", ListControllerTypes, request
+        node,
+        f"{controller_manager_name}/list_controller_types",
+        ListControllerTypes,
+        request,
+        service_timeout,
     )
 
 
-def list_hardware_components(node, controller_manager_name):
+def list_hardware_components(node, controller_manager_name, service_timeout=10.0):
     request = ListHardwareComponents.Request()
     return service_caller(
         node,
         f"{controller_manager_name}/list_hardware_components",
         ListHardwareComponents,
         request,
+        service_timeout,
     )
 
 
-def list_hardware_interfaces(node, controller_manager_name):
+def list_hardware_interfaces(node, controller_manager_name, service_timeout=10.0):
     request = ListHardwareInterfaces.Request()
     return service_caller(
         node,
         f"{controller_manager_name}/list_hardware_interfaces",
         ListHardwareInterfaces,
         request,
+        service_timeout,
     )
 
 
-def load_controller(node, controller_manager_name, controller_name):
+def load_controller(node, controller_manager_name, controller_name, service_timeout=10.0):
     request = LoadController.Request()
     request.name = controller_name
     return service_caller(
-        node, f"{controller_manager_name}/load_controller", LoadController, request
+        node,
+        f"{controller_manager_name}/load_controller",
+        LoadController,
+        request,
+        service_timeout,
     )
 
 
-def reload_controller_libraries(node, controller_manager_name, force_kill):
+def reload_controller_libraries(node, controller_manager_name, force_kill, service_timeout=10.0):
     request = ReloadControllerLibraries.Request()
     request.force_kill = force_kill
     return service_caller(
@@ -105,10 +123,13 @@ def reload_controller_libraries(node, controller_manager_name, force_kill):
         f"{controller_manager_name}/reload_controller_libraries",
         ReloadControllerLibraries,
         request,
+        service_timeout,
     )
 
 
-def set_hardware_component_state(node, controller_manager_name, component_name, lifecyle_state):
+def set_hardware_component_state(
+    node, controller_manager_name, component_name, lifecyle_state, service_timeout=10.0
+):
     request = SetHardwareComponentState.Request()
     request.name = component_name
     request.target_state = lifecyle_state
@@ -117,6 +138,7 @@ def set_hardware_component_state(node, controller_manager_name, component_name, 
         f"{controller_manager_name}/set_hardware_component_state",
         SetHardwareComponentState,
         request,
+        service_timeout,
     )
 
 
@@ -143,9 +165,13 @@ def switch_controllers(
     )
 
 
-def unload_controller(node, controller_manager_name, controller_name):
+def unload_controller(node, controller_manager_name, controller_name, service_timeout=10.0):
     request = UnloadController.Request()
     request.name = controller_name
     return service_caller(
-        node, f"{controller_manager_name}/unload_controller", UnloadController, request
+        node,
+        f"{controller_manager_name}/unload_controller",
+        UnloadController,
+        request,
+        service_timeout,
     )

--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -172,16 +172,22 @@ class ControllerManager(Plugin):
         @rtype [str]
         """
         # Add loaded controllers first
-        controllers = list_controllers(self._node, self._cm_name).controller
+        try:
+            controllers = list_controllers(
+                self._node, self._cm_name, 2.0 / self._cm_update_freq
+            ).controller
 
-        # Append potential controller configs found in the node's parameters
-        for name in _get_parameter_controller_names(self._node, self._cm_name):
-            add_ctrl = all(name != ctrl.name for ctrl in controllers)
-            if add_ctrl:
-                type_str = _get_controller_type(self._node, self._cm_name, name)
-                uninit_ctrl = ControllerState(name=name, type=type_str)
-                controllers.append(uninit_ctrl)
-        return controllers
+            # Append potential controller configs found in the node's parameters
+            for name in _get_parameter_controller_names(self._node, self._cm_name):
+                add_ctrl = all(name != ctrl.name for ctrl in controllers)
+                if add_ctrl:
+                    type_str = _get_controller_type(self._node, self._cm_name, name)
+                    uninit_ctrl = ControllerState(name=name, type=type_str)
+                    controllers.append(uninit_ctrl)
+            return controllers
+        except RuntimeError as e:
+            print(e)
+            return []
 
     def _show_controllers(self):
         table_view = self._widget.table_view


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/issues/1223

Before:

```
Traceback (most recent call last):
  File "/workspaces/ros2_baustelle_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 153, in _update_controllers
    controllers = self._list_controllers()
  File "/workspaces/ros2_baustelle_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 171, in _list_controllers
    controllers = list_controllers(self._node, self._cm_name).controller
  File "/workspaces/ros2_baustelle_ws/install/controller_manager/local/lib/python3.10/dist-packages/controller_manager/controller_manager_services.py", line 49, in list_controllers
    return service_caller(node, f'{controller_manager_name}/list_controllers',
  File "/workspaces/ros2_baustelle_ws/install/controller_manager/local/lib/python3.10/dist-packages/controller_manager/controller_manager_services.py", line 29, in service_caller
    raise RuntimeError(f'Could not contact service {service_name}')
RuntimeError: Could not contact service /controller_manager/list_controllers

```

Now, instead of raising an exception and closing, it will clear the window and then connects to the server when it is available again
![image](https://github.com/ros-controls/ros2_control/assets/10082428/f5f2bd73-b5c5-4710-a11f-033479bca7e2)
