### PR TITLE
[CI] Use reusable-reviewer-lottery from ros2_control_ci

### DIFF
--- a/.github/workflows/reviewer_lottery.yml
+++ b/.github/workflows/reviewer_lottery.yml
@@ -1,15 +1,10 @@
 name: Reviewer lottery
+# pull_request_target takes the same events as pull_request,
+# but it runs on the base branch instead of the head branch.
 on:
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
   assign_reviewers:
-    runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.actor != 'mergify[bot]'
-    steps:
-    - uses: actions/checkout@v4
-    - uses: uesteibar/reviewer-lottery@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        config: ros-controls/ros2_control_ci/.github/reviewer-lottery.yml
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-reviewer-lottery.yml@master


### PR DESCRIPTION
This is a fix to #1395: The reviewer-lottery action only takes files from the [local filesystem](https://github.com/uesteibar/reviewer-lottery/blob/c291d74388da1cb583aff994b8be945e8eefbcd5/src/config.ts#L15), which makes the action fail as [reported here](https://github.com/ros-controls/ros2_control/pull/1401#issuecomment-1949407357).

To fix this, I added a [reusable workflow](https://github.com/ros-controls/ros2_control_ci/blob/master/.github/workflows/reusable-reviewer-lottery.yml) to ros2_control_ci using wget to download the config file.

I tested this [here](https://github.com/christophfroehlich/ros2_control/actions/runs/7942073051/job/21685010060?pr=2), this should work now.
