### PR TITLE
[rqt_cm] Add CM as dependency

### DIFF
--- a/rqt_controller_manager/package.xml
+++ b/rqt_controller_manager/package.xml
@@ -18,6 +18,7 @@
   <author email="kphawkins@gatech.edu">Kelsey Hawkins</author>
   <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodríguez Tsouroukdissian</author>
 
+  <exec_depend>controller_manager</exec_depend>
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>


### PR DESCRIPTION
If controller_manager itself is not built, then one gets an error at launching rqt_controller_manager
```
    from controller_manager.controller_manager_services import (
ModuleNotFoundError: No module named 'controller_manager'
```
imported here

https://github.com/ros-controls/ros2_control/blob/20e01d867fd14c1a3a0b8ea999d41d9d27dcf3bb/rqt_controller_manager/rqt_controller_manager/controller_manager.py#L20-L26