### PR TITLE
Reactivate generate_version_header for joint_limits

### DIFF
--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -62,5 +62,4 @@ install(TARGETS joint_limits
 ament_export_targets(export_joint_limits HAS_LIBRARY_TARGET)
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()
-# TODO(anyone) uncomment if https://github.com/ament/ament_cmake/pull/526 is merged
-# ament_generate_version_header(${PROJECT_NAME})
+ament_generate_version_header(${PROJECT_NAME})

--- a/joint_limits/package.xml
+++ b/joint_limits/package.xml
@@ -13,8 +13,7 @@
   <url type="repository">https://github.com/ros-controls/ros2_control</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <!-- TODO(anyone) uncomment if https://github.com/ament/ament_cmake/pull/526 is merged -->
-  <!-- <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend> -->
+  <buildtool_depend>ament_cmake_gen_version_h</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>


### PR DESCRIPTION
Was deactivated with https://github.com/ros-controls/ros2_control/pull/1534 and the build farm is happy now
https://build.ros2.org/job/Rbin_uN64__joint_limits__ubuntu_noble_amd64__binary/

After https://github.com/ament/ament_cmake/pull/529 is merged (backport to jazzy, held back until the first patch release) we can reactivate it.