### PR TITLE
Fix controller parameter loading issue in different cases

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -414,6 +414,16 @@ private:
     const std::vector<controller_manager::ControllerSpec> & controllers);
 
   void controller_activity_diagnostic_callback(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  /**
+   * @brief determine_controller_node_options - A method that retrieves the controller defined node
+   * options and adapts them, based on if there is a params file to be loaded or the use_sim_time
+   * needs to be set
+   * @param controller - controller info
+   * @return The node options that will be set to the controller LifeCycleNode
+   */
+  rclcpp::NodeOptions determine_controller_node_options(const ControllerSpec & controller) const;
+
   diagnostic_updater::Updater diagnostics_updater_;
 
   std::shared_ptr<rclcpp::Executor> executor_;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -574,6 +574,23 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
   controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(
     0, 0, this->get_node_clock_interface()->get_clock()->get_clock_type());
 
+  // We have to fetch the params_file at the time of loading the controller, because this way we can
+  // load them at the creating of the LifeCycleNode and this helps in using the features such as
+  // read_only params, dynamic maps lists etc
+  // Now check if the params_file parameter exist
+  const std::string param_name = controller_name + ".params_file";
+  std::string params_file;
+
+  // Check if parameter has been declared
+  if (!has_parameter(param_name))
+  {
+    declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_STRING);
+  }
+  if (get_parameter(param_name, params_file) && !params_file.empty())
+  {
+    controller_spec.info.params_file = params_file;
+  }
+
   return add_controller_impl(controller_spec);
 }
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1317,10 +1317,16 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
     return nullptr;
   }
 
+  rclcpp::NodeOptions controller_node_options = rclcpp::NodeOptions().enable_logger_service(true);
+  if (controller.info.params_file.has_value())
+  {
+    controller_node_options = controller_node_options.arguments(
+      {"--ros-args", "--params-file", controller.info.params_file.value()});
+  }
   if (
     controller.c->init(
-      controller.info.name, robot_description_, get_update_rate(), get_namespace()) ==
-    controller_interface::return_type::ERROR)
+      controller.info.name, robot_description_, get_update_rate(), get_namespace(),
+      controller_node_options) == controller_interface::return_type::ERROR)
   {
     to.clear();
     RCLCPP_ERROR(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -574,21 +574,21 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
   controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(
     0, 0, this->get_node_clock_interface()->get_clock()->get_clock_type());
 
-  // We have to fetch the params_file at the time of loading the controller, because this way we can
-  // load them at the creation of the LifeCycleNode and this helps in using the features such as
+  // We have to fetch the parameters_file at the time of loading the controller, because this way we
+  // can load them at the creation of the LifeCycleNode and this helps in using the features such as
   // read_only params, dynamic maps lists etc
-  // Now check if the params_file parameter exist
+  // Now check if the parameters_file parameter exist
   const std::string param_name = controller_name + ".params_file";
-  std::string params_file;
+  std::string parameters_file;
 
   // Check if parameter has been declared
   if (!has_parameter(param_name))
   {
     declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_STRING);
   }
-  if (get_parameter(param_name, params_file) && !params_file.empty())
+  if (get_parameter(param_name, parameters_file) && !parameters_file.empty())
   {
-    controller_spec.info.params_file = params_file;
+    controller_spec.info.parameters_file = parameters_file;
   }
 
   return add_controller_impl(controller_spec);
@@ -1318,10 +1318,10 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
   }
 
   rclcpp::NodeOptions controller_node_options = rclcpp::NodeOptions().enable_logger_service(true);
-  if (controller.info.params_file.has_value())
+  if (controller.info.parameters_file.has_value())
   {
     controller_node_options = controller_node_options.arguments(
-      {"--ros-args", "--params-file", controller.info.params_file.value()});
+      {"--ros-args", "--params-file", controller.info.parameters_file.value()});
   }
   if (
     controller.c->init(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -575,7 +575,7 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
     0, 0, this->get_node_clock_interface()->get_clock()->get_clock_type());
 
   // We have to fetch the params_file at the time of loading the controller, because this way we can
-  // load them at the creating of the LifeCycleNode and this helps in using the features such as
+  // load them at the creation of the LifeCycleNode and this helps in using the features such as
   // read_only params, dynamic maps lists etc
   // Now check if the params_file parameter exist
   const std::string param_name = controller_name + ".params_file";

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1332,6 +1332,19 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
     node_options_arguments.push_back("--params-file");
     node_options_arguments.push_back(controller.info.parameters_file.value());
   }
