### PR TITLE
[Feature] Choose different read and write rate for the hardware components

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -112,6 +112,44 @@ hardware_interface
 
 * Soft limits are also parsed from the URDF into the ``HardwareInfo`` structure for the defined joints (`#1488 <https://github.com/ros-controls/ros2_control/pull/1488>`_)
 * Access to logger and clock through ``get_logger`` and ``get_clock`` methods in ResourceManager and HardwareComponents ``Actuator``, ``Sensor`` and ``System`` (`#1585 <https://github.com/ros-controls/ros2_control/pull/1585>`_)
+* The ``ros2_control`` tag now supports parsing read/write rate ``rw_rate`` for the each hardware component parsed through the URDF (`#1570 <https://github.com/ros-controls/ros2_control/pull/1570>`_)
+
+  .. code:: xml
+
+    <ros2_control name="RRBotSystemMutipleGPIOs" type="system" rw_rate="500">
+      <hardware>
+        <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
+        <param name="example_param_hw_start_duration_sec">2.0</param>
+        <param name="example_param_hw_stop_duration_sec">3.0</param>
+        <param name="example_param_hw_slowdown">2.0</param>
+      </hardware>
+      <joint name="joint1">
+        <command_interface name="position"/>
+        <command_interface name="velocity"/>
+        <state_interface name="position"/>
+      </joint>
+      <joint name="joint2">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+      </joint>
+    </ros2_control>
+    <ros2_control name="MultimodalGripper" type="actuator" rw_rate="200">
+      <hardware>
+        <plugin>ros2_control_demo_hardware/MultimodalGripper</plugin>
+      </hardware>
+      <joint name="parallel_fingers">
+        <command_interface name="position">
+          <param name="min">0</param>
+          <param name="max">100</param>
+        </command_interface>
+        <state_interface name="position"/>
+      </joint>
+      <gpio name="suction">
+        <command_interface name="suction"/>
+        <state_interface name="suction"/>
+      </gpio>
+    </ros2_control>
+
 * Added ``get_hardware_info`` method to the hardware components interface to access the ``HardwareInfo`` instead of accessing the variable ``info_`` directly (`#1643 <https://github.com/ros-controls/ros2_control/pull/1643>`_)
 * With (`#1683 <https://github.com/ros-controls/ros2_control/pull/1683>`_) the ``rclcpp_lifecycle::State & get_state()`` and ``void set_state(const rclcpp_lifecycle::State & new_state)`` are replaced by ``rclcpp_lifecycle::State & get_lifecycle_state()`` and ``void set_lifecycle_state(const rclcpp_lifecycle::State & new_state)``. This change affects controllers and hardware. This is related to (`#1240 <https://github.com/ros-controls/ros2_control/pull/1240>`_) as variant support introduces ``get_state`` and ``set_state`` methods for setting/getting state of handles.
 * With (`#1421 <https://github.com/ros-controls/ros2_control/pull/1421>`_) a key-value storage is added to InterfaceInfo. This allows to define extra params with per Command-/StateInterface in the ``.ros2_control.xacro`` file.

--- a/hardware_interface/doc/different_update_rates_userdoc.rst
+++ b/hardware_interface/doc/different_update_rates_userdoc.rst
@@ -5,165 +5,86 @@
 Different update rates for Hardware Components
 ===============================================================================
 
-In the following sections you can find some advice which will help you to implement Hardware
-Components with update rates different from the main control loop.
+The ``ros2_control`` framework allows to run different hardware components at different update rates. This is useful when some of the hardware components needs to run at a different frequency than the traditional control loop frequency which is same as the one of the ``controller_manager``. It is very typical to have different components with different frequencies in a robotic system with different sensors or different components using different communication protocols.
+This is useful when you have a hardware component that needs to run at a higher rate than the rest of the components. For example, you might have a sensor that needs to be read at 1000Hz, while the rest of the components can run at 500Hz, given that the control loop frequency of the ``controller_manager`` is higher than 1000Hz. The read/write rate can be defined easily by adding the parameter ``rw_rate`` to the ``ros2_control`` tag of the hardware component.
 
-By counting loops
--------------------------------------------------------------------------------
+Examples
+*****************************
+The following examples show how to use the different hardware interface types with different update frequencies in a ``ros2_control`` URDF.
+They can be combined together within the different hardware component types (system, actuator, sensor) (:ref:`see detailed documentation <overview_hardware_components>`) as follows
 
-Current implementation of
-`ros2_control main node <https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/controller_manager/src/ros2_control_node.cpp>`_
-has one update rate that controls the rate of the
-`read(...) <https://github.com/ros-controls/ros2_control/blob/0bdcd414c7ab8091f3e1b8d9b73a91c778388e82/hardware_interface/include/hardware_interface/system_interface.hpp#L175>`_
-and `write(...) <https://github.com/ros-controls/ros2_control/blob/fe462926416d527d1da163bc3eabd02ee1de9be9/hardware_interface/include/hardware_interface/system_interface.hpp#L178>`_
-calls in `hardware_interface(s) <https://github.com/ros-controls/ros2_control/blob/{REPOS_FILE_BRANCH}/hardware_interface/include/hardware_interface/system_interface.hpp>`_.
-To achieve different update rates for your hardware component you can use the following steps:
+For a RRBot with Multimodal gripper and external sensor running at different rates:
 
-.. _step-1:
+.. code-block:: xml
 
-1. Add parameters of main control loop update rate and desired update rate for your hardware component
+  <ros2_control name="RRBotSystemMutipleGPIOs" type="system" rw_rate="500">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
+      <param name="example_param_hw_start_duration_sec">2.0</param>
+      <param name="example_param_hw_stop_duration_sec">3.0</param>
+      <param name="example_param_hw_slowdown">2.0</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="joint2">
+      <command_interface name="position">
+        <param name="min">-1</param>
+        <param name="max">1</param>
+      </command_interface>
+      <state_interface name="position"/>
+    </joint>
+    <gpio name="flange_digital_IOs">
+      <command_interface name="digital_output1"/>
+      <state_interface name="digital_output1"/>    <!-- Needed to know current state of the output -->
+      <command_interface name="digital_output2"/>
+      <state_interface name="digital_output2"/>
+      <state_interface name="digital_input1"/>
+      <state_interface name="digital_input2"/>
+    </gpio>
+  </ros2_control>
+  <ros2_control name="MultimodalGripper" type="actuator" rw_rate="200">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/MultimodalGripper</plugin>
+    </hardware>
+    <joint name="parallel_fingers">
+      <command_interface name="position">
+        <param name="min">0</param>
+        <param name="max">100</param>
+      </command_interface>
+      <state_interface name="position"/>
+    </joint>
+    <gpio name="suction">
+      <command_interface name="suction"/>
+      <state_interface name="suction"/>    <!-- Needed to know current state of the output -->
+    </gpio>
+  </ros2_control>
+  <ros2_control name="RRBotForceTorqueSensor2D" type="sensor" rw_rate="250">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/ForceTorqueSensor2DHardware</plugin>
+      <param name="example_param_read_for_sec">0.43</param>
+    </hardware>
+    <sensor name="tcp_fts_sensor">
+      <state_interface name="fx"/>
+      <state_interface name="tz"/>
+      <param name="frame_id">kuka_tcp</param>
+      <param name="fx_range">100</param>
+      <param name="tz_range">100</param>
+    </sensor>
+    <sensor name="temp_feedback">
+      <state_interface name="temperature"/>
+    </sensor>
+    <gpio name="calibration">
+      <command_interface name="calibration_matrix_nr"/>
+      <state_interface name="calibration_matrix_nr"/>
+    </gpio>
+  </ros2_control>
 
