### PR TITLE
fix the multiple definitions of lexical casts methods

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(hardware_interface SHARED
   src/resource_manager.cpp
   src/sensor.cpp
   src/system.cpp
+  src/lexical_casts.cpp
 )
 target_compile_features(hardware_interface PUBLIC cxx_std_17)
 target_include_directories(hardware_interface PUBLIC

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 ros2_control Development Team
+// Copyright 2024 ros2_control Development Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
-#define HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
-
-#include <locale>
-#include <sstream>
-#include <stdexcept>
-#include <string>
+#include "hardware_interface/lexical_casts.hpp"
 
 namespace hardware_interface
 {
+double stod(const std::string & s)
+{
+  // convert from string using no locale
+  std::istringstream stream(s);
+  stream.imbue(std::locale::classic());
+  double result;
+  stream >> result;
+  if (stream.fail() || !stream.eof())
+  {
+    throw std::invalid_argument("Failed converting string to real number");
+  }
+  return result;
+}
 
-/** \brief Helper function to convert a std::string to double in a locale-independent way.
- \throws std::invalid_argument if not a valid number
- * from
- https://github.com/ros-planning/srdfdom/blob/ad17b8d25812f752c397a6011cec64aeff090c46/src/model.cpp#L53
-*/
-double stod(const std::string & s);
-
-bool parse_bool(const std::string & bool_string);
-
+bool parse_bool(const std::string & bool_string)
+{
+  return bool_string == "true" || bool_string == "True";
+}
 }  // namespace hardware_interface
-
-#endif  // HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_


### PR DESCRIPTION
Fixes the issue caused in the PR : https://github.com/ros-controls/ros2_control_demos/pull/428

When you have multiple files using the lexical casts header and they create the same library/executable, they show this multiple definitions error

````
--- stderr: ros2_control_demo_example_14
/usr/bin/ld: CMakeFiles/ros2_control_demo_example_14.dir/hardware/rrbot_sensor_for_position_feedback.cpp.o: in function `hardware_interface::stod(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
rrbot_sensor_for_position_feedback.cpp:(.text+0x3a): multiple definition of `hardware_interface::stod(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'; CMakeFiles/ros2_control_demo_example_14.dir/hardware/rrbot_actuator_without_feedback.cpp.o:rrbot_actuator_without_feedback.cpp:(.text+0xb): first defined here
/usr/bin/ld: CMakeFiles/ros2_control_demo_example_14.dir/hardware/rrbot_sensor_for_position_feedback.cpp.o: in function `hardware_interface::parse_bool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
rrbot_sensor_for_position_feedback.cpp:(.text+0x1cb): multiple definition of `hardware_interface::parse_bool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'; CMakeFiles/ros2_control_demo_example_14.dir/hardware/rrbot_actuator_without_feedback.cpp.o:rrbot_actuator_without_feedback.cpp:(.text+0x19c): first defined here
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/ros2_control_demo_example_14.dir/build.make:257: libros2_control_demo_example_14.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/ros2_control_demo_example_14.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
```

