### PR TITLE
Add documentation about initial_value regarding mock_hw

### DIFF
--- a/hardware_interface/doc/hardware_interface_types_userdoc.rst
+++ b/hardware_interface/doc/hardware_interface_types_userdoc.rst
@@ -86,7 +86,7 @@ They can be combined together within the different hardware component types (sys
       <gpio name="flange_analog_IOs">
         <command_interface name="analog_output1"/>
         <state_interface name="analog_output1">    <!-- Needed to know current state of the output -->
-          <param name="initial_value">3.1</param>  <!-- Optional initial value for mock_hardware or gazebo -->
+          <param name="initial_value">3.1</param>  <!-- Optional initial value for mock_hardware -->
         </state_interface>
         <state_interface name="analog_input1"/>
         <state_interface name="analog_input2"/>

--- a/hardware_interface/doc/hardware_interface_types_userdoc.rst
+++ b/hardware_interface/doc/hardware_interface_types_userdoc.rst
@@ -85,7 +85,9 @@ They can be combined together within the different hardware component types (sys
       </gpio>
       <gpio name="flange_analog_IOs">
         <command_interface name="analog_output1"/>
-        <state_interface name="analog_output1"/>    <!-- Needed to know current state of the output -->
+        <state_interface name="analog_output1">    <!-- Needed to know current state of the output -->
+          <param name="initial_value">3.1</param>  <!-- Optional initial value for mock_hardware or gazebo -->
+        </state_interface>
         <state_interface name="analog_input1"/>
         <state_interface name="analog_input2"/>
       </gpio>

--- a/hardware_interface/doc/mock_components_userdoc.rst
+++ b/hardware_interface/doc/mock_components_userdoc.rst
@@ -66,4 +66,6 @@ initial_value (optional; double)
        <param name="initial_value">3.45</param>
      </state_interface>
 
-  Note: This parameter is shared with the gazebo and gazebo classic plugins.
+  Note: This parameter is shared with the gazebo and gazebo classic plugins for
+  joint interfaces. For Mock components it is also possible to set initial
+  values for gpio or sensor state interfaces.

--- a/hardware_interface/doc/mock_components_userdoc.rst
+++ b/hardware_interface/doc/mock_components_userdoc.rst
@@ -53,3 +53,17 @@ mimic (optional; string)
 
 multiplier (optional; double; default: 1; used if mimic joint is defined)
   Multiplier of values for mimicking joint defined in ``mimic`` parameter. Example: ``<param name="multiplier">-2</param>``.
+
+Per-interface Parameters
+,,,,,,,,,,,,,,,,,,,,,,,,
+
+initial_value (optional; double)
+  Initial value of certain state interface directly after startup. Example:
+
+  .. code-block:: xml
+
+     <state_interface name="position">
+       <param name="initial_value">3.45</param>
+     </state_interface>
+
+  Note: This parameter is shared with the gazebo and gazebo classic plugins.


### PR DESCRIPTION
This should fix #1351. I added documentation on the mock_hardware page and on the components overview page in the example URDF.