### PR TITLE
add conditioning to get_parameter_value method import

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -32,7 +32,13 @@ import rclpy
 from rcl_interfaces.msg import Parameter
 from rclpy.duration import Duration
 from rclpy.node import Node
-from rclpy.parameter import get_parameter_value
+
+# @note: The versions conditioning is added here to support the source-compatibility with Humble
+# The `get_parameter_value` function is moved to `rclpy.parameter` module from `ros2param.api` module from version 3.6.0
+try:
+    from rclpy.parameter import get_parameter_value
+except ImportError:
+    from ros2param.api import get_parameter_value
 from rclpy.signals import SignalHandlerOptions
 from ros2param.api import call_set_parameters
 


### PR DESCRIPTION
@christophfroehlich reported that the [controller_manager spawner tests](https://github.com/ros-controls/ros2_control_ci/pull/30#issuecomment-1977277056) failed due to an import error when running tests in Humble. 

* https://github.com/ros2/rclpy/commit/3053a8ad9cc266300c7c8e3070bb6552652cf88d The `get_parameter_value` is available from version 3.6.o. I wanted to use the `__version__` attribute to condition it, but unfortunately the `rclpy`  doesn't have this attribute, so I went with the catch the import error and using the old library for compatibility 

The following fix should solve the issue and make the spawner compatible with the older versions. 

I've tested this fix by compiling and running all the tests of `ros2_control`  with  #1422, `ros2_controllers` with https://github.com/ros-controls/ros2_controllers/pull/1071, and `gazebo_ros2_control`  in Humble. All the tests are successful now.
