### PR TITLE
Fix spawners for python3.6

### DIFF
--- a/controller_manager/controller_manager/hardware_spawner.py
+++ b/controller_manager/controller_manager/hardware_spawner.py
@@ -45,7 +45,8 @@ def first_match(iterable, predicate):
 
 def wait_for_value_or(function, node, timeout, default, description):
     while node.get_clock().now() < timeout:
-        if result := function():
+        result = function()
+        if result:
             return result
         node.get_logger().info(
             f"Waiting for {description}", throttle_duration_sec=2, skip_first=True

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -52,7 +52,8 @@ def first_match(iterable, predicate):
 
 def wait_for_value_or(function, node, timeout, default, description):
     while node.get_clock().now() < timeout:
-        if result := function():
+        result = function()
+        if result:
             return result
         node.get_logger().info(
             f'Waiting for {description}',


### PR DESCRIPTION
https://github.com/ros-controls/ros2_control/pull/683 introduced an incompatibility with python 3.6, see this [test](https://github.com/ros-controls/ros2_control/actions/runs/7754628381/job/21148323904?pr=1364). 

python 3.6 is the [minimum requirement for humble](https://www.ros.org/reps/rep-2000.html#humble-hawksbill-may-2022-may-2027) and default on rhel 8. 

copilot told me:

> The code you've provided is written in Python and uses the "walrus operator" (`:=`), which is a feature introduced in Python 3.8. This operator is used for assignment expressions. It assigns values to variables as part of a larger expression.The line of code where your cursor is located:
> ```python
> if result := function():
> ```
> is using this operator. If you're seeing a syntax error, it's likely because you're using a version of Python that is older than 3.8.To fix this, you can either upgrade your Python version to 3.8 or later, or you can refactor the code to not use the walrus operator. Here's how you could refactor it:
> ```python
> result = function()
> if result:
> ```
> This will work in Python versions prior to 3.8.