### PR TITLE
Add missing export macros in lexical_casts.hpp

### DIFF
--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -21,6 +21,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "hardware_interface/visibility_control.h"
+
 namespace hardware_interface
 {
 
@@ -29,8 +31,10 @@ namespace hardware_interface
  * from
  https://github.com/ros-planning/srdfdom/blob/ad17b8d25812f752c397a6011cec64aeff090c46/src/model.cpp#L53
 */
+HARDWARE_INTERFACE_PUBLIC
 double stod(const std::string & s);
 
+HARDWARE_INTERFACE_PUBLIC
 bool parse_bool(const std::string & bool_string);
 
 }  // namespace hardware_interface


### PR DESCRIPTION
https://github.com/ros-controls/ros2_control/pull/1281 made `hardware_interface::stod` and `hardware_interface::parse_bool` proper methods defined in the shared library, but the export macros were not properly added there.


- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
