### PR TITLE
Add find_package for ament_cmake_gen_version_h

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -12,6 +12,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -21,6 +21,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -20,6 +20,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -62,4 +62,5 @@ install(TARGETS joint_limits
 ament_export_targets(export_joint_limits HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()
-ament_generate_version_header(${PROJECT_NAME})
+# TODO(anyone) uncomment if https://github.com/ament/ament_cmake/pull/526 is merged
+# ament_generate_version_header(${PROJECT_NAME})

--- a/joint_limits/package.xml
+++ b/joint_limits/package.xml
@@ -13,7 +13,8 @@
   <url type="repository">https://github.com/ros-controls/ros2_control</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
+  <!-- TODO(anyone) uncomment if https://github.com/ament/ament_cmake/pull/526 is merged -->
+  <!-- <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend> -->
 
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -13,6 +13,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()


### PR DESCRIPTION
We have the joint_limits package failing on the [build farm](https://build.ros2.org/job/Rbin_uN64__joint_limits__ubuntu_noble_amd64__binary/) since #1449

```
08:25:10 CMake Error at cmake_install.cmake:145 (file):
08:25:10   file INSTALL cannot find
08:25:10   "/tmp/binarydeb/ros-rolling-joint-limits-4.10.0/.obj-x86_64-linux-gnu/ament_generate_version_header/joint_limits/joint_limits/version.h":
08:25:10   No such file or directory.
```

@saikishor and myself tried to find the root cause, and why joint_limits is the only package failing. 

We now think this might be due to a missing `find_package(ament_cmake_gen_version_h REQUIRED)`. The other packages include rclcpp, which includes tracetools, which has this [find_package](https://github.com/ros2/ros2_tracing/pull/112/files) and might export this dependency "upstream". This is missing in joint_limits.

Related to https://github.com/ament/ament_cmake/issues/525