### PR TITLE
Fix crash for missing urdf in resource manager

### DIFF
--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -418,8 +418,6 @@ private:
 
   // Structure to store read and write status so it is not initialized in the real-time loop
   HardwareReadWriteStatus read_write_status;
-
-  bool is_urdf_loaded__ = false;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -86,8 +86,12 @@ public:
    * \param[in] urdf string containing the URDF.
    * \param[in] validate_interfaces boolean argument indicating whether the exported
    * interfaces ought to be validated. Defaults to true.
+   * \param[in] load_and_initialize_components boolean argument indicating whether to load and
+   * initialize the components present in the parsed URDF. Defaults to true.
    */
-  void load_urdf(const std::string & urdf, bool validate_interfaces = true);
+  void load_urdf(
+    const std::string & urdf, bool validate_interfaces = true,
+    bool load_and_initialize_components = true);
 
   /**
    * @brief if the resource manager load_urdf(...) function has been called this returns true.

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -418,6 +418,8 @@ private:
 
   // Structure to store read and write status so it is not initialized in the real-time loop
   HardwareReadWriteStatus read_write_status;
+
+  bool is_urdf_loaded__ = false;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -795,7 +795,12 @@ void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfac
     resource_storage_->systems_.size());
 }
 
-bool ResourceManager::is_urdf_already_loaded() const { return is_urdf_loaded__; }
+bool ResourceManager::is_urdf_already_loaded() const
+{
+  return (
+    !resource_storage_->actuators_.empty() || !resource_storage_->sensors_.empty() ||
+    !resource_storage_->systems_.empty());
+}
 
 // CM API: Called in "update"-thread
 LoanedStateInterface ResourceManager::claim_state_interface(const std::string & key)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -758,7 +758,6 @@ ResourceManager::ResourceManager(
 // CM API: Called in "callback/slow"-thread
 void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfaces)
 {
-  is_urdf_loaded__ = true;
   const std::string system_type = "system";
   const std::string sensor_type = "sensor";
   const std::string actuator_type = "actuator";

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -758,6 +758,7 @@ ResourceManager::ResourceManager(
 // CM API: Called in "callback/slow"-thread
 void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfaces)
 {
+  is_urdf_loaded__ = true;
   const std::string system_type = "system";
   const std::string sensor_type = "sensor";
   const std::string actuator_type = "actuator";

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -756,7 +756,8 @@ ResourceManager::ResourceManager(
 }
 
 // CM API: Called in "callback/slow"-thread
-void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfaces)
+void ResourceManager::load_urdf(
+  const std::string & urdf, bool validate_interfaces, bool load_and_initialize_components)
 {
   is_urdf_loaded__ = true;
   const std::string system_type = "system";
@@ -764,22 +765,25 @@ void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfac
   const std::string actuator_type = "actuator";
 
   const auto hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf);
-  for (const auto & individual_hardware_info : hardware_info)
+  if (load_and_initialize_components)
   {
-    if (individual_hardware_info.type == actuator_type)
+    for (const auto & individual_hardware_info : hardware_info)
     {
-      std::scoped_lock guard(resource_interfaces_lock_, claimed_command_interfaces_lock_);
-      resource_storage_->load_and_initialize_actuator(individual_hardware_info);
-    }
-    if (individual_hardware_info.type == sensor_type)
-    {
-      std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
-      resource_storage_->load_and_initialize_sensor(individual_hardware_info);
-    }
-    if (individual_hardware_info.type == system_type)
-    {
-      std::scoped_lock guard(resource_interfaces_lock_, claimed_command_interfaces_lock_);
-      resource_storage_->load_and_initialize_system(individual_hardware_info);
+      if (individual_hardware_info.type == actuator_type)
+      {
+        std::scoped_lock guard(resource_interfaces_lock_, claimed_command_interfaces_lock_);
+        resource_storage_->load_and_initialize_actuator(individual_hardware_info);
+      }
+      if (individual_hardware_info.type == sensor_type)
+      {
+        std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
+        resource_storage_->load_and_initialize_sensor(individual_hardware_info);
+      }
+      if (individual_hardware_info.type == system_type)
+      {
+        std::scoped_lock guard(resource_interfaces_lock_, claimed_command_interfaces_lock_);
+        resource_storage_->load_and_initialize_system(individual_hardware_info);
+      }
     }
   }
 
@@ -795,12 +799,7 @@ void ResourceManager::load_urdf(const std::string & urdf, bool validate_interfac
     resource_storage_->systems_.size());
 }
 
-bool ResourceManager::is_urdf_already_loaded() const
-{
-  return (
-    !resource_storage_->actuators_.empty() || !resource_storage_->sensors_.empty() ||
-    !resource_storage_->systems_.empty());
-}
+bool ResourceManager::is_urdf_already_loaded() const { return is_urdf_loaded__; }
 
 // CM API: Called in "update"-thread
 LoanedStateInterface ResourceManager::claim_state_interface(const std::string & key)


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/issues/1299

These changes are needed after the merging of https://github.com/ros-controls/ros2_control/pull/1271 and https://github.com/ros-controls/ros2_control/pull/1272. It seems like the gazebo_ros2_control doesn't load the URDF into the resource manager, and this is causing the CM services not to start.

https://github.com/saikishor/gazebo_ros2_control/blob/60e4b75f4a786c9563d7dd97c6d08a31ca69c5b1/gazebo_ros2_control/src/gazebo_ros2_control_plugin.cpp#L366-L371

The gazebo_ros2_control doesn't load_urdf into the resource manager instead, it sets up the components and initializes it. Loading the URDF with the [`load_urdf`](https://github.com/ros-controls/ros2_control/blob/3309c6dbaf4ab5140d13908bedb6fb471c422498/hardware_interface/src/resource_manager.cpp#L759-L796) method will probably fail, because this method originally loads and initializes the hardware interfaces and this step might probably fail.

## Solution 1
I thought it would be wiser to utilize the size of the components to check if the URDF is loaded. This way without any changes from the gazebo_ros2_control side, we can have this issue fixed.

## Solution 2
We can either go with this fix or add a new default argument to the `load_urdf` method to not load_and_initialize_components

https://github.com/ros-controls/ros2_control/blob/3309c6dbaf4ab5140d13908bedb6fb471c422498/hardware_interface/src/resource_manager.cpp#L759-L796

This is also interesting as in the future, if we want to get the URDF information into the resource manager to parse things like limits or other entities