### PR TITLE
[CI] RHEL workflows (backport #1302) 

### DIFF
--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -1,17 +1,15 @@
 name: Humble RHEL Binary Build
 on:
   workflow_dispatch:
+  push:
     branches:
       - humble
-#  pull_request:
-#    branches:
-#      - humble
-#  push:
-#    branches:
-#      - humble
-#  schedule:
-#    # Run every day to detect flakiness and broken dependencies
-#    - cron: '03 1 * * *'
+  pull_request:
+    branches:
+      - humble
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
 
 jobs:
   humble_rhel_binary:

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -26,5 +26,6 @@ jobs:
           rosdep update
           rosdep install -iy --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build
-          colcon test
+          colcon build --packages-skip rqt_controller_manager
+          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          colcon test-result

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -24,7 +24,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iy --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -24,7 +24,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iyr --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control || true
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -25,7 +25,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iyr --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control || true
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -27,5 +27,6 @@ jobs:
           rosdep update
           rosdep install -iy --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build
-          colcon test
+          colcon build --packages-skip rqt_controller_manager
+          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          colcon test-result

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -25,7 +25,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iy --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -1,17 +1,16 @@
 name: Iron RHEL Binary Build
 on:
   workflow_dispatch:
+  push:
     branches:
       - iron
-#  pull_request:
-#    branches:
-#      - iron
-#  push:
-#    branches:
-#      - iron
-#  schedule:
-#    # Run every day to detect flakiness and broken dependencies
-#    - cron: '03 1 * * *'
+  pull_request:
+    branches:
+      - iron
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
 
 jobs:
   iron_rhel_binary:

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -25,7 +25,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iyr --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control || true
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -27,5 +27,6 @@ jobs:
           rosdep update
           rosdep install -iy --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          colcon build
-          colcon test
+          colcon build --packages-skip rqt_controller_manager
+          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          colcon test-result

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -25,7 +25,7 @@ jobs:
           path: src/ros2_control
       - run: |
           rosdep update
-          rosdep install -iy --from-path src/ros2_control
+          rosdep install -iyr --from-path src/ros2_control
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   schedule:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 1 * * *'


### PR DESCRIPTION
Fix syntax to match https://github.com/ros-controls/ros2_control/pull/1302 for future backports

> RHEL iron workflow now fails because of rosdep is missing binaries
> 
> >  ERROR: the following rosdeps failed to install
> >   dnf: Failed to detect successful installation of [ros-iron-rqt-gui]
> >   dnf: Failed to detect successful installation of [ros-iron-rqt-gui-py]
> >   dnf: Failed to detect successful installation of [python%{python3_pkgversion}-pygraphviz]
> 
> But I think this is not our fault: https://build.ros2.org/job/Ibin_rhel_el964__rqt_gui__rhel_9_x86_64__binary/

Edit: I excluded the GUI packages, what makes the job succeed.