-  .. code:: xml
-
-    <?xml version="1.0"?>
-    <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-
-      <xacro:macro name="system_interface" params="name main_loop_update_rate desired_hw_update_rate">
-
-        <ros2_control name="${name}" type="system">
-          <hardware>
-              <plugin>my_system_interface/MySystemHardware</plugin>
-              <param name="main_loop_update_rate">${main_loop_update_rate}</param>
-              <param name="desired_hw_update_rate">${desired_hw_update_rate}</param>
-          </hardware>
-          ...
-        </ros2_control>
-
-      </xacro:macro>
-
-    </robot>
-
-.. _step-2:
-
-2. In you ``on_init()`` specific implementation fetch the desired parameters
-
-  .. code:: cpp
-
-    namespace my_system_interface
-    {
-    hardware_interface::CallbackReturn MySystemHardware::on_init(
-      const hardware_interface::HardwareInfo & info)
-    {
-      if (
-        hardware_interface::SystemInterface::on_init(info) !=
-        hardware_interface::CallbackReturn::SUCCESS)
-      {
-        return hardware_interface::CallbackReturn::ERROR;
-      }
-
-      //   declaration in *.hpp file --> unsigned int main_loop_update_rate_, desired_hw_update_rate_ = 100 ;
-      main_loop_update_rate_ = stoi(info_.hardware_parameters["main_loop_update_rate"]);
-      desired_hw_update_rate_ = stoi(info_.hardware_parameters["desired_hw_update_rate"]);
-
-      ...
-    }
-    ...
-    } // my_system_interface
-
-3. In your ``on_activate`` specific implementation reset internal loop counter
-
-  .. code:: cpp
-
-    hardware_interface::CallbackReturn MySystemHardware::on_activate(
-      const rclcpp_lifecycle::State & /*previous_state*/)
-    {
-        //   declaration in *.hpp file --> unsigned int update_loop_counter_ ;
-        update_loop_counter_ = 0;
-        ...
-    }
-
-4. In your ``read(const rclcpp::Time & time, const rclcpp::Duration & period)``
-   and/or ``write(const rclcpp::Time & time, const rclcpp::Duration & period)``
-   specific implementations decide if you should interfere with your hardware
-
-  .. code:: cpp
-
-    hardware_interface::return_type MySystemHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
-    {
-
-      bool hardware_go = main_loop_update_rate_ == 0  ||
-                        desired_hw_update_rate_ == 0 ||
-                        ((update_loop_counter_ % desired_hw_update_rate_) == 0);
-
-      if (hardware_go){
-        // hardware comms and operations
-        ...
-      }
-      ...
-
-      // update counter
-      ++update_loop_counter_;
-      update_loop_counter_ %= main_loop_update_rate_;
-    }
-
-By measuring elapsed time
--------------------------------------------------------------------------------
-
-Another way to decide if hardware communication should be executed in the
-``read(const rclcpp::Time & time, const rclcpp::Duration & period)`` and/or
-``write(const rclcpp::Time & time, const rclcpp::Duration & period)``
-implementations is to measure elapsed time since last pass:
-
-1. In your ``on_activate`` specific implementation reset the flags that indicate
-   that this is the first pass of the ``read`` and ``write`` methods
-
-  .. code:: cpp
-
-    hardware_interface::CallbackReturn MySystemHardware::on_activate(
-      const rclcpp_lifecycle::State & /*previous_state*/)
-    {
-        //   declaration in *.hpp file --> bool first_read_pass_, first_write_pass_ = true ;
-        first_read_pass_ = first_write_pass_ = true;
-        ...
-    }
-
-2. In your ``read(const rclcpp::Time & time, const rclcpp::Duration & period)``
-   and/or ``write(const rclcpp::Time & time, const rclcpp::Duration & period)``
-   specific implementations decide if you should interfere with your hardware
-
-    .. code:: cpp
-
-      hardware_interface::return_type MySystemHardware::read(const rclcpp::Time & time, const rclcpp::Duration & period)
-      {
-          if (first_read_pass_ || (time - last_read_time_ ) > desired_hw_update_period_)
-          {
-            first_read_pass_ = false;
-            //   declaration in *.hpp file --> rclcpp::Time last_read_time_ ;
-            last_read_time_ = time;
-            // hardware comms and operations
-            ...
-          }
-          ...
-      }
-
-      hardware_interface::return_type MySystemHardware::write(const rclcpp::Time & time, const rclcpp::Duration & period)
-      {
-          if (first_write_pass_ || (time - last_write_time_ ) > desired_hw_update_period_)
-          {
-            first_write_pass_ = false;
-            //   declaration in *.hpp file --> rclcpp::Time last_write_time_ ;
-            last_write_time_ = time;
-            // hardware comms and operations
-            ...
-          }
-          ...
-      }
+In the above example, the system hardware component that controls the joints of the RRBot is running at 500 Hz, the multimodal gripper is running at 200 Hz and the force torque sensor is running at 250 Hz.
 
 .. note::
-
-  The approach to get the desired update period value from the URDF and assign it to the variable
-  ``desired_hw_update_period_`` is the same as in the previous section (|step-1|_ and |step-2|_) but
-  with a different parameter name.
-
-.. |step-1| replace:: step 1
-.. |step-2| replace:: step 2
+  In the above example, the ``rw_rate`` parameter is set to 500 Hz, 200 Hz and 250 Hz for the system, actuator and sensor hardware components respectively. This parameter is optional and if not set, the default value of 0 will be used which means that the hardware component will run at the same rate as the ``controller_manager``. However, if the specified rate is higher than the ``controller_manager`` rate, the hardware component will then run at the rate of the ``controller_manager``.

--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -96,6 +96,12 @@ public:
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 
   HARDWARE_INTERFACE_PUBLIC
+  const rclcpp::Time & get_last_read_time() const;
+
+  HARDWARE_INTERFACE_PUBLIC
+  const rclcpp::Time & get_last_write_time() const;
+
+  HARDWARE_INTERFACE_PUBLIC
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   HARDWARE_INTERFACE_PUBLIC
@@ -104,6 +110,10 @@ public:
 private:
   std::unique_ptr<ActuatorInterface> impl_;
   mutable std::recursive_mutex actuators_mutex_;
+  // Last read cycle time
+  rclcpp::Time last_read_cycle_time_;
+  // Last write cycle time
+  rclcpp::Time last_write_cycle_time_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -107,6 +107,9 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   return_type write(const rclcpp::Time & time, const rclcpp::Duration & period);
 
+  HARDWARE_INTERFACE_PUBLIC
+  std::recursive_mutex & get_mutex();
+
 private:
   std::unique_ptr<ActuatorInterface> impl_;
   mutable std::recursive_mutex actuators_mutex_;

--- a/hardware_interface/include/hardware_interface/hardware_component_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_info.hpp
@@ -54,12 +54,6 @@ struct HardwareComponentInfo
   //// write rate
   unsigned int write_rate;
 
-  //// Next read cycle time
-  std::shared_ptr<rclcpp::Time> next_read_cycle_time;
-
-  //// Next write cycle time
-  std::shared_ptr<rclcpp::Time> next_write_cycle_time;
-
   /// Component current state.
   rclcpp_lifecycle::State state;
 

--- a/hardware_interface/include/hardware_interface/hardware_component_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_info.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include <rclcpp/time.hpp>
 #include "rclcpp_lifecycle/state.hpp"
 
 namespace hardware_interface
@@ -46,6 +47,18 @@ struct HardwareComponentInfo
 
   /// Component is async
   bool is_async;
+
+  //// read rate
+  unsigned int read_rate;
+
+  //// write rate
+  unsigned int write_rate;
+
+  //// Next read cycle time
+  std::shared_ptr<rclcpp::Time> next_read_cycle_time;
+
+  //// Next write cycle time
+  std::shared_ptr<rclcpp::Time> next_write_cycle_time;
 
   /// Component current state.
   rclcpp_lifecycle::State state;

--- a/hardware_interface/include/hardware_interface/hardware_component_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_info.hpp
@@ -48,11 +48,8 @@ struct HardwareComponentInfo
   /// Component is async
   bool is_async;
 
-  //// read rate
-  unsigned int read_rate;
-
-  //// write rate
-  unsigned int write_rate;
+  //// read/write rate
+  unsigned int rw_rate;
 
   /// Component current state.
   rclcpp_lifecycle::State state;

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -174,6 +174,8 @@ struct HardwareInfo
   std::string type;
   ///  Hardware group to which the hardware belongs.
   std::string group;
+  /// Component's read and write rates in Hz.
+  unsigned int rw_rate;
   /// Component is async
   bool is_async;
   /// Name of the pluginlib plugin of the hardware that will be loaded.

--- a/hardware_interface/include/hardware_interface/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/sensor.hpp
@@ -83,6 +83,9 @@ public:
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 
   HARDWARE_INTERFACE_PUBLIC
+  const rclcpp::Time & get_last_read_time() const;
+
+  HARDWARE_INTERFACE_PUBLIC
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   HARDWARE_INTERFACE_PUBLIC
@@ -91,6 +94,8 @@ public:
 private:
   std::unique_ptr<SensorInterface> impl_;
   mutable std::recursive_mutex sensors_mutex_;
+  // Last read cycle time
+  rclcpp::Time last_read_cycle_time_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/sensor.hpp
@@ -91,6 +91,9 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   return_type write(const rclcpp::Time &, const rclcpp::Duration &) { return return_type::OK; }
 
