### PR TITLE
add missing compiler definitions of RCLCPP_VERSION_MAJOR

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCLCPP_VERSION_MAJOR=${rclcpp_lifecycle_VERSION_MAJOR})
 
 add_library(controller_interface SHARED
   src/controller_interface_base.cpp

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+add_compile_definitions(RCLCPP_VERSION_MAJOR=${rclcpp_VERSION_MAJOR})
 
 add_library(controller_manager SHARED
   src/controller_manager.cpp


### PR DESCRIPTION
I apologize for the missing compiler definition flags in PR: #1422, It seems like without those the macros have no effect at all. In rolling, right now it is using the deprecated API. The following changes should fix it.