### PR TITLE
allow extra spawner arguments to not declare every argument in launch utils

### DIFF
--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -20,7 +20,7 @@ from launch_ros.actions import Node
 
 
 def generate_load_controller_launch_description(
-    controller_name, controller_type=None, controller_params_file=None
+    controller_name, controller_type=None, controller_params_file=None, extra_spawner_args=[]
 ):
     """
     Generate launch description for loading a controller using spawner.
@@ -39,7 +39,8 @@ def generate_load_controller_launch_description(
         'joint_state_broadcaster',
         controller_type='joint_state_broadcaster/JointStateBroadcaster',
         controller_params_file=os.path.join(get_package_share_directory('my_pkg'),
-                                            'config', 'controller_params.yaml')
+                                            'config', 'controller_params.yaml'),
+        extra_spawner_args=[--load-only]
         )
 
     """
@@ -78,6 +79,9 @@ def generate_load_controller_launch_description(
             ]
         )
     ]
+
+    if extra_spawner_args:
+        spawner_arguments += extra_spawner_args
 
     spawner = Node(
         package="controller_manager",


### PR DESCRIPTION
This PR allows the users to parser extra spawner arguments without having to redeclare everything again in the launch utils