+  HARDWARE_INTERFACE_PUBLIC
+  std::recursive_mutex & get_mutex();
+
 private:
   std::unique_ptr<SensorInterface> impl_;
   mutable std::recursive_mutex sensors_mutex_;

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -107,6 +107,9 @@ public:
   HARDWARE_INTERFACE_PUBLIC
   return_type write(const rclcpp::Time & time, const rclcpp::Duration & period);
 
+  HARDWARE_INTERFACE_PUBLIC
+  std::recursive_mutex & get_mutex();
+
 private:
   std::unique_ptr<SystemInterface> impl_;
   mutable std::recursive_mutex system_mutex_;

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -96,6 +96,12 @@ public:
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 
   HARDWARE_INTERFACE_PUBLIC
+  const rclcpp::Time & get_last_read_time() const;
+
+  HARDWARE_INTERFACE_PUBLIC
+  const rclcpp::Time & get_last_write_time() const;
+
+  HARDWARE_INTERFACE_PUBLIC
   return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   HARDWARE_INTERFACE_PUBLIC
@@ -104,6 +110,10 @@ public:
 private:
   std::unique_ptr<SystemInterface> impl_;
   mutable std::recursive_mutex system_mutex_;
+  // Last read cycle time
+  rclcpp::Time last_read_cycle_time_;
+  // Last write cycle time
+  rclcpp::Time last_write_cycle_time_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -282,6 +282,10 @@ const rclcpp_lifecycle::State & Actuator::get_lifecycle_state() const
   return impl_->get_lifecycle_state();
 }
 
+const rclcpp::Time & Actuator::get_last_read_time() const { return last_read_cycle_time_; }
+
+const rclcpp::Time & Actuator::get_last_write_time() const { return last_write_cycle_time_; }
+
 return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_, std::try_to_lock);
@@ -294,6 +298,7 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
+    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -306,6 +311,7 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
     {
       error();
     }
+    last_read_cycle_time_ = time;
   }
   return result;
 }
@@ -322,6 +328,7 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
+    last_write_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -334,6 +341,7 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
     {
       error();
     }
+    last_write_cycle_time_ = time;
   }
   return result;
 }

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -41,6 +41,8 @@ Actuator::Actuator(Actuator && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.actuators_mutex_);
   impl_ = std::move(other.impl_);
+  last_read_cycle_time_ = other.last_read_cycle_time_;
+  last_write_cycle_time_ = other.last_write_cycle_time_;
 }
 
 const rclcpp_lifecycle::State & Actuator::initialize(

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -53,6 +53,8 @@ const rclcpp_lifecycle::State & Actuator::initialize(
     switch (impl_->init(actuator_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
+        last_read_cycle_time_ = clock_interface->get_clock()->now();
+        last_write_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -298,7 +300,7 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
-    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
+    last_read_cycle_time_ = time;
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -328,7 +330,7 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
-    last_write_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
+    last_write_cycle_time_ = time;
     return return_type::OK;
   }
   return_type result = return_type::ERROR;

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -290,14 +290,6 @@ const rclcpp::Time & Actuator::get_last_write_time() const { return last_write_c
 
 return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  std::unique_lock<std::recursive_mutex> lock(actuators_mutex_, std::try_to_lock);
-  if (!lock.owns_lock())
-  {
-    RCLCPP_DEBUG(
-      impl_->get_logger(), "Skipping read() call for actuator '%s' since it is locked",
-      impl_->get_name().c_str());
-    return return_type::OK;
-  }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
     last_read_cycle_time_ = time;
@@ -320,14 +312,6 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
 
 return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  std::unique_lock<std::recursive_mutex> lock(actuators_mutex_, std::try_to_lock);
-  if (!lock.owns_lock())
-  {
-    RCLCPP_DEBUG(
-      impl_->get_logger(), "Skipping write() call for actuator '%s' since it is locked",
-      impl_->get_name().c_str());
-    return return_type::OK;
-  }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
     last_write_cycle_time_ = time;
@@ -348,4 +332,5 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
   return result;
 }
 
+std::recursive_mutex & Actuator::get_mutex() { return actuators_mutex_; }
 }  // namespace hardware_interface

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -234,14 +234,29 @@ std::string parse_data_type_attribute(const tinyxml2::XMLElement * elem)
 unsigned int parse_rw_rate_attribute(const tinyxml2::XMLElement * elem)
 {
   const tinyxml2::XMLAttribute * attr = elem->FindAttribute(kReadWriteRateAttribute);
-  const auto rw_rate = attr ? std::stoi(attr->Value()) : 0;
-  if (rw_rate < 0)
+  try
+  {
+    const auto rw_rate = attr ? std::stoi(attr->Value()) : 0;
+    if (rw_rate < 0)
+    {
+      throw std::runtime_error(
+        "Could not parse rw_rate tag in \"" + std::string(elem->Name()) + "\"." + "Got \"" +
+        std::to_string(rw_rate) + "\", but expected a positive integer.");
+    }
+    return static_cast<unsigned int>(rw_rate);
+  }
+  catch (const std::invalid_argument & e)
   {
     throw std::runtime_error(
-      "Could not parse rw_rate tag in \"" + std::string(elem->Name()) + "\"." + "Got \"" +
-      std::to_string(rw_rate) + "\", but expected a positive integer.");
+      "Could not parse rw_rate tag in \"" + std::string(elem->Name()) + "\"." +
+      " Invalid value : \"" + attr->Value() + "\", expected a positive integer.");
   }
-  return static_cast<unsigned int>(rw_rate);
+  catch (const std::out_of_range & e)
+  {
+    throw std::runtime_error(
+      "Could not parse rw_rate tag in \"" + std::string(elem->Name()) + "\"." +
+      " Out of range value : \"" + attr->Value() + "\", expected a positive valid integer.");
+  }
 }
 
 /// Parse is_async attribute

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -58,6 +58,7 @@ constexpr const auto kTypeAttribute = "type";
 constexpr const auto kRoleAttribute = "role";
 constexpr const auto kReductionAttribute = "mechanical_reduction";
 constexpr const auto kOffsetAttribute = "offset";
+constexpr const auto kReadWriteRateAttribute = "rw_rate";
 constexpr const auto kIsAsyncAttribute = "is_async";
 
 }  // namespace
@@ -220,6 +221,27 @@ std::string parse_data_type_attribute(const tinyxml2::XMLElement * elem)
   }
 
   return data_type;
+}
+
+/// Parse rw_rate attribute
+/**
+ * Parses an XMLElement and returns the value of the rw_rate attribute.
+ * Defaults to 0 if not specified.
+ *
+ * \param[in] elem XMLElement that has the rw_rate attribute.
+ * \return unsigned int specifying the read/write rate.
+ */
+unsigned int parse_rw_rate_attribute(const tinyxml2::XMLElement * elem)
+{
+  const tinyxml2::XMLAttribute * attr = elem->FindAttribute(kReadWriteRateAttribute);
+  const auto rw_rate = attr ? std::stoi(attr->Value()) : 0;
+  if (rw_rate < 0)
+  {
+    throw std::runtime_error(
+      "Could not parse rw_rate tag in \"" + std::string(elem->Name()) + "\"." + "Got \"" +
+      std::to_string(rw_rate) + "\", but expected a positive integer.");
+  }
+  return static_cast<unsigned int>(rw_rate);
 }
 
 /// Parse is_async attribute
