### PR TITLE
readd activate_all_components method to not break API

### DIFF
--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -387,6 +387,18 @@ public:
    */
   HardwareReadWriteStatus write(const rclcpp::Time & time, const rclcpp::Duration & period);
 
+  /// Activates all available hardware components in the system.
+  /**
+   * All available hardware components int the ros2_control framework are activated.
+   * This is used to preserve default behavior from previous versions where all hardware components
+   * are activated per default.
+   */
+  [[deprecated(
+    "The method 'activate_all_components' is deprecated. "
+    "Use the new 'hardware_components_initial_state' parameter structure to setup the "
+    "components")]] void
+  activate_all_components();
+
   /// Checks whether a command interface is registered under the given key.
   /**
    * \param[in] key string identifying the interface to check.

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1387,6 +1387,28 @@ void ResourceManager::validate_storage(
     throw std::runtime_error(err_msg);
   }
 }
+
+// Temporary method to keep old interface and reduce framework changes in the PRs
+void ResourceManager::activate_all_components()
+{
+  using lifecycle_msgs::msg::State;
+  rclcpp_lifecycle::State active_state(
+    State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
+
+  for (auto & component : resource_storage_->actuators_)
+  {
+    set_component_state(component.get_name(), active_state);
+  }
+  for (auto & component : resource_storage_->sensors_)
+  {
+    set_component_state(component.get_name(), active_state);
+  }
+  for (auto & component : resource_storage_->systems_)
+  {
+    set_component_state(component.get_name(), active_state);
+  }
+}
+
 // END: private methods
 
 }  // namespace hardware_interface


### PR DESCRIPTION
Readd the `activate_all_components` method for backward compatibility 