### PR TITLE
[CI] Set the os_code explicitly to jammy

### DIFF
--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -27,3 +27,4 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control-not-released.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: master
+      os_code_name: jammy

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   binary:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@fix_caches
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   binary:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@fix_caches
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   coverage_rolling:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@fix_coverage_build
     secrets: inherit
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   coverage_rolling:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@fix_coverage_build
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
     secrets: inherit
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   binary:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@fix_caches
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -27,3 +27,4 @@ jobs:
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: master
+      os_code_name: jammy

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   binary:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@fix_caches
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ICI introduced a workaround to set the dependencies to the last jammy-release for rolling. 
https://github.com/ros-industrial/industrial_ci/commit/a49872410cc12e2fa8b34e80d9292fc81996318f

Needs 

- [x] https://github.com/ros-controls/ros2_control_ci/pull/50
- [x] https://github.com/ros-controls/ros2_control_ci/pull/49

to be merged before to have green CI.