### PR TITLE
Fix dependencies for source build

### DIFF
--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -21,6 +21,6 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master
     with:
       ros_distro: rolling
-      ref: master
+      ref: fix_source_build
       ros2_repo_branch: master
       container: ubuntu:24.04

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -21,6 +21,6 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master
     with:
       ros_distro: rolling
-      ref: fix_source_build
+      ref: master
       ros2_repo_branch: master
       container: ubuntu:24.04

--- a/controller_interface/test/test_controller_interface.cpp
+++ b/controller_interface/test/test_controller_interface.cpp
@@ -88,7 +88,8 @@ TEST(TestableControllerInterface, setting_update_rate_in_configure)
   ASSERT_EQ(controller.get_update_rate(), 2812u);
 
   // Test updating of update_rate parameter
-  EXPECT_EQ(std::system("ros2 param set /testable_controller_interface update_rate 623"), 0);
+  auto res = controller.get_node()->set_parameter(rclcpp::Parameter("update_rate", 623));
+  EXPECT_EQ(res.successful, true);
   // Keep the same update rate until transition from 'UNCONFIGURED' TO 'INACTIVE' does not happen
   controller.configure();  // No transition so the update rate should stay intact
   ASSERT_NE(controller.get_update_rate(), 623u);

--- a/joint_limits/package.xml
+++ b/joint_limits/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>urdf</depend>
 
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
The [source builds consistently fail](https://github.com/ros-controls/ros2_control/actions/runs/9009050170/job/24752476561) with the following errors

       sh: 1: ros2: not found
      /__w/ros2_control/ros2_control/ros_ws/src/rna86ha94vo/ros2_control/controller_interface/test/test_controller_interface.cpp:91: Failure
      Expected equality of these values:
        std::system("ros2 param set /testable_controller_interface update_rate 623")
          Which is: 32512
        0

and

      launch_test.py: error: No module named 'launch_ros'

Both come from missing dependencies on ros2cli and launch_ros.

- I don't think that std::system is necessary and changed this to set the parameter of the node via C++ API.
- Added launch_ros to the test_dependency of joint_limits

[Voilà](https://github.com/ros-controls/ros2_control/actions/runs/9028074244)