### PR TITLE
Robustify spawner

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -201,6 +201,16 @@ if(BUILD_TESTING)
   ament_target_dependencies(test_hardware_management_srvs
     controller_manager_msgs
   )
+
+  install(
+    DIRECTORY test
+    DESTINATION share/${PROJECT_NAME}
+  )
+
+  find_package(launch_testing_ament_cmake)
+  add_launch_test(test/test_spawner_integration.py
+    TIMEOUT 180
+  )
 endif()
 
 install(

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -130,8 +130,12 @@ def wait_for_controller_manager(node, controller_manager, timeout_duration):
     return False
 
 
-def is_controller_loaded(node, controller_manager, controller_name):
-    controllers = list_controllers(node, controller_manager).controller
+def is_controller_loaded(
+    node, controller_manager, controller_name, controller_manager_timeout=10.0
+):
+    controllers = list_controllers(
+        node, controller_manager, service_timeout=controller_manager_timeout
+    ).controller
     return any(c.name == controller_name for c in controllers)
 
 
@@ -222,7 +226,12 @@ def main(args=None):
             if controller_namespace:
                 prefixed_controller_name = controller_namespace + "/" + controller_name
 
-            if is_controller_loaded(node, controller_manager_name, prefixed_controller_name):
+            if is_controller_loaded(
+                node,
+                controller_manager_name,
+                prefixed_controller_name,
+                controller_manager_timeout=controller_manager_timeout,
+            ):
                 node.get_logger().warn(
                     bcolors.WARNING
                     + "Controller already loaded, skipping load_controller"

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -217,14 +217,6 @@ def main(args=None):
             controller_manager_name = f"/{controller_manager_name}"
 
     try:
-        if not wait_for_controller_manager(
-            node, controller_manager_name, controller_manager_timeout
-        ):
-            node.get_logger().error(
-                bcolors.FAIL + "Controller manager not available" + bcolors.ENDC
-            )
-            return 1
-
         for controller_name in controller_names:
             prefixed_controller_name = controller_name
             if controller_namespace:

--- a/controller_manager/test/test_spawner_integration.py
+++ b/controller_manager/test/test_spawner_integration.py
@@ -1,0 +1,198 @@
+# Copyright 2024 FZI Forschungszentrum Informatik
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Felix Exner
+
+import time
+import pytest
+import unittest
+
+import launch
+import launch_testing.actions
+
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    PathJoinSubstitution,
+)
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.parameter_descriptions import ParameterFile
+
+from launch_ros.actions import Node as LaunchNode
+
+# Imports for tests
+import rclpy
+from rclpy.node import Node
+import logging
+
+from controller_manager_msgs.srv import ListControllers
+
+CONTROLLER_SPAWNER_TIMEOUT = "10"
+
+active_controllers = [
+    "joint_state_broadcaster0",
+    "joint_state_broadcaster1",
+    "joint_state_broadcaster2",
+    "joint_state_broadcaster3",
+    "joint_state_broadcaster4",
+    "joint_state_broadcaster5",
+    "joint_state_broadcaster6",
+    "joint_state_broadcaster7",
+    "joint_state_broadcaster8",
+    "joint_state_broadcaster9",
+    "joint_state_broadcaster10",
+    "joint_state_broadcaster11",
+    "joint_state_broadcaster12",
+    "joint_state_broadcaster13",
+    "joint_state_broadcaster14",
+    "joint_state_broadcaster15",
+    "joint_state_broadcaster16",
+    "joint_state_broadcaster17",
+    "joint_state_broadcaster18",
+    "joint_state_broadcaster19",
+    "joint_state_broadcaster20",
+    "joint_state_broadcaster21",
+    "joint_state_broadcaster22",
+    "joint_state_broadcaster23",
+    "joint_state_broadcaster24",
+    "joint_state_broadcaster25",
+    "joint_state_broadcaster26",
+    "joint_state_broadcaster27",
+    "joint_state_broadcaster28",
+    "joint_state_broadcaster29",
+    "joint_state_broadcaster30",
+    "joint_state_broadcaster31",
+    "joint_state_broadcaster32",
+    "joint_state_broadcaster33",
+    "joint_state_broadcaster34",
+    "joint_state_broadcaster35",
+    "joint_state_broadcaster36",
+    "joint_state_broadcaster37",
+    "joint_state_broadcaster38",
+    "joint_state_broadcaster39",
+    "joint_state_broadcaster40",
+    "joint_state_broadcaster41",
+    "joint_state_broadcaster42",
+    "joint_state_broadcaster43",
+    "joint_state_broadcaster44",
+    "joint_state_broadcaster45",
+    "joint_state_broadcaster46",
+    "joint_state_broadcaster47",
+    "joint_state_broadcaster48",
+    "joint_state_broadcaster49",
+    "fts_broadcaster",
+    "base_controller",
+    "joint1_controller",
+    "joint2_controller",
+]
+
+
+def controller_spawner(controllers, active=True):
+    inactive_flags = ["--inactive"] if not active else []
+    return LaunchNode(
+        package="controller_manager",
+        executable="spawner",
+        arguments=[
+            "--controller-manager",
+            "/controller_manager",
+            "--controller-manager-timeout",
+            CONTROLLER_SPAWNER_TIMEOUT,
+        ]
+        + inactive_flags
+        + controllers,
+    )
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ros2_control_test_assets"),
+                    "urdf",
+                    "test_description_mock.urdf",
+                ]
+            ),
+        ]
+    )
+    robot_state_publisher_node = LaunchNode(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="both",
+        parameters=[{"robot_description": robot_description_content}],
+    )
+
+    control_node = LaunchNode(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            ParameterFile(
+                PathJoinSubstitution(
+                    [FindPackageShare("controller_manager"), "test", "test_controllers.yaml"]
+                )
+            )
+        ],
+        output="screen",
+    )
+
+    spawners = [controller_spawner([x]) for x in active_controllers]
+
+    return launch.LaunchDescription(
+        [
+            robot_state_publisher_node,
+            control_node,
+            launch_testing.actions.ReadyToTest(),
+        ]
+        + spawners
+    )
+
+
+class TestControllersRunning(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Initialize the ROS context
+        rclpy.init()
+        cls.node = Node("controller_spawner_test")
+
+    def _wait_for_service(self, srv_name, srv_type, timeout=10):
+        client = self.node.create_client(srv_type, srv_name)
+
+        logging.info("Waiting for service '%s' with timeout %fs...", srv_name, timeout)
+        if client.wait_for_service(timeout) is False:
+            raise Exception(f"Could not reach service '{srv_name}' within timeout of {timeout}")
+        logging.info("  Successfully connected to service '%s'", srv_name)
+
+        return client
+
+    def test_all_controllers_available(self):
+        client = self._wait_for_service(
+            srv_name="controller_manager/list_controllers", srv_type=ListControllers
+        )
+        # This is basically a dirty hack. It would be better to add events to all the spawners
+        # exiting and emit ReadyToTest() only after all of them have quit. One problem there: They
+        # do not necessarily quit, but can get into a deadlock waiting for a service response.
+        time.sleep(30)
+        request = ListControllers.Request()
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future)
+        if future.result() is None:
+            raise Exception(
+                f"Error while calling service '{client.srv_name}': {future.exception()}"
+            )
+
+        result = future.result()
+        self.assertEqual(len(result.controller), len(active_controllers))

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -14,6 +14,10 @@ install(
   DIRECTORY include/
   DESTINATION include/ros2_control_test_assets
 )