@@ -575,6 +597,7 @@ HardwareInfo parse_resource_from_xml(
   HardwareInfo hardware;
   hardware.name = get_attribute_value(ros2_control_it, kNameAttribute, kROS2ControlTag);
   hardware.type = get_attribute_value(ros2_control_it, kTypeAttribute, kROS2ControlTag);
+  hardware.rw_rate = parse_rw_rate_attribute(ros2_control_it);
   hardware.is_async = parse_is_async_attribute(ros2_control_it);
 
   // Parse everything under ros2_control tag

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1855,16 +1855,16 @@ HardwareReadWriteStatus ResourceManager::read(
         }
         else
         {
-          const rclcpp::Duration hw_read_period = rclcpp::Duration::from_seconds(
-            1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate);
+          const double read_rate =
+            resource_storage_->hardware_info_map_[component.get_name()].read_rate;
           const auto current_time = resource_storage_->get_clock()->now();
           if (
             component.get_last_read_time().seconds() == 0 ||
-            (current_time - component.get_last_read_time()) >= hw_read_period)
+            (current_time - component.get_last_read_time()).seconds() * read_rate >= 0.99)
           {
             const rclcpp::Duration actual_period =
               component.get_last_read_time().seconds() == 0
-                ? hw_read_period
+                ? rclcpp::Duration::from_seconds(1.0 / read_rate)
                 : current_time - component.get_last_read_time();
             ret_val = component.read(time, actual_period);
           }
@@ -1937,16 +1937,16 @@ HardwareReadWriteStatus ResourceManager::write(
         }
         else
         {
-          const rclcpp::Duration hw_write_period = rclcpp::Duration::from_seconds(
-            1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate);
+          const double write_rate =
+            resource_storage_->hardware_info_map_[component.get_name()].write_rate;
           const auto current_time = resource_storage_->get_clock()->now();
           if (
             component.get_last_write_time().seconds() == 0 ||
-            (current_time - component.get_last_write_time()) >= hw_write_period)
+            (current_time - component.get_last_write_time()).seconds() * write_rate >= 0.99)
           {
             const rclcpp::Duration actual_period =
               component.get_last_write_time().seconds() == 0
-                ? hw_write_period
+                ? rclcpp::Duration::from_seconds(1.0 / write_rate)
                 : current_time - component.get_last_write_time();
             ret_val = component.write(time, actual_period);
           }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1856,8 +1856,9 @@ HardwareReadWriteStatus ResourceManager::read(
       try
       {
         if (
+          resource_storage_->hardware_info_map_[component.get_name()].read_rate == 0 ||
           resource_storage_->hardware_info_map_[component.get_name()].read_rate ==
-          resource_storage_->cm_update_rate_)
+            resource_storage_->cm_update_rate_)
         {
           ret_val = component.read(time, period);
         }
@@ -1941,8 +1942,9 @@ HardwareReadWriteStatus ResourceManager::write(
       try
       {
         if (
+          resource_storage_->hardware_info_map_[component.get_name()].write_rate == 0 ||
           resource_storage_->hardware_info_map_[component.get_name()].write_rate ==
-          resource_storage_->cm_update_rate_)
+            resource_storage_->cm_update_rate_)
         {
           ret_val = component.write(time, period);
         }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1847,6 +1847,17 @@ HardwareReadWriteStatus ResourceManager::read(
         {
           ret_val = component.read(time, period);
         }
+        else
+        {
+          const double hw_read_period =
+            1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate;
+          if (
+            component.get_last_read_time().seconds() == 0 ||
+            (time - component.get_last_read_time()).seconds() >= hw_read_period)
+          {
+            ret_val = component.read(time, period);
+          }
+        }
         const auto component_group = component.get_group_name();
         ret_val =
           resource_storage_->update_hardware_component_group_state(component_group, ret_val);
@@ -1912,6 +1923,17 @@ HardwareReadWriteStatus ResourceManager::write(
           resource_storage_->cm_update_rate_)
         {
           ret_val = component.write(time, period);
+        }
+        else
+        {
+          const double hw_write_period =
+            1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate;
+          if (
+            component.get_last_write_time().seconds() == 0 ||
+            (time - component.get_last_write_time()).seconds() >= hw_write_period)
+          {
+            ret_val = component.write(time, period);
+          }
         }
         const auto component_group = component.get_group_name();
         ret_val =

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1859,9 +1859,12 @@ HardwareReadWriteStatus ResourceManager::read(
             1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate);
           if (
             component.get_last_read_time().seconds() == 0 ||
-            (time - component.get_last_read_time()).seconds() >= hw_read_period.seconds())
+            (time - component.get_last_read_time()) >= hw_read_period)
           {
-            ret_val = component.read(time, hw_read_period);
+            const rclcpp::Duration actual_period = component.get_last_read_time().seconds() == 0
+                                                     ? hw_read_period
+                                                     : time - component.get_last_read_time();
+            ret_val = component.read(time, actual_period);
           }
         }
         const auto component_group = component.get_group_name();
@@ -1936,9 +1939,12 @@ HardwareReadWriteStatus ResourceManager::write(
             1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate);
           if (
             component.get_last_write_time().seconds() == 0 ||
-            (time - component.get_last_write_time()).seconds() >= hw_write_period.seconds())
+            (time - component.get_last_write_time()) >= hw_write_period)
           {
-            ret_val = component.write(time, hw_write_period);
+            const rclcpp::Duration actual_period = component.get_last_write_time().seconds() == 0
+                                                     ? hw_write_period
+                                                     : time - component.get_last_read_time();
+            ret_val = component.write(time, actual_period);
           }
         }
         const auto component_group = component.get_group_name();

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1844,6 +1844,14 @@ HardwareReadWriteStatus ResourceManager::read(
   {
     for (auto & component : components)
     {
+      std::unique_lock<std::recursive_mutex> lock(component.get_mutex(), std::try_to_lock);
+      if (!lock.owns_lock())
+      {
+        RCLCPP_DEBUG(
+          get_logger(), "Skipping read() call for the component '%s' since it is locked",
+          component.get_name().c_str());
+        continue;
+      }
       auto ret_val = return_type::OK;
       try
       {
@@ -1921,6 +1929,14 @@ HardwareReadWriteStatus ResourceManager::write(
   {
     for (auto & component : components)
     {
+      std::unique_lock<std::recursive_mutex> lock(component.get_mutex(), std::try_to_lock);
+      if (!lock.owns_lock())
+      {
+        RCLCPP_DEBUG(
+          get_logger(), "Skipping write() call for the component '%s' since it is locked",
+          component.get_name().c_str());
+        continue;
+      }
       auto ret_val = return_type::OK;
       try
       {

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1855,13 +1855,13 @@ HardwareReadWriteStatus ResourceManager::read(
         }
         else
         {
-          const double hw_read_period =
-            1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate;
+          const rclcpp::Duration hw_read_period = rclcpp::Duration::from_seconds(
+            1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate);
           if (
             component.get_last_read_time().seconds() == 0 ||
-            (time - component.get_last_read_time()).seconds() >= hw_read_period)
+            (time - component.get_last_read_time()).seconds() >= hw_read_period.seconds())
           {
-            ret_val = component.read(time, period);
+            ret_val = component.read(time, hw_read_period);
           }
         }
         const auto component_group = component.get_group_name();
@@ -1932,13 +1932,13 @@ HardwareReadWriteStatus ResourceManager::write(
         }
         else
         {
-          const double hw_write_period =
-            1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate;
+          const rclcpp::Duration hw_write_period = rclcpp::Duration::from_seconds(
+            1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate);
           if (
             component.get_last_write_time().seconds() == 0 ||
-            (time - component.get_last_write_time()).seconds() >= hw_write_period)
+            (time - component.get_last_write_time()).seconds() >= hw_write_period.seconds())
           {
-            ret_val = component.write(time, period);
+            ret_val = component.write(time, hw_write_period);
           }
         }
         const auto component_group = component.get_group_name();

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1857,13 +1857,15 @@ HardwareReadWriteStatus ResourceManager::read(
         {
           const rclcpp::Duration hw_read_period = rclcpp::Duration::from_seconds(
             1.0 / resource_storage_->hardware_info_map_[component.get_name()].read_rate);
+          const auto current_time = resource_storage_->get_clock()->now();
           if (
             component.get_last_read_time().seconds() == 0 ||
-            (time - component.get_last_read_time()) >= hw_read_period)
+            (current_time - component.get_last_read_time()) >= hw_read_period)
           {
-            const rclcpp::Duration actual_period = component.get_last_read_time().seconds() == 0
-                                                     ? hw_read_period
-                                                     : time - component.get_last_read_time();
+            const rclcpp::Duration actual_period =
+              component.get_last_read_time().seconds() == 0
+                ? hw_read_period
+                : current_time - component.get_last_read_time();
             ret_val = component.read(time, actual_period);
           }
         }
@@ -1937,13 +1939,15 @@ HardwareReadWriteStatus ResourceManager::write(
         {
           const rclcpp::Duration hw_write_period = rclcpp::Duration::from_seconds(
             1.0 / resource_storage_->hardware_info_map_[component.get_name()].write_rate);
+          const auto current_time = resource_storage_->get_clock()->now();
           if (
             component.get_last_write_time().seconds() == 0 ||
-            (time - component.get_last_write_time()) >= hw_write_period)
+            (current_time - component.get_last_write_time()) >= hw_write_period)
           {
-            const rclcpp::Duration actual_period = component.get_last_write_time().seconds() == 0
-                                                     ? hw_write_period
-                                                     : time - component.get_last_read_time();
+            const rclcpp::Duration actual_period =
+              component.get_last_write_time().seconds() == 0
+                ? hw_write_period
+                : current_time - component.get_last_write_time();
             ret_val = component.write(time, actual_period);
           }
         }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -142,11 +142,7 @@ public:
         component_info.name = hardware_info.name;
         component_info.type = hardware_info.type;
         component_info.group = hardware_info.group;
-        component_info.read_rate =
-          (hardware_info.rw_rate == 0 || hardware_info.rw_rate > cm_update_rate_)
-            ? cm_update_rate_
-            : hardware_info.rw_rate;
-        component_info.write_rate =
+        component_info.rw_rate =
           (hardware_info.rw_rate == 0 || hardware_info.rw_rate > cm_update_rate_)
             ? cm_update_rate_
             : hardware_info.rw_rate;
@@ -1856,8 +1852,8 @@ HardwareReadWriteStatus ResourceManager::read(
       try
       {
         if (
-          resource_storage_->hardware_info_map_[component.get_name()].read_rate == 0 ||
-          resource_storage_->hardware_info_map_[component.get_name()].read_rate ==
+          resource_storage_->hardware_info_map_[component.get_name()].rw_rate == 0 ||
+          resource_storage_->hardware_info_map_[component.get_name()].rw_rate ==
             resource_storage_->cm_update_rate_)
         {
           ret_val = component.read(time, period);
@@ -1865,7 +1861,7 @@ HardwareReadWriteStatus ResourceManager::read(
         else
         {
           const double read_rate =
-            resource_storage_->hardware_info_map_[component.get_name()].read_rate;
+            resource_storage_->hardware_info_map_[component.get_name()].rw_rate;
           const auto current_time = resource_storage_->get_clock()->now();
           const rclcpp::Duration actual_period = current_time - component.get_last_read_time();
           if (actual_period.seconds() * read_rate >= 0.99)
@@ -1942,8 +1938,8 @@ HardwareReadWriteStatus ResourceManager::write(
       try
       {
         if (
-          resource_storage_->hardware_info_map_[component.get_name()].write_rate == 0 ||
-          resource_storage_->hardware_info_map_[component.get_name()].write_rate ==
+          resource_storage_->hardware_info_map_[component.get_name()].rw_rate == 0 ||
+          resource_storage_->hardware_info_map_[component.get_name()].rw_rate ==
             resource_storage_->cm_update_rate_)
         {
           ret_val = component.write(time, period);
@@ -1951,7 +1947,7 @@ HardwareReadWriteStatus ResourceManager::write(
         else
         {
           const double write_rate =
-            resource_storage_->hardware_info_map_[component.get_name()].write_rate;
+            resource_storage_->hardware_info_map_[component.get_name()].rw_rate;
           const auto current_time = resource_storage_->get_clock()->now();
           const rclcpp::Duration actual_period = current_time - component.get_last_write_time();
           if (actual_period.seconds() * write_rate >= 0.99)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -142,6 +142,8 @@ public:
         component_info.name = hardware_info.name;
         component_info.type = hardware_info.type;
         component_info.group = hardware_info.group;
+        component_info.read_rate = cm_update_rate_;
+        component_info.write_rate = cm_update_rate_;
         component_info.plugin_name = hardware_info.hardware_plugin_name;
         component_info.is_async = hardware_info.is_async;
 
@@ -1839,7 +1841,12 @@ HardwareReadWriteStatus ResourceManager::read(
       auto ret_val = return_type::OK;
       try
       {
-        ret_val = component.read(time, period);
+        if (
+          resource_storage_->hardware_info_map_[component.get_name()].read_rate ==
+          resource_storage_->cm_update_rate_)
+        {
+          ret_val = component.read(time, period);
+        }
         const auto component_group = component.get_group_name();
         ret_val =
           resource_storage_->update_hardware_component_group_state(component_group, ret_val);
@@ -1900,7 +1907,12 @@ HardwareReadWriteStatus ResourceManager::write(
       auto ret_val = return_type::OK;
       try
       {
-        ret_val = component.write(time, period);
+        if (
+          resource_storage_->hardware_info_map_[component.get_name()].write_rate ==
+          resource_storage_->cm_update_rate_)
+        {
+          ret_val = component.write(time, period);
+        }
         const auto component_group = component.get_group_name();
         ret_val =
           resource_storage_->update_hardware_component_group_state(component_group, ret_val);

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1858,15 +1858,10 @@ HardwareReadWriteStatus ResourceManager::read(
           const double read_rate =
             resource_storage_->hardware_info_map_[component.get_name()].read_rate;
           const auto current_time = resource_storage_->get_clock()->now();
-          if (
-            component.get_last_read_time().seconds() == 0 ||
-            (current_time - component.get_last_read_time()).seconds() * read_rate >= 0.99)
+          const rclcpp::Duration actual_period = current_time - component.get_last_read_time();
+          if (actual_period.seconds() * read_rate >= 0.99)
           {
-            const rclcpp::Duration actual_period =
-              component.get_last_read_time().seconds() == 0
-                ? rclcpp::Duration::from_seconds(1.0 / read_rate)
-                : current_time - component.get_last_read_time();
-            ret_val = component.read(time, actual_period);
+            ret_val = component.read(current_time, actual_period);
           }
         }
         const auto component_group = component.get_group_name();
@@ -1940,15 +1935,10 @@ HardwareReadWriteStatus ResourceManager::write(
           const double write_rate =
             resource_storage_->hardware_info_map_[component.get_name()].write_rate;
           const auto current_time = resource_storage_->get_clock()->now();
-          if (
-            component.get_last_write_time().seconds() == 0 ||
-            (current_time - component.get_last_write_time()).seconds() * write_rate >= 0.99)
+          const rclcpp::Duration actual_period = current_time - component.get_last_write_time();
+          if (actual_period.seconds() * write_rate >= 0.99)
           {
-            const rclcpp::Duration actual_period =
-              component.get_last_write_time().seconds() == 0
-                ? rclcpp::Duration::from_seconds(1.0 / write_rate)
-                : current_time - component.get_last_write_time();
-            ret_val = component.write(time, actual_period);
+            ret_val = component.write(current_time, actual_period);
           }
         }
         const auto component_group = component.get_group_name();

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -142,8 +142,14 @@ public:
         component_info.name = hardware_info.name;
         component_info.type = hardware_info.type;
         component_info.group = hardware_info.group;
-        component_info.read_rate = cm_update_rate_;
-        component_info.write_rate = cm_update_rate_;
+        component_info.read_rate =
+          (hardware_info.rw_rate == 0 || hardware_info.rw_rate > cm_update_rate_)
+            ? cm_update_rate_
+            : hardware_info.rw_rate;
+        component_info.write_rate =
+          (hardware_info.rw_rate == 0 || hardware_info.rw_rate > cm_update_rate_)
+            ? cm_update_rate_
+            : hardware_info.rw_rate;
         component_info.plugin_name = hardware_info.hardware_plugin_name;
         component_info.is_async = hardware_info.is_async;
 

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -240,6 +240,8 @@ const rclcpp_lifecycle::State & Sensor::get_lifecycle_state() const
   return impl_->get_lifecycle_state();
 }
 
+const rclcpp::Time & Sensor::get_last_read_time() const { return last_read_cycle_time_; }
+
 return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_, std::try_to_lock);
@@ -252,6 +254,7 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
+    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -264,6 +267,7 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
     {
       error();
     }
+    last_read_cycle_time_ = time;
   }
   return result;
 }

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -52,6 +52,7 @@ const rclcpp_lifecycle::State & Sensor::initialize(
     switch (impl_->init(sensor_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
+        last_read_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -254,7 +255,7 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
-    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
+    last_read_cycle_time_ = time;
     return return_type::OK;
   }
   return_type result = return_type::ERROR;

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -245,14 +245,6 @@ const rclcpp::Time & Sensor::get_last_read_time() const { return last_read_cycle
 
 return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  std::unique_lock<std::recursive_mutex> lock(sensors_mutex_, std::try_to_lock);
-  if (!lock.owns_lock())
-  {
-    RCLCPP_DEBUG(
-      impl_->get_logger(), "Skipping read() call for the sensor '%s' since it is locked",
-      impl_->get_name().c_str());
-    return return_type::OK;
-  }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
     last_read_cycle_time_ = time;
@@ -273,4 +265,5 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
   return result;
 }
 
+std::recursive_mutex & Sensor::get_mutex() { return sensors_mutex_; }
 }  // namespace hardware_interface

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -40,6 +40,7 @@ Sensor::Sensor(Sensor && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.sensors_mutex_);
   impl_ = std::move(other.impl_);
+  last_read_cycle_time_ = other.last_read_cycle_time_;
 }
 
 const rclcpp_lifecycle::State & Sensor::initialize(

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -280,6 +280,10 @@ const rclcpp_lifecycle::State & System::get_lifecycle_state() const
   return impl_->get_lifecycle_state();
 }
 
+const rclcpp::Time & System::get_last_read_time() const { return last_read_cycle_time_; }
+
+const rclcpp::Time & System::get_last_write_time() const { return last_write_cycle_time_; }
+
 return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_, std::try_to_lock);
@@ -292,6 +296,7 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
+    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -304,6 +309,7 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
     {
       error();
     }
+    last_read_cycle_time_ = time;
   }
   return result;
 }
@@ -320,6 +326,7 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
+    last_write_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -332,6 +339,7 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
     {
       error();
     }
+    last_write_cycle_time_ = time;
   }
   return result;
 }

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -39,6 +39,8 @@ System::System(System && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.system_mutex_);
   impl_ = std::move(other.impl_);
+  last_read_cycle_time_ = other.last_read_cycle_time_;
+  last_write_cycle_time_ = other.last_write_cycle_time_;
 }
 
 const rclcpp_lifecycle::State & System::initialize(

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -288,14 +288,6 @@ const rclcpp::Time & System::get_last_write_time() const { return last_write_cyc
 
 return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  std::unique_lock<std::recursive_mutex> lock(system_mutex_, std::try_to_lock);
-  if (!lock.owns_lock())
-  {
-    RCLCPP_DEBUG(
-      impl_->get_logger(), "Skipping read() call for system '%s' since it is locked",
-      impl_->get_name().c_str());
-    return return_type::OK;
-  }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
     last_read_cycle_time_ = time;
@@ -318,14 +310,6 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
 
 return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  std::unique_lock<std::recursive_mutex> lock(system_mutex_, std::try_to_lock);
-  if (!lock.owns_lock())
-  {
-    RCLCPP_DEBUG(
-      impl_->get_logger(), "Skipping write() call for system '%s' since it is locked",
-      impl_->get_name().c_str());
-    return return_type::OK;
-  }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
     last_write_cycle_time_ = time;
@@ -346,4 +330,5 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
   return result;
 }
 
+std::recursive_mutex & System::get_mutex() { return system_mutex_; }
 }  // namespace hardware_interface

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -51,6 +51,8 @@ const rclcpp_lifecycle::State & System::initialize(
     switch (impl_->init(system_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
+        last_read_cycle_time_ = clock_interface->get_clock()->now();
+        last_write_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -296,7 +298,7 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
-    last_read_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
+    last_read_cycle_time_ = time;
     return return_type::OK;
   }
   return_type result = return_type::ERROR;
@@ -326,7 +328,7 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
   }
   if (lifecycleStateThatRequiresNoAction(impl_->get_lifecycle_state().id()))
   {
-    last_write_cycle_time_ = rclcpp::Time(0, 0, time.get_clock_type());
+    last_write_cycle_time_ = time;
     return return_type::OK;
   }
   return_type result = return_type::ERROR;

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -783,8 +783,9 @@ TEST(TestComponentInterfaces, dummy_actuator_default)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_actuator = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_component");
-  auto state = actuator_hw.initialize(dummy_actuator, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    actuator_hw.initialize(dummy_actuator, node->get_logger(), node->get_node_clock_interface());
 
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
@@ -938,8 +939,9 @@ TEST(TestComponentInterfaces, dummy_sensor_default)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo voltage_sensor_res = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_sensor_component");
-  auto state = sensor_hw.initialize(voltage_sensor_res, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    sensor_hw.initialize(voltage_sensor_res, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1110,8 +1112,9 @@ TEST(TestComponentInterfaces, dummy_system_default)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_system = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_component");
-  auto state = system_hw.initialize(dummy_system, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(dummy_system, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1407,8 +1410,9 @@ TEST(TestComponentInterfaces, dummy_actuator_default_read_error_behavior)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_actuator = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_component");
-  auto state = actuator_hw.initialize(dummy_actuator, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    actuator_hw.initialize(dummy_actuator, node->get_logger(), node->get_node_clock_interface());
 
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
@@ -1541,8 +1545,9 @@ TEST(TestComponentInterfaces, dummy_actuator_default_write_error_behavior)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_actuator = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_component");
-  auto state = actuator_hw.initialize(dummy_actuator, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    actuator_hw.initialize(dummy_actuator, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1678,8 +1683,9 @@ TEST(TestComponentInterfaces, dummy_sensor_default_read_error_behavior)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo voltage_sensor_res = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_sensor_component");
-  auto state = sensor_hw.initialize(voltage_sensor_res, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    sensor_hw.initialize(voltage_sensor_res, node->get_logger(), node->get_node_clock_interface());
 
   auto state_interfaces = sensor_hw.export_state_interfaces();
   // Updated because is is INACTIVE
@@ -1806,8 +1812,9 @@ TEST(TestComponentInterfaces, dummy_system_default_read_error_behavior)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_system = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_component");
-  auto state = system_hw.initialize(dummy_system, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(dummy_system, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1945,8 +1952,9 @@ TEST(TestComponentInterfaces, dummy_system_default_write_error_behavior)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_system = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_component");
-  auto state = system_hw.initialize(dummy_system, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(dummy_system, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -33,6 +33,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
@@ -683,8 +684,9 @@ TEST(TestComponentInterfaces, dummy_actuator)
   hardware_interface::Actuator actuator_hw(std::make_unique<test_components::DummyActuator>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_components");
-  auto state = actuator_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_actuator_components");
+  auto state =
+    actuator_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -896,8 +898,9 @@ TEST(TestComponentInterfaces, dummy_sensor)
   hardware_interface::Sensor sensor_hw(std::make_unique<test_components::DummySensor>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_sensor_components");
-  auto state = sensor_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_sensor_components");
+  auto state =
+    sensor_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -974,8 +977,9 @@ TEST(TestComponentInterfaces, dummy_system)
   hardware_interface::System system_hw(std::make_unique<test_components::DummySystem>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_components");
-  auto state = system_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1300,8 +1304,9 @@ TEST(TestComponentInterfaces, dummy_command_mode_system)
   hardware_interface::System system_hw(
     std::make_unique<test_components::DummySystemPreparePerform>());
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_components");
-  auto state = system_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1333,8 +1338,9 @@ TEST(TestComponentInterfaces, dummy_actuator_read_error_behavior)
   hardware_interface::Actuator actuator_hw(std::make_unique<test_components::DummyActuator>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_components");
-  auto state = actuator_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_actuator_components");
+  auto state =
+    actuator_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1466,8 +1472,9 @@ TEST(TestComponentInterfaces, dummy_actuator_write_error_behavior)
   hardware_interface::Actuator actuator_hw(std::make_unique<test_components::DummyActuator>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_components");
-  auto state = actuator_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_actuator_components");
+  auto state =
+    actuator_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1598,8 +1605,9 @@ TEST(TestComponentInterfaces, dummy_sensor_read_error_behavior)
   hardware_interface::Sensor sensor_hw(std::make_unique<test_components::DummySensor>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_sensor_components");
-  auto state = sensor_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_sensor_components");
+  auto state =
+    sensor_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
 
   auto state_interfaces = sensor_hw.export_state_interfaces();
   // Updated because is is INACTIVE
@@ -1725,8 +1733,9 @@ TEST(TestComponentInterfaces, dummy_system_read_error_behavior)
   hardware_interface::System system_hw(std::make_unique<test_components::DummySystem>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_components");
-  auto state = system_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1863,8 +1872,9 @@ TEST(TestComponentInterfaces, dummy_system_write_error_behavior)
   hardware_interface::System system_hw(std::make_unique<test_components::DummySystem>());
 
   hardware_interface::HardwareInfo mock_hw_info{};
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_components");
-  auto state = system_hw.initialize(mock_hw_info, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_components");
+  auto state =
+    system_hw.initialize(mock_hw_info, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -1993,4 +2003,11 @@ TEST(TestComponentInterfaces, dummy_system_default_write_error_behavior)
   state = system_hw.configure();
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::FINALIZED, state.label());
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/hardware_interface/test/test_component_interfaces_custom_export.cpp
+++ b/hardware_interface/test/test_component_interfaces_custom_export.cpp
@@ -33,6 +33,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/node.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
@@ -169,8 +170,9 @@ TEST(TestComponentInterfaces, dummy_actuator_default_custom_export)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_actuator = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_actuator_component");
-  auto state = actuator_hw.initialize(dummy_actuator, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_actuator_component");
+  auto state =
+    actuator_hw.initialize(dummy_actuator, node->get_logger(), node->get_node_clock_interface());
 
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
@@ -234,8 +236,9 @@ TEST(TestComponentInterfaces, dummy_sensor_default_custom_export)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo voltage_sensor_res = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_sensor_component");
-  auto state = sensor_hw.initialize(voltage_sensor_res, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_sensor_component");
+  auto state =
+    sensor_hw.initialize(voltage_sensor_res, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -271,8 +274,9 @@ TEST(TestComponentInterfaces, dummy_system_default_custom_export)
   const std::vector<hardware_interface::HardwareInfo> control_resources =
     hardware_interface::parse_control_resources_from_urdf(urdf_to_test);
   const hardware_interface::HardwareInfo dummy_system = control_resources[0];
-  rclcpp::Logger logger = rclcpp::get_logger("test_system_component");
-  auto state = system_hw.initialize(dummy_system, logger, nullptr);
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("test_system_component");
+  auto state =
+    system_hw.initialize(dummy_system, node->get_logger(), node->get_node_clock_interface());
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::UNCONFIGURED, state.label());
 
@@ -372,4 +376,11 @@ TEST(TestComponentInterfaces, dummy_system_default_custom_export)
     EXPECT_EQ("some_unlisted_interface", command_interfaces[position]->get_interface_name());
     EXPECT_EQ("joint1", command_interfaces[position]->get_prefix_name());
   }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1443,6 +1443,36 @@ TEST_F(TestComponentParser, gripper_no_mimic_valid_config)
   EXPECT_EQ(hw_info[0].mimic_joints[0].joint_index, 1);
 }
 
+TEST_F(TestComponentParser, negative_rw_rates_throws_error)
+{
+  const auto urdf_to_test =
+    std::string(ros2_control_test_assets::gripper_urdf_head) +
+    std::string(ros2_control_test_assets::hardware_resources_with_negative_rw_rates) +
+    std::string(ros2_control_test_assets::urdf_tail);
+  std::vector<hardware_interface::HardwareInfo> hw_info;
+  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
+}
+
+TEST_F(TestComponentParser, invalid_rw_rates_throws_error)
+{
+  const auto urdf_to_test =
+    std::string(ros2_control_test_assets::gripper_urdf_head) +
+    std::string(ros2_control_test_assets::hardware_resources_invalid_with_text_in_rw_rates) +
+    std::string(ros2_control_test_assets::urdf_tail);
+  std::vector<hardware_interface::HardwareInfo> hw_info;
+  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
+}
+
+TEST_F(TestComponentParser, invalid_rw_rates_out_of_range)
+{
+  const auto urdf_to_test =
+    std::string(ros2_control_test_assets::gripper_urdf_head) +
+    std::string(ros2_control_test_assets::hardware_resources_invalid_out_of_range_in_rw_rates) +
+    std::string(ros2_control_test_assets::urdf_tail);
+  std::vector<hardware_interface::HardwareInfo> hw_info;
+  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
+}
+
 TEST_F(TestComponentParser, gripper_mimic_with_unknown_joint_throws_error)
 {
   const auto urdf_to_test =

--- a/hardware_interface_testing/test/test_components/test_system.cpp
+++ b/hardware_interface_testing/test/test_components/test_system.cpp
@@ -104,6 +104,12 @@ class TestSystem : public SystemInterface
     {
       return return_type::DEACTIVATE;
     }
+    // The next line is for the testing purposes. We need value to be changed to
+    // be sure that the feedback from hardware to controllers in the chain is
+    // working as it should. This makes value checks clearer and confirms there
+    // is no "state = command" line or some other mixture of interfaces
+    // somewhere in the test stack.
+    velocity_state_[0] = velocity_command_[0] / 2.0;
     return return_type::OK;
   }
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -444,7 +444,8 @@ TEST_F(ResourceManagerTest, default_prepare_perform_switch)
 
 TEST_F(ResourceManagerTest, resource_status)
 {
-  TestableResourceManager rm(node_, ros2_control_test_assets::minimal_robot_urdf);
+  TestableResourceManager rm(
+    node_, ros2_control_test_assets::minimal_robot_urdf_with_different_hw_rw_rate);
 
   auto status_map = rm.get_components_status();
 
@@ -456,6 +457,14 @@ TEST_F(ResourceManagerTest, resource_status)
   EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].type, TEST_ACTUATOR_HARDWARE_TYPE);
   EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].type, TEST_SENSOR_HARDWARE_TYPE);
   EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].type, TEST_SYSTEM_HARDWARE_TYPE);
+  // read_rate
+  EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].read_rate, 50u);
+  EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].read_rate, 20u);
+  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate, 100u);
+  // write_rate
+  EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].write_rate, 50u);
+  EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].write_rate, 20u);
+  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].write_rate, 100u);
   // plugin_name
   EXPECT_EQ(
     status_map[TEST_ACTUATOR_HARDWARE_NAME].plugin_name, TEST_ACTUATOR_HARDWARE_PLUGIN_NAME);

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -460,11 +460,11 @@ TEST_F(ResourceManagerTest, resource_status)
   // read_rate
   EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].read_rate, 50u);
   EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].read_rate, 20u);
-  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate, 100u);
+  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate, 25u);
   // write_rate
   EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].write_rate, 50u);
   EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].write_rate, 20u);
-  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].write_rate, 100u);
+  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].write_rate, 25u);
   // plugin_name
   EXPECT_EQ(
     status_map[TEST_ACTUATOR_HARDWARE_NAME].plugin_name, TEST_ACTUATOR_HARDWARE_PLUGIN_NAME);

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -457,14 +457,10 @@ TEST_F(ResourceManagerTest, resource_status)
   EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].type, TEST_ACTUATOR_HARDWARE_TYPE);
   EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].type, TEST_SENSOR_HARDWARE_TYPE);
   EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].type, TEST_SYSTEM_HARDWARE_TYPE);
