### PR TITLE
Fix rqt_controller_manager for non-humble

### DIFF
--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -415,7 +415,7 @@ def _get_parameter_controller_names(node, node_name):
     parameter_names = call_list_parameters(node=node, node_name=node_name)
     suffix = ".type"
     # @note: The versions conditioning is added here to support the source-compatibility with Humble
-    if os.environ.get('ROS_DISTRO') == "humble":
+    if os.environ.get("ROS_DISTRO") == "humble":
         # for humble, ros2param < 0.20.0
         return [n[: -len(suffix)] for n in parameter_names if n.endswith(suffix)]
     else:

--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -419,6 +419,6 @@ def _get_parameter_controller_names(node, node_name):
         return [
             n[: -len(suffix)] for n in parameter_names.result().result.names if n.endswith(suffix)
         ]
-    finally:
+    except:
         # for humble, ros2param < 0.20.0
         return [n[: -len(suffix)] for n in parameter_names if n.endswith(suffix)]

--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -415,10 +415,10 @@ def _get_parameter_controller_names(node, node_name):
     parameter_names = call_list_parameters(node=node, node_name=node_name)
     suffix = ".type"
     # @note: The versions conditioning is added here to support the source-compatibility with Humble
-    try:
+    if os.environ.get('ROS_DISTRO') == "humble":
+        # for humble, ros2param < 0.20.0
+        return [n[: -len(suffix)] for n in parameter_names if n.endswith(suffix)]
+    else:
         return [
             n[: -len(suffix)] for n in parameter_names.result().result.names if n.endswith(suffix)
         ]
-    except:
-        # for humble, ros2param < 0.20.0
-        return [n[: -len(suffix)] for n in parameter_names if n.endswith(suffix)]


### PR DESCRIPTION
I made a mistake with #1429: rqt_cm does not work on rolling now (sorry): The `finally` part is always executed, `except` should be the right python syntax. 
```
Traceback (most recent call last):
  File "/workspaces/ros2_rolling_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 150, in _on_cm_change
    self._update_controllers()
  File "/workspaces/ros2_rolling_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 157, in _update_controllers
    controllers = self._list_controllers()
  File "/workspaces/ros2_rolling_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 181, in _list_controllers
    for name in _get_parameter_controller_names(self._node, self._cm_name):
  File "/workspaces/ros2_rolling_ws/build/rqt_controller_manager/rqt_controller_manager/controller_manager.py", line 424, in _get_parameter_controller_names
    return [n[: -len(suffix)] for n in parameter_names if n.endswith(suffix)]
TypeError: 'Future' object is not iterable
```



However,  I made the version conditioning now by `os.environ.get('ROS_DISTRO')` what seems to be cleaner than a try/catch imho.

Tested now on rolling and humble.