### PR TITLE
Add controller exception handling in controller manager

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -562,11 +562,26 @@ controller_interface::return_type ControllerManager::unload_controller(
       get_logger(), "Controller '%s' is cleaned-up before unloading!", controller_name.c_str());
     // TODO(destogl): remove reference interface if chainable; i.e., add a separate method for
     // cleaning-up controllers?
-    const auto new_state = controller.c->get_node()->cleanup();
-    if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+    try
     {
-      RCLCPP_WARN(
-        get_logger(), "Failed to clean-up the controller '%s' before unloading!",
+      const auto new_state = controller.c->get_node()->cleanup();
+      if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+      {
+        RCLCPP_WARN(
+          get_logger(), "Failed to clean-up the controller '%s' before unloading!",
+          controller_name.c_str());
+      }
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR(
+        get_logger(), "Failed to clean-up the controller '%s' before unloading: %s",
+        controller_name.c_str(), e.what());
+    }
+    catch (...)
+    {
+      RCLCPP_ERROR(
+        get_logger(), "Failed to clean-up the controller '%s' before unloading",
         controller_name.c_str());
     }
   }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1399,8 +1399,25 @@ void ControllerManager::deactivate_controllers(
     auto controller = found_it->c;
     if (is_controller_active(*controller))
     {
-      const auto new_state = controller->get_node()->deactivate();
-      controller->release_interfaces();
+      try
+      {
+        const auto new_state = controller->get_node()->deactivate();
+        controller->release_interfaces();
+      }
+      catch (const std::exception & e)
+      {
+        RCLCPP_ERROR(
+          get_logger(), "Caught exception while deactivating the  controller '%s': %s",
+          controller_name.c_str(), e.what());
+        continue;
+      }
+      catch (...)
+      {
+        RCLCPP_ERROR(
+          get_logger(), "Caught unknown exception while deactivating the controller '%s'",
+          controller_name.c_str());
+        continue;
+      }
       // if it is a chainable controller, make the reference interfaces unavailable on deactivation
       if (controller->is_chainable())
       {


### PR DESCRIPTION
This PR adds the exception handling in the controller manager for the most commonly used controller methods that are triggered by different controller manager services