-  // read_rate
-  EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].read_rate, 50u);
-  EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].read_rate, 20u);
-  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate, 25u);
-  // write_rate
-  EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].write_rate, 50u);
-  EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].write_rate, 20u);
-  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].write_rate, 25u);
+  // read/write_rate
+  EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].rw_rate, 50u);
+  EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].rw_rate, 20u);
+  EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].rw_rate, 25u);
   // plugin_name
   EXPECT_EQ(
     status_map[TEST_ACTUATOR_HARDWARE_NAME].plugin_name, TEST_ACTUATOR_HARDWARE_PLUGIN_NAME);
@@ -1765,17 +1761,13 @@ public:
       status_map[TEST_SENSOR_HARDWARE_NAME].state.id(),
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
-    // read_rate
-    EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].read_rate, 50u);
-    EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].read_rate, 20u);
-    EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate, 25u);
-    // write_rate
-    EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].write_rate, 50u);
-    EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].write_rate, 20u);
-    EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].write_rate, 25u);
+    // read/write_rate
+    EXPECT_EQ(status_map[TEST_ACTUATOR_HARDWARE_NAME].rw_rate, 50u);
+    EXPECT_EQ(status_map[TEST_SENSOR_HARDWARE_NAME].rw_rate, 20u);
+    EXPECT_EQ(status_map[TEST_SYSTEM_HARDWARE_NAME].rw_rate, 25u);
 
