### PR TITLE
[CI] Update branch of reusable workflow

### DIFF
--- a/.github/workflows/rolling-check-docs.yml
+++ b/.github/workflows/rolling-check-docs.yml
@@ -9,6 +9,7 @@ on:
       - '**.rst'
       - '**.md'
       - '**.yaml'
+      - '.github/workflows/rolling-check-docs.yml'
 
 jobs:
   check-docs:

--- a/.github/workflows/rolling-check-docs.yml
+++ b/.github/workflows/rolling-check-docs.yml
@@ -13,6 +13,6 @@ on:
 jobs:
   check-docs:
     name: Check Docs
-    uses: ros-controls/control.ros.org/.github/workflows/reusable-sphinx-check-single-version.yml@master
+    uses: ros-controls/control.ros.org/.github/workflows/reusable-sphinx-check-single-version.yml@rolling
     with:
       ROS2_CONTROL_PR: ${{ github.ref }}


### PR DESCRIPTION
Since https://github.com/ros-controls/control.ros.org/pull/293 we need to specify `rolling` instead of `master` for the reusable workflow. 