### PR TITLE
added conditioning to have rolling tags compilable in older versions

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -172,7 +172,13 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual rclcpp::NodeOptions define_custom_node_options() const
   {
+#if RCLCPP_VERSION_MAJOR >= 21
     return rclcpp::NodeOptions().enable_logger_service(true);
+#else
+    return rclcpp::NodeOptions()
+      .allow_undeclared_parameters(true)
+      .automatically_declare_parameters_from_overrides(true);
+#endif
   }
 
   /// Declare and initialize a parameter with a type.

--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -172,6 +172,7 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual rclcpp::NodeOptions define_custom_node_options() const
   {
+// \note The versions conditioning is added here to support the source-compatibility with Humble
 #if RCLCPP_VERSION_MAJOR >= 21
     return rclcpp::NodeOptions().enable_logger_service(true);
 #else

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -36,10 +36,23 @@ static constexpr const char * kChainableControllerInterfaceClassName =
   "controller_interface::ChainableControllerInterface";
 
 // Changed services history QoS to keep all so we don't lose any client service calls
+#if RCLCPP_VERSION_MAJOR >= 17
 rclcpp::QoS qos_services =
   rclcpp::QoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_ALL, 1))
     .reliable()
     .durability_volatile();
+#else
+static const rmw_qos_profile_t qos_services = {
+  RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+  1,  // message queue depth
+  RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+  RMW_QOS_POLICY_DURABILITY_VOLATILE,
+  RMW_QOS_DEADLINE_DEFAULT,
+  RMW_QOS_LIFESPAN_DEFAULT,
+  RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
+  RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+  false};
+#endif
 
 inline bool is_controller_inactive(const controller_interface::ControllerInterfaceBase & controller)
 {

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -36,6 +36,7 @@ static constexpr const char * kChainableControllerInterfaceClassName =
   "controller_interface::ChainableControllerInterface";
 
 // Changed services history QoS to keep all so we don't lose any client service calls
+// \note The versions conditioning is added here to support the source-compatibility with Humble
 #if RCLCPP_VERSION_MAJOR >= 17
 rclcpp::QoS qos_services =
   rclcpp::QoS(rclcpp::QoSInitialization(RMW_QOS_POLICY_HISTORY_KEEP_ALL, 1))


### PR DESCRIPTION
As discussed in the yesterday's WG meeting, I've added some small fixes that will enable us to compile rolling tags directly in earlier versions from now on.

The following are the breaking changes between both versions:
* https://github.com/ros2/rclcpp/commit/9d2849cb0ada510073dc90d7497aa2380a97b51a (The [new API of the NodeOptions](https://github.com/ros2/rclcpp/commit/3610b68348adbc441f130e058f8a8e38032e855a) is available from the tag 21.0.0)
* https://github.com/ros2/rclcpp/commit/4744fb6f500cbb3d7a0619f4ef6a7bdf34370e34 (The [new method of the create client](https://github.com/ros2/rclcpp/commit/64e4c72791811e25ee7780fc84b07dc70f36a4c9) is available from the tag 17.0.0)