+install(
+  DIRECTORY urdf
+  DESTINATION share/${PROJECT_NAME}
+)
 install(TARGETS ros2_control_test_assets
   EXPORT export_ros2_control_test_assets
   ARCHIVE DESTINATION lib

--- a/ros2_control_test_assets/urdf/test_description_mock.urdf
+++ b/ros2_control_test_assets/urdf/test_description_mock.urdf
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<robot name="MinimalRobot">
+  <link name="world"/>
+  <joint name="base_joint" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+  <link name="base_link">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint1" type="revolute">
+    <origin rpy="-1.57079632679 0 0" xyz="0 0 0.2"/>
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link1">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <joint name="joint2" type="revolute">
+    <origin rpy="1.57079632679 0 0" xyz="0 0 0.9"/>
+    <parent link="link1"/>
+    <child link="link2"/>
+    <limit effort="0.1" lower="-3.14159265359" upper="3.14159265359" velocity="0.2"/>
+  </joint>
+  <link name="link2">
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <cylinder length="1" radius="0.1"/>
+      </geometry>
+    </collision>
+  </link>
+  <ros2_control name="MockComponent" type="system">
+    <hardware>
+      <plugin>mock_components/GenericSystem</plugin>
+    </hardware>
+    <joint name="base_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+
+    <sensor name="base_ft_sensor">
+      <state_interface name="force.x"/>
+      <state_interface name="force.y"/>
+      <state_interface name="force.z"/>
+      <state_interface name="torque.x"/>
+      <state_interface name="torque.y"/>
+      <state_interface name="torque.z"/>
+    </sensor>
+
+    <gpio name="gpio">
+      <state_interface name="digital_output_0"/>
+      <state_interface name="digital_output_1"/>
+      <state_interface name="digital_output_2"/>
+      <state_interface name="digital_output_3"/>
+      <state_interface name="digital_output_4"/>
+      <state_interface name="digital_output_5"/>
+      <state_interface name="digital_output_6"/>
+      <state_interface name="digital_output_7"/>
+      <state_interface name="digital_output_8"/>
+      <state_interface name="digital_output_9"/>
+      <state_interface name="digital_output_10"/>
+      <state_interface name="digital_output_11"/>
+      <state_interface name="digital_output_12"/>
+      <state_interface name="digital_output_13"/>
+      <state_interface name="digital_output_14"/>
+      <state_interface name="digital_output_15"/>
+    </gpio>
+  </ros2_control>
+</robot>


### PR DESCRIPTION
With the current implementation it can happen that when using multiple controller spawners some of them fail or get stuck, see #1182. This fixes #1182.

While writing this, I realize this has great overlap with #1483, but I see no problem combining those two.

As briefly mentioned above, this change addresses two things:

- The node discovery mechanism for the controller manager seems to be error-prone and not strictly needed.
- It can happen that we don't get a response from the service server and hang in a deadlock.

Note: The test I implemented is a bit hacky, so we might also want to remove it again? Otherwise I think we would have to change the following things:

- I installed the `test` folder in order to access the controller configuration file living in there. We should either install that file by hand rather than the complete test folder or move it somewhere else.
- I've added a urdf file in `ros_control_test_assets` as I thought that might be the most useful place. I might be wrong.
- I've added a sleep to my test before checking whether the controller_manager shows up all the expected controllers. That worked for me for an implementation, but since a timeout is very error-prone it would be better to have a proper waiting mechanism. With the changes I made the spawners should die eventually and not hang in a deadlock, so we could add event handlers to the launch description, but I'm not sure how to combine the exit events from all the spawners into one trigger.

I implemented and tested things on the rolling on jammy installation I currently have, but I know the problem definitively also arises for humble users.