### PR TITLE
[CI] Improvements and Cleanups 

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -2,6 +2,18 @@ name: ROS Lint
 on:
   pull_request:
 
+env:
+  package-name:
+    controller_interface
+    controller_manager
+    controller_manager_msgs
+    hardware_interface
+    hardware_interface_testing
+    ros2controlcli
+    ros2_control
+    ros2_control_test_assets
+    transmission_interface
+
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
@@ -19,17 +31,7 @@ jobs:
       with:
         distribution: rolling
         linter: ${{ matrix.linter }}
-        package-name:
-          controller_interface
-          controller_manager
-          controller_manager_msgs
-          hardware_interface
-          hardware_interface_testing
-          ros2controlcli
-          ros2_control
-          ros2_control_test_assets
-          transmission_interface
-
+        package-name: ${{ env.package-name }}
   ament_lint_100:
     name: ament_${{ matrix.linter }}
     runs-on: ubuntu-latest
@@ -45,13 +47,4 @@ jobs:
         distribution: rolling
         linter: cpplint
         arguments: "--linelength=100 --filter=-whitespace/newline"
-        package-name:
-          controller_interface
-          controller_manager
-          controller_manager_msgs
-          hardware_interface
-          hardware_interface_testing
-          ros2controlcli
-          ros2_control
-          ros2_control_test_assets
-          transmission_interface
+        package-name: ${{ env.package-name }}

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -15,17 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: humble
+      skip-packages-build: rqt_controller_manager
+      skip-packages-test: rqt_controller_manager controller_manager_msgs
     container: ghcr.io/ros-controls/ros:humble-debian
     steps:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_control
           ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
-      - name: Build and test
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_control/ros2_control.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager control_msgs controller_manager_msgs
+          colcon build --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages-build }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages-test }}
           colcon test-result --verbose

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: humble
+      skip-packages: rqt_controller_manager
     container: ghcr.io/ros-controls/ros:humble-rhel
     steps:
       - uses: actions/checkout@v4
@@ -22,12 +23,20 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'humble' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_control || true
-      - name: Build and test
+      - name: Build workspace
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon build --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -15,17 +15,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: iron
+      skip-packages-build: rqt_controller_manager
+      skip-packages-test: rqt_controller_manager controller_manager_msgs
     container: ghcr.io/ros-controls/ros:iron-debian
     steps:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_control
-          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
-      - name: Build and test
+          #ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_control/ros2_control.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager control_msgs controller_manager_msgs
+          colcon build --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages-build }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages-test }}
           colcon test-result --verbose

--- a/.github/workflows/iron-debian-build.yml
+++ b/.github/workflows/iron-debian-build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: src/ros2_control
-          #ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
+          ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
       - name: Build workspace
         shell: bash
         run: |

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: iron
+      skip-packages: rqt_controller_manager
     container: ghcr.io/ros-controls/ros:iron-rhel
     steps:
       - uses: actions/checkout@v4
@@ -22,12 +23,21 @@ jobs:
           ref: ${{ github.event_name == 'schedule' && 'iron' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_control || true
-      - name: Build and test
+      - name: Build workspace
+        # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon build --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip  ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: rolling
+      skip-packages: rqt_controller_manager
     container: ghcr.io/ros-controls/ros:rolling-debian
     steps:
       - uses: actions/checkout@v4
@@ -22,11 +23,16 @@ jobs:
           path: src/ros2_control
           # default behavior is correct on master branch
           # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
-      - name: Build and test
+      - name: Build workspace
         shell: bash
         run: |
           source /opt/ros2_ws/install/setup.bash
           vcs import src < src/ros2_control/ros2_control.${{ env.ROS_DISTRO }}.repos
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager
+          colcon build --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros2_ws/install/setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages }}
           colcon test-result --verbose

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: rolling
+      skip-packages: rqt_controller_manager
     container: ghcr.io/ros-controls/ros:rolling-rhel
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +24,21 @@ jobs:
           # ref: ${{ github.event_name == 'schedule' && 'master' || '' }}
       - name: Install dependencies
         run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
           rosdep update
           rosdep install -iyr --from-path src/ros2_control || true
-      - name: Build and test
+      - name: Build workspace
+        # source also underlay workspace with generate_parameter_library on rhel9
         run: |
           source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
-          source /opt/ros2_ws/install/setup.bash
-          colcon build --packages-skip rqt_controller_manager
-          colcon test --packages-skip rqt_controller_manager ros2controlcli
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon build  --packages-up-to $(colcon list --paths src/ros2_control/* --names-only) --packages-skip ${{ env.skip-packages }}
+      - name: Test workspace
+        shell: bash
+        continue-on-error: true
+        run: |
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          source /opt/ros2_ws/install/local_setup.bash
+          colcon test --packages-select $(colcon list --paths src/ros2_control/* --names-only) --packages-skip  ${{ env.skip-packages }}
           colcon test-result --verbose


### PR DESCRIPTION
Similar to https://github.com/ros-controls/ros2_controllers/pull/1028

RHEL/Debian
- Build and test only the packages from this repo, instead of all packages imported with the repos file. I used `colcon list` instead of hardcoding it as it is done with the lint jobs.
- Split build and test steps, and let the test step [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error): The main goal is to detect compilation problems with unsupported C++ features, which are now visible at first glance. Tests remain flaky on theses platforms, which is a different issue.
- Activate test of ros2controlcli on debian, it seems to succeed now.

Others
- Use a single package list for lint job

Backport after #1364 #1374 / #1365 #1375