### PR TITLE
Add more common hardware interface type constants

### DIFF
--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -35,6 +35,20 @@ constexpr char HW_IF_FORCE[] = "force";
 constexpr char HW_IF_CURRENT[] = "current";
 /// Constant defining temperature interface name
 constexpr char HW_IF_TEMPERATURE[] = "temperature";
+
+/// Gains interface constants
+/// Constant defining proportional gain interface name
+constexpr char HW_IF_PROPORTIONAL_GAIN[] = "proportional";
+/// Constant defining integral gain interface name
+constexpr char HW_IF_INTEGRAL_GAIN[] = "integral";
+/// Constant defining derivative gain interface name
+constexpr char HW_IF_DERIVATIVE_GAIN[] = "derivative";
+/// Constant defining integral clamp interface name
+constexpr char HW_IF_INTEGRAL_CLAMP_MAX[] = "integral_clamp_max";
+/// Constant defining integral clamp interface name
+constexpr char HW_IF_INTEGRAL_CLAMP_MIN[] = "integral_clamp_min";
+/// Constant defining the feedforward interface name
+constexpr char HW_IF_FEEDFORWARD[] = "feedforward";
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -19,8 +19,6 @@ namespace hardware_interface
 {
 /// Constant defining position interface name
 constexpr char HW_IF_POSITION[] = "position";
-/// Constant defining absolute position interface name
-constexpr char HW_IF_ABSOLUTE_POSITION[] = "absolute_position";
 /// Constant defining velocity interface name
 constexpr char HW_IF_VELOCITY[] = "velocity";
 /// Constant defining acceleration interface name

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -19,12 +19,20 @@ namespace hardware_interface
 {
 /// Constant defining position interface name
 constexpr char HW_IF_POSITION[] = "position";
+/// Constant defining absolute position interface name
+constexpr char HW_IF_ABSOLUTE_POSITION[] = "absolute_position";
 /// Constant defining velocity interface name
 constexpr char HW_IF_VELOCITY[] = "velocity";
 /// Constant defining acceleration interface name
 constexpr char HW_IF_ACCELERATION[] = "acceleration";
 /// Constant defining effort interface name
 constexpr char HW_IF_EFFORT[] = "effort";
+/// Constant defining torque interface name
+constexpr char HW_IF_TORQUE[] = "torque";
+/// Constant defining force interface name
+constexpr char HW_IF_FORCE[] = "force";
+/// Constant defining current interface name
+constexpr char HW_IF_CURRENT[] = "current";
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_type_values.hpp
@@ -33,6 +33,8 @@ constexpr char HW_IF_TORQUE[] = "torque";
 constexpr char HW_IF_FORCE[] = "force";
 /// Constant defining current interface name
 constexpr char HW_IF_CURRENT[] = "current";
+/// Constant defining temperature interface name
+constexpr char HW_IF_TEMPERATURE[] = "temperature";
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_TYPE_VALUES_HPP_


### PR DESCRIPTION
This is to add more sets of more common hardware interface type constants that are used day-to-day. Defining it here would bring some standards in the naming + reusability.

Some reference : https://github.com/ros-controls/ros_control/blob/noetic-devel/hardware_interface/include/hardware_interface/joint_state_interface.h