+
+  // ensure controller's `use_sim_time` parameter matches controller_manager's
+  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
+  if (use_sim_time.as_bool())
+  {
+    if (!check_for_element(node_options_arguments, ros_args_arg))
+    {
+      node_options_arguments.push_back(ros_args_arg);
+    }
+    node_options_arguments.push_back("-p");
+    node_options_arguments.push_back("use_sim_time:=true");
+  }
+
   controller_node_options = controller_node_options.arguments(node_options_arguments);
   if (
     controller.c->init(
@@ -1344,17 +1357,6 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
     return nullptr;
   }
 
-  // ensure controller's `use_sim_time` parameter matches controller_manager's
-  const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
-  if (use_sim_time.as_bool())
-  {
-    RCLCPP_INFO(
-      get_logger(),
-      "Setting use_sim_time=True for %s to match controller manager "
-      "(see ros2_control#325 for details)",
-      controller.info.name.c_str());
-    controller.c->get_node()->set_parameter(use_sim_time);
-  }
   executor_->add_node(controller.c->get_node()->get_node_base_interface());
   to.emplace_back(controller);
 

--- a/hardware_interface/include/hardware_interface/controller_info.hpp
+++ b/hardware_interface/include/hardware_interface/controller_info.hpp
@@ -34,7 +34,7 @@ struct ControllerInfo
   std::string type;
 
   /// Controller param file
-  std::optional<std::string> params_file;
+  std::optional<std::string> parameters_file;
 
   /// List of claimed interfaces by the controller.
   std::vector<std::string> claimed_interfaces;

--- a/hardware_interface/include/hardware_interface/controller_info.hpp
+++ b/hardware_interface/include/hardware_interface/controller_info.hpp
@@ -15,6 +15,7 @@
 #ifndef HARDWARE_INTERFACE__CONTROLLER_INFO_HPP_
 #define HARDWARE_INTERFACE__CONTROLLER_INFO_HPP_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,9 @@ struct ControllerInfo
 
   /// Controller type.
   std::string type;
+
+  /// Controller param file
+  std::optional<std::string> params_file;
 
   /// List of claimed interfaces by the controller.
   std::vector<std::string> claimed_interfaces;


### PR DESCRIPTION
Lately, we have had reports about issues with loading parameters by parsing the param file to the spawners. This didn't work sometimes because we were trying to initialize the GPL library in the init. When it tries to declare and get the parameters, as they are not available, it throws an exception as the validation sometimes fails (as in https://github.com/ros-controls/ros2_controllers/pull/698 and https://github.com/ros-controls/ros2_controllers/pull/795)  (or) that we couldn't also use the `read_only` parameters in this case, and they need to exist upon the LifeCycleNode creation (https://github.com/ros-controls/ros2_controllers/issues/966). 

Upon taking a close look at the documentation, I think we can use the following approach to be able to properly set the parameters to the Node.

The following approach can be backported, however, in some cases that the controllers needs to override their `NodeOptions` for their particular use-case (as [in some tests](https://github.com/ros-controls/ros2_control/blob/8c34ab6b383ea53c53c05fe460f9c7c743a96fa1/controller_manager/test/test_controller_failed_init/test_controller_failed_init.hpp#L41-L48)), this won't work as the default argument from the controller_interface_base.hpp will be overridden by the CM now. Inorder to properly fix this, we will need a part of this PR : https://github.com/ros-controls/ros2_control/pull/1169

Fixes: https://github.com/ros-controls/ros2_control/issues/1311
Fixes: https://github.com/ros-controls/ros2_controllers/issues/966
Closes: https://github.com/ros-controls/ros2_controllers/pull/795
Closes: https://github.com/PickNikRobotics/generate_parameter_library/pull/156