### PR TITLE
Modify resource manager logic to support multiple hardware components

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1162,7 +1162,7 @@ bool ResourceManager::prepare_command_mode_switch(
         component.get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
         if (
-          return_type::OK !=
+          return_type::OK ==
           component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
         {
           ret = true;

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1154,7 +1154,7 @@ bool ResourceManager::prepare_command_mode_switch(
   auto call_prepare_mode_switch =
     [&start_interfaces, &stop_interfaces, &interfaces_to_string](auto & components)
   {
-    bool ret = true;
+    bool ret = false;
     for (auto & component : components)
     {
       if (
@@ -1165,11 +1165,14 @@ bool ResourceManager::prepare_command_mode_switch(
           return_type::OK !=
           component.prepare_command_mode_switch(start_interfaces, stop_interfaces))
         {
+          ret = true;
+        }
+        else
+        {
           RCUTILS_LOG_ERROR_NAMED(
             "resource_manager",
             "Component '%s' did not accept command interfaces combination: \n%s",
             component.get_name().c_str(), interfaces_to_string().c_str());
-          ret = false;
         }
       }
     }
@@ -1179,7 +1182,7 @@ bool ResourceManager::prepare_command_mode_switch(
   const bool actuators_result = call_prepare_mode_switch(resource_storage_->actuators_);
   const bool systems_result = call_prepare_mode_switch(resource_storage_->systems_);
 
-  return actuators_result && systems_result;
+  return actuators_result || systems_result;
 }
 
 // CM API: Called in "update"-thread

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1198,7 +1198,7 @@ bool ResourceManager::perform_command_mode_switch(
 
   auto call_perform_mode_switch = [&start_interfaces, &stop_interfaces](auto & components)
   {
-    bool ret = true;
+    bool ret = false;
     for (auto & component : components)
     {
       if (
@@ -1206,13 +1206,16 @@ bool ResourceManager::perform_command_mode_switch(
         component.get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
       {
         if (
-          return_type::OK !=
+          return_type::OK ==
           component.perform_command_mode_switch(start_interfaces, stop_interfaces))
+        {
+          ret = true;
+        }
+        else
         {
           RCUTILS_LOG_ERROR_NAMED(
             "resource_manager", "Component '%s' could not perform switch",
             component.get_name().c_str());
-          ret = false;
         }
       }
     }
@@ -1222,7 +1225,7 @@ bool ResourceManager::perform_command_mode_switch(
   const bool actuators_result = call_perform_mode_switch(resource_storage_->actuators_);
   const bool systems_result = call_perform_mode_switch(resource_storage_->systems_);
 
-  return actuators_result && systems_result;
+  return actuators_result || systems_result;
 }
 
 // CM API: Called in "callback/slow"-thread


### PR DESCRIPTION
## What does this implement/fix?
The current implementation requires that all components have the appropriate interface and will not work well if the hardware is split into multiple components.
It should only be necessary for one component to have an interface, so we will modify the logic accordingly.

Specifically, we are considering the following examples.
If you want to connect to follower_joint1/effort, it should be no problem if component 1 has the corresponding interface.
```
Hardware Component 1
        command interfaces
                follower_joint1/position [available] [unclaimed]
                follower_joint1/effort [available] [claimed]
Hardware Component 2
        command interfaces
                leader_joint1/position [available] [unclaimed]
                leader_joint1/effort [available] [claimed]
```

## Does this close any currently open issues?
I don't have Franka Emika Panda so I am not able to reproduce the same situation completely, 
but this PR may solve this issue.
https://github.com/ros-controls/ros2_control/issues/1177