### PR TITLE
[RHEL-CI] Source underlay with generate_parameter_library

### DIFF
--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Build and test
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli
           colcon test-result --verbose

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build and test
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli
           colcon test-result --verbose

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build and test
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/setup.bash
           colcon build --packages-skip rqt_controller_manager
           colcon test --packages-skip rqt_controller_manager ros2controlcli
           colcon test-result --verbose


### PR DESCRIPTION
generate_parameter_library is necessary for https://github.com/ros-controls/ros2_control/pull/971, and somehow it is not released for RHEL: [ _This project is currently disabled_](https://build.ros2.org/job/Rbin_rhel_el964__generate_parameter_library__rhel_9_x86_64__binary/) 

For build details see
https://github.com/ros-controls/ros2_rhel/blob/7bfd5933856388cbfee493e1805b6d95cfee32f6/Dockerfile.rhel9#L49-L61
https://github.com/ros-controls/ros2_rhel/blame/7bfd5933856388cbfee493e1805b6d95cfee32f6/Dockerfile.rhel8#L33-L46