-    actuator_rw_rate_ = status_map[TEST_ACTUATOR_HARDWARE_NAME].read_rate;
-    system_rw_rate_ = status_map[TEST_SYSTEM_HARDWARE_NAME].read_rate;
+    actuator_rw_rate_ = status_map[TEST_ACTUATOR_HARDWARE_NAME].rw_rate;
+    system_rw_rate_ = status_map[TEST_SYSTEM_HARDWARE_NAME].rw_rate;
 
     claimed_itfs.push_back(
       rm->claim_command_interface(TEST_ACTUATOR_HARDWARE_COMMAND_INTERFACES[0]));

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1826,7 +1826,7 @@ public:
   using FunctionT =
     std::function<hardware_interface::HardwareReadWriteStatus(rclcpp::Time, rclcpp::Duration)>;
 
-  void check_read_and_write_cycles()
+  void check_read_and_write_cycles(bool test_for_changing_values)
   {
     double prev_act_state_value = state_itfs[0].get_value();
     double prev_system_state_value = state_itfs[1].get_value();
@@ -1836,13 +1836,13 @@ public:
       auto [ok, failed_hardware_names] = rm->read(time, duration);
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
-      if (i % (cm_update_rate_ / system_rw_rate_) == 0)
+      if (i % (cm_update_rate_ / system_rw_rate_) == 0 && test_for_changing_values)
       {
         // The values are computations exactly within the test_components
         prev_system_state_value = claimed_itfs[1].get_value() / 2.0;
         claimed_itfs[1].set_value(claimed_itfs[1].get_value() + 20.0);
       }
-      if (i % (cm_update_rate_ / actuator_rw_rate_) == 0)
+      if (i % (cm_update_rate_ / actuator_rw_rate_) == 0 && test_for_changing_values)
       {
         // The values are computations exactly within the test_components
         prev_act_state_value = claimed_itfs[0].get_value() / 2.0;
@@ -1877,7 +1877,7 @@ TEST_F(
 {
   setup_resource_manager_and_do_initial_checks();
 
-  check_read_and_write_cycles();
+  check_read_and_write_cycles(true);
 }
 
 TEST_F(
@@ -1905,7 +1905,7 @@ TEST_F(
     status_map[TEST_SENSOR_HARDWARE_NAME].state.id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
 
-  check_read_and_write_cycles();
+  check_read_and_write_cycles(true);
 }
 
 int main(int argc, char ** argv)

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1752,6 +1752,7 @@ public:
     activate_components(*rm);
 
     cm_update_rate_ = 100u;  // The default value inside
+    time = node_.get_clock()->now();
 
     auto status_map = rm->get_components_status();
     EXPECT_EQ(
@@ -1848,14 +1849,15 @@ public:
         prev_act_state_value = claimed_itfs[0].get_value() / 2.0;
         claimed_itfs[0].set_value(claimed_itfs[0].get_value() + 10.0);
       }
-      // Even though we skip some read and write iterations, the state interafces should be the same
+      // Even though we skip some read and write iterations, the state interfaces should be the same
       // as previous updated one until the next cycle
       ASSERT_EQ(state_itfs[0].get_value(), prev_act_state_value);
       ASSERT_EQ(state_itfs[1].get_value(), prev_system_state_value);
       auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
       EXPECT_TRUE(ok_write);
       EXPECT_TRUE(failed_hardware_names_write.empty());
-      time = time + duration;
+      node_.get_clock()->sleep_until(time + duration);
+      time = node_.get_clock()->now();
     }
   }
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1908,6 +1908,62 @@ TEST_F(
   check_read_and_write_cycles(true);
 }
 
+TEST_F(
+  ResourceManagerTestReadWriteDifferentReadWriteRate,
+  test_components_with_different_read_write_freq_on_unconfigured)
+{
+  setup_resource_manager_and_do_initial_checks();
+
+  // Now deactivate all the components and test the same as above
+  rclcpp_lifecycle::State state_unconfigured(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    hardware_interface::lifecycle_state_names::UNCONFIGURED);
+  rm->set_component_state(TEST_SYSTEM_HARDWARE_NAME, state_unconfigured);
+  rm->set_component_state(TEST_ACTUATOR_HARDWARE_NAME, state_unconfigured);
+  rm->set_component_state(TEST_SENSOR_HARDWARE_NAME, state_unconfigured);
+
+  auto status_map = rm->get_components_status();
+  EXPECT_EQ(
+    status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_EQ(
+    status_map[TEST_SYSTEM_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  EXPECT_EQ(
+    status_map[TEST_SENSOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+
+  check_read_and_write_cycles(false);
+}
+
+TEST_F(
+  ResourceManagerTestReadWriteDifferentReadWriteRate,
+  test_components_with_different_read_write_freq_on_finalized)
+{
+  setup_resource_manager_and_do_initial_checks();
+
+  // Now deactivate all the components and test the same as above
+  rclcpp_lifecycle::State state_finalized(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
+    hardware_interface::lifecycle_state_names::FINALIZED);
+  rm->set_component_state(TEST_SYSTEM_HARDWARE_NAME, state_finalized);
+  rm->set_component_state(TEST_ACTUATOR_HARDWARE_NAME, state_finalized);
+  rm->set_component_state(TEST_SENSOR_HARDWARE_NAME, state_finalized);
+
+  auto status_map = rm->get_components_status();
+  EXPECT_EQ(
+    status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+  EXPECT_EQ(
+    status_map[TEST_SYSTEM_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+  EXPECT_EQ(
+    status_map[TEST_SENSOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+
+  check_read_and_write_cycles(false);
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1880,6 +1880,34 @@ TEST_F(
   check_read_and_write_cycles();
 }
 
+TEST_F(
+  ResourceManagerTestReadWriteDifferentReadWriteRate,
+  test_components_with_different_read_write_freq_on_deactivate)
+{
+  setup_resource_manager_and_do_initial_checks();
+
+  // Now deactivate all the components and test the same as above
+  rclcpp_lifecycle::State state_inactive(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    hardware_interface::lifecycle_state_names::INACTIVE);
+  rm->set_component_state(TEST_SYSTEM_HARDWARE_NAME, state_inactive);
+  rm->set_component_state(TEST_ACTUATOR_HARDWARE_NAME, state_inactive);
+  rm->set_component_state(TEST_SENSOR_HARDWARE_NAME, state_inactive);
+
+  auto status_map = rm->get_components_status();
+  EXPECT_EQ(
+    status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(
+    status_map[TEST_SYSTEM_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_EQ(
+    status_map[TEST_SENSOR_HARDWARE_NAME].state.id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  check_read_and_write_cycles();
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -709,6 +709,55 @@ const auto async_hardware_resources =
   </ros2_control>
 )";
 
+const auto hardware_resources_with_different_rw_rates =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="50">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <command_interface name="max_velocity" />
+    </joint>
+  </ros2_control>
+  <ros2_control name="TestSensorHardware" type="sensor" rw_rate="20">
+    <hardware>
+      <plugin>test_sensor</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <sensor name="sensor1">
+      <state_interface name="velocity"/>
+    </sensor>
+  </ros2_control>
+  <ros2_control name="TestSystemHardware" type="system" rw_rate="200">
+    <hardware>
+      <plugin>test_system</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="acceleration"/>
+      <command_interface name="max_acceleration" />
+    </joint>
+    <joint name="joint3">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="acceleration"/>
+    </joint>
+    <gpio name="configuration">
+      <command_interface name="max_tcp_jerk"/>
+      <state_interface name="max_tcp_jerk"/>
+    </gpio>
+  </ros2_control>
+)";
+
 const auto uninitializable_hardware_resources =
   R"(
   <ros2_control name="TestUninitializableActuatorHardware" type="actuator">
@@ -1938,6 +1987,9 @@ const auto minimal_robot_urdf =
   std::string(urdf_head) + std::string(hardware_resources) + std::string(urdf_tail);
 const auto minimal_async_robot_urdf =
   std::string(urdf_head) + std::string(async_hardware_resources) + std::string(urdf_tail);
+const auto minimal_robot_urdf_with_different_hw_rw_rate =
+  std::string(urdf_head) + std::string(hardware_resources_with_different_rw_rates) +
+  std::string(urdf_tail);
 const auto minimal_uninitializable_robot_urdf =
   std::string(urdf_head) + std::string(uninitializable_hardware_resources) + std::string(urdf_tail);
 

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -732,7 +732,7 @@ const auto hardware_resources_with_different_rw_rates =
       <state_interface name="velocity"/>
     </sensor>
   </ros2_control>
-  <ros2_control name="TestSystemHardware" type="system" rw_rate="200">
+  <ros2_control name="TestSystemHardware" type="system" rw_rate="25">
     <hardware>
       <plugin>test_system</plugin>
       <param name="example_param_write_for_sec">2</param>

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -758,6 +758,51 @@ const auto hardware_resources_with_different_rw_rates =
   </ros2_control>
 )";
 
+const auto hardware_resources_with_negative_rw_rates =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="-50">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="right_finger_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <command_interface name="max_velocity" />
+    </joint>
+  </ros2_control>
+)";
+
+const auto hardware_resources_invalid_with_text_in_rw_rates =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="d 50">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="right_finger_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <command_interface name="max_velocity" />
+    </joint>
+  </ros2_control>
+)";
+
+const auto hardware_resources_invalid_out_of_range_in_rw_rates =
+  R"(
+  <ros2_control name="TestActuatorHardware" type="actuator" rw_rate="12345678901">
+    <hardware>
+      <plugin>test_actuator</plugin>
+    </hardware>
+    <joint name="right_finger_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <command_interface name="max_velocity" />
+    </joint>
+  </ros2_control>
+)";
+
 const auto uninitializable_hardware_resources =
   R"(
   <ros2_control name="TestUninitializableActuatorHardware" type="actuator">


### PR DESCRIPTION
Hello!

This PR helps to obtain different read and write update rates rather than having the same update rate as of the controller manager. With these changes, each and every component can run at their own chosen rate and they update the State and Command interfaces according to that rate. This is very useful for system with different communication layers such as EtherCAT, CAN and Serial. Hope this helps the community.

![image](https://github.com/user-attachments/assets/55b0f308-5083-47af-a658-a496a5cf6bb9)
y axis corresponds to the nanoseconds

Thank you 