### PR TITLE
adding backward compatibility for string-to-double conversion

### DIFF
--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -16,6 +16,7 @@
 #define HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
 
 #include <locale>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -16,8 +16,10 @@
 
 namespace hardware_interface
 {
+
+#if __cplusplus > 201402L
 double stod(const std::string & s)
-{
+{ 
   // convert from string using no locale
   std::istringstream stream(s);
   stream.imbue(std::locale::classic());
@@ -29,7 +31,19 @@ double stod(const std::string & s)
   }
   return result;
 }
+#else
+double stod(const std::string & text)
+{
+  double result_value;
+  const auto parse_result = std::from_chars(text.data(), text.data() + text.size(), result_value);
+  if (parse_result.ec == std::errc())
+  {
+    return result_value;
+  }
 
+  return 0.0;
+}
+#endif
 bool parse_bool(const std::string & bool_string)
 {
   return bool_string == "true" || bool_string == "True";

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -16,7 +16,6 @@
 
 namespace hardware_interface
 {
-
 double stod(const std::string & s)
 #if __cplusplus > 201703L
 {

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -17,8 +17,8 @@
 namespace hardware_interface
 {
 double stod(const std::string & s)
-#if __cplusplus > 201703L
 {
+#if __cplusplus < 202002L
   // convert from string using no locale
   std::istringstream stream(s);
   stream.imbue(std::locale::classic());
@@ -29,11 +29,9 @@ double stod(const std::string & s)
     throw std::invalid_argument("Failed converting string to real number");
   }
   return result;
-}
 #else
-{
   double result_value;
-  const auto parse_result = std::from_chars(text.data(), text.data() + text.size(), result_value);
+  const auto parse_result = std::from_chars(s.data(), s.data() + s.size(), result_value);
   if (parse_result.ec == std::errc())
   {
     return result_value;

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -41,8 +41,8 @@ double stod(const std::string & s)
   }
 
   return 0.0;
-}
 #endif
+}
 bool parse_bool(const std::string & bool_string)
 {
   return bool_string == "true" || bool_string == "True";

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -16,10 +16,13 @@
 
 namespace hardware_interface
 {
-double stod(const std::string & s)
+namespace impl
+{
+std::optional<double> stod(const std::string & s)
 {
 #if __cplusplus < 202002L
   // convert from string using no locale
+  // Impl with std::istringstream
   std::istringstream stream(s);
   stream.imbue(std::locale::classic());
   double result;
@@ -30,6 +33,7 @@ double stod(const std::string & s)
   }
   return result;
 #else
+  // Impl with std::from_chars
   double result_value;
   const auto parse_result = std::from_chars(s.data(), s.data() + s.size(), result_value);
   if (parse_result.ec == std::errc())
@@ -37,8 +41,18 @@ double stod(const std::string & s)
     return result_value;
   }
 
-  return 0.0;
+  return std::nullopt;
+  ;
 #endif
+}
+}  // namespace impl
+double stod(const std::string & s)
+{
+  if (const auto result = impl::stod(s))
+  {
+    return *result;
+  }
+  throw std::invalid_argument("Failed converting string to real number");
 }
 bool parse_bool(const std::string & bool_string)
 {

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -29,7 +29,7 @@ std::optional<double> stod(const std::string & s)
   stream >> result;
   if (stream.fail() || !stream.eof())
   {
-    throw std::invalid_argument("Failed converting string to real number");
+    return std::nullopt;
   }
   return result;
 #else
@@ -40,9 +40,7 @@ std::optional<double> stod(const std::string & s)
   {
     return result_value;
   }
-
   return std::nullopt;
-  ;
 #endif
 }
 }  // namespace impl

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -32,7 +32,6 @@ double stod(const std::string & s)
   return result;
 }
 #else
-double stod(const std::string & text)
 {
   double result_value;
   const auto parse_result = std::from_chars(text.data(), text.data() + text.size(), result_value);

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -19,7 +19,7 @@ namespace hardware_interface
 
 #if __cplusplus > 201402L
 double stod(const std::string & s)
-{ 
+{
   // convert from string using no locale
   std::istringstream stream(s);
   stream.imbue(std::locale::classic());

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -17,8 +17,8 @@
 namespace hardware_interface
 {
 
-#if __cplusplus > 201402L
 double stod(const std::string & s)
+#if __cplusplus > 201703L
 {
   // convert from string using no locale
   std::istringstream stream(s);


### PR DESCRIPTION
Adding backward compatibility for string to double conversion as mentioned in 
https://github.com/ros-controls/ros2_control/pull/1257#discussion_r1442821397