### PR TITLE
Deactivate the controllers when they return error similar to the hard…

### DIFF
--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -225,7 +225,7 @@ Note that not all controllers have to be restarted, e.g., broadcasters.
 Restarting hardware
 ^^^^^^^^^^^^^^^^^^^^^
 
-If hardware gets restarted then you should go through its lifecycle again inorder to reconfigure and export the interfaces
+If hardware gets restarted then you should go through its lifecycle again in order to reconfigure and export the interfaces
 
 Hardware and Controller Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -228,3 +228,9 @@ Restarting hardware
 If hardware gets restarted then you should go through its lifecycle again.
 This can be simply achieved by returning ``ERROR`` from ``write`` and ``read`` methods of interface implementation.
 **NOT IMPLEMENTED YET - PLEASE STOP/RESTART ALL CONTROLLERS MANUALLY FOR NOW** The controller manager detects that and stops all the controllers that are commanding that hardware and restarts broadcasters that are listening to its states.
+
+Hardware and Controller Errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the hardware during it's ``read`` or ``write`` method returns ``return_type::ERROR``, the controller manager will stop all controllers that are using the hardware's command and state interfaces.
+Likewise, if a controller returns ``return_type::ERROR`` from its ``update`` method, the controller manager will deactivate the respective controller. In future, the controller manager will try to start any fallback controllers if available.

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -225,9 +225,7 @@ Note that not all controllers have to be restarted, e.g., broadcasters.
 Restarting hardware
 ^^^^^^^^^^^^^^^^^^^^^
 
-If hardware gets restarted then you should go through its lifecycle again.
-This can be simply achieved by returning ``ERROR`` from ``write`` and ``read`` methods of interface implementation.
-**NOT IMPLEMENTED YET - PLEASE STOP/RESTART ALL CONTROLLERS MANUALLY FOR NOW** The controller manager detects that and stops all the controllers that are commanding that hardware and restarts broadcasters that are listening to its states.
+If hardware gets restarted then you should go through its lifecycle again inorder to reconfigure and export the interfaces
 
 Hardware and Controller Errors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2073,10 +2073,10 @@ controller_interface::return_type ControllerManager::update(
     std::string failed_controllers;
     for (const auto & controller : failed_controllers_list)
     {
-      failed_controllers += controller + " ";
+      failed_controllers += "\n\t- " + controller;
     }
     RCLCPP_ERROR(
-      get_logger(), "Deactivating controllers: %s, as their update resulted in an error",
+      get_logger(), "Deactivating following controllers as their update resulted in an error :%s",
       failed_controllers.c_str());
 
     deactivate_controllers(rt_controller_list, failed_controllers_list);

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2023,6 +2023,7 @@ controller_interface::return_type ControllerManager::update(
   ++update_loop_counter_;
   update_loop_counter_ %= update_rate_;
 
+  std::vector<std::string> failed_controllers_list;
   for (const auto & loaded_controller : rt_controller_list)
   {
     // TODO(v-lopez) we could cache this information
@@ -2061,10 +2062,24 @@ controller_interface::return_type ControllerManager::update(
 
         if (controller_ret != controller_interface::return_type::OK)
         {
+          failed_controllers_list.push_back(loaded_controller.info.name);
           ret = controller_ret;
         }
       }
     }
+  }
+  if (!failed_controllers_list.empty())
+  {
+    std::string failed_controllers;
+    for (const auto & controller : failed_controllers_list)
+    {
+      failed_controllers += controller + " ";
+    }
+    RCLCPP_ERROR(
+      get_logger(), "Deactivating controllers: %s, as their update resulted in an error",
+      failed_controllers.c_str());
+
+    deactivate_controllers(rt_controller_list, failed_controllers_list);
   }
 
   // there are controllers to (de)activate

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -76,6 +76,14 @@ controller_interface::return_type TestController::update(
   {
     for (size_t i = 0; i < command_interfaces_.size(); ++i)
     {
+      if (!std::isfinite(external_commands_for_testing_[i]))
+      {
+        RCLCPP_ERROR(
+          get_node()->get_logger(),
+          "External command value for command interface '%s' is not finite",
+          command_interfaces_[i].get_name().c_str());
+        return controller_interface::return_type::ERROR;
+      }
       RCLCPP_INFO(
         get_node()->get_logger(), "Setting value of command interface '%s' to %f",
         command_interfaces_[i].get_name().c_str(), external_commands_for_testing_[i]);


### PR DESCRIPTION
Hello!

This is something we have discussed long back in one of the WG meetings to unify the approach with HW and controllers. Right now, when the hardware returns ERROR, it currently deactivates the controllers that use the hardware's interfaces.

Likewise, we want to enforce that if a controller returns an error, we would like to deactivate it to avoid situations in the next cycles. Moreover, this return info from the controllers are not used at all, so, I think it would make sense to put them to proper use.

Thank you