### PR TITLE
[CI] remove workflow dispatch branch

### DIFF
--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -4,8 +4,6 @@ name: Humble Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -4,8 +4,6 @@ name: Humble Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-semi-binary-build-main.yml
+++ b/.github/workflows/humble-semi-binary-build-main.yml
@@ -3,8 +3,6 @@ name: Humble Semi-Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-semi-binary-build-testing.yml
+++ b/.github/workflows/humble-semi-binary-build-testing.yml
@@ -3,8 +3,6 @@ name: Humble Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - humble
   pull_request:
     branches:
       - humble

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -1,8 +1,6 @@
 name: Humble Source Build
 on:
   workflow_dispatch:
-    branches:
-      - humble
   push:
     branches:
       - humble

--- a/.github/workflows/iron-binary-build-main.yml
+++ b/.github/workflows/iron-binary-build-main.yml
@@ -4,8 +4,6 @@ name: Iron Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-binary-build-testing.yml
+++ b/.github/workflows/iron-binary-build-testing.yml
@@ -4,8 +4,6 @@ name: Iron Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-semi-binary-build-main.yml
+++ b/.github/workflows/iron-semi-binary-build-main.yml
@@ -3,8 +3,6 @@ name: Iron Semi-Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-semi-binary-build-testing.yml
+++ b/.github/workflows/iron-semi-binary-build-testing.yml
@@ -3,8 +3,6 @@ name: Iron Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-source-build.yml
+++ b/.github/workflows/iron-source-build.yml
@@ -1,8 +1,6 @@
 name: Iron Source Build
 on:
   workflow_dispatch:
-    branches:
-      - iron
   push:
     branches:
       - iron

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -4,8 +4,6 @@ name: Rolling Binary Build - main
 
 on:
   workflow_dispatch:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/rolling-semi-binary-build-testing.yml
+++ b/.github/workflows/rolling-semi-binary-build-testing.yml
@@ -3,8 +3,6 @@ name: Rolling Semi-Binary Build - testing
 
 on:
   workflow_dispatch:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -1,8 +1,6 @@
 name: Rolling Source Build
 on:
   workflow_dispatch:
-    branches:
-      - master
   push:
     branches:
       - master


### PR DESCRIPTION
According to [github docs](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch) (and linters), there is no field `branches` below `workflow_dispatch`. One can just select from a drop-down list on which branch the workflow should be started.