### PR TITLE
Controller restart by switch_controller (minimal implementation)

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -72,6 +72,17 @@ if(BUILD_TESTING)
     DESTINATION lib
   )
 
+  add_library(test_controller_with_command SHARED
+    test/test_controller_with_command/test_controller_with_command.cpp)
+  target_link_libraries(test_controller_with_command PUBLIC controller_manager)
+  target_compile_definitions(test_controller_with_command PRIVATE "CONTROLLER_MANAGER_BUILDING_DLL")
+  pluginlib_export_plugin_description_file(
+    controller_interface test/test_controller_with_command/test_controller_with_command.xml)
+  install(
+    TARGETS test_controller_with_command
+    DESTINATION lib
+  )
+
   add_library(test_chainable_controller SHARED
     test/test_chainable_controller/test_chainable_controller.cpp
   )
@@ -120,6 +131,16 @@ if(BUILD_TESTING)
     controller_manager
     test_controller
     test_controller_failed_init
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+
+  ament_add_gmock(test_restart_controller
+    test/test_restart_controller.cpp
+    APPEND_ENV AMENT_PREFIX_PATH=${ament_index_build_path}_$<CONFIG>
+  )
+  target_link_libraries(test_restart_controller
+    controller_manager
+    test_controller_with_command
     ros2_control_test_assets::ros2_control_test_assets
   )
 

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -421,13 +421,13 @@ private:
    * \returns return_type::OK if all preceding controllers pass the checks, otherwise
    * return_type::ERROR.
    */
-  controller_interface::return_type check_preceeding_controllers_for_deactivate(
+  controller_interface::return_type check_preceding_controllers_for_deactivate(
     const std::vector<ControllerSpec> & controllers, int strictness,
     const ControllersListIterator controller_it);
 
   /**
    * Check if all deactivate requests are valid.
-   * Perform a detailed check internally by calling check_preceeding_controllers_for_deactivate.
+   * Perform a detailed check internally by calling check_preceding_controllers_for_deactivate.
    *
    * \param[in] controllers list with controllers.
    * \param[in] strictness if value is equal "MANIPULATE_CONTROLLERS_CHAIN" then all following

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -831,16 +831,21 @@ void ControllerManager::clear_requests()
 {
   deactivate_request_.clear();
   activate_request_.clear();
-  // Set these interfaces as unavailable when clearing requests to avoid leaving them in available
-  // state without the controller being in active state
+  clear_chained_mode_requests();
+  activate_command_interface_request_.clear();
+  deactivate_command_interface_request_.clear();
+}
+
+void ControllerManager::clear_chained_mode_requests()
+{
+  // Set these interfaces as unavailable when clearing requests to avoid leaving them in
+  // available state without the controller being in active state
   for (const auto & controller_name : to_chained_mode_request_)
   {
     resource_manager_->make_controller_reference_interfaces_unavailable(controller_name);
   }
   to_chained_mode_request_.clear();
   from_chained_mode_request_.clear();
-  activate_command_interface_request_.clear();
-  deactivate_command_interface_request_.clear();
 }
 
 controller_interface::return_type ControllerManager::switch_controller(
@@ -963,136 +968,25 @@ controller_interface::return_type ControllerManager::switch_controller(
 
   const std::vector<ControllerSpec> & controllers = rt_controllers_wrapper_.get_updated_list(guard);
 
-  enum class CreateRequestResult
-  {
-    OK,
-    ERROR,
-    RETRY
-  };
-
   const auto check_de_activate_request_and_create_chained_mode_request =
-    [this, &strictness, &controllers]() -> CreateRequestResult
+    [this, &strictness, &controllers]() -> CheckDeActivateRequestResult
   {
-    const auto clear_chained_mode_requests = [this]()
-    {
-      // Set these interfaces as unavailable when clearing requests to avoid leaving them in
-      // available state without the controller being in active state
-      for (const auto & controller_name : to_chained_mode_request_)
-      {
-        resource_manager_->make_controller_reference_interfaces_unavailable(controller_name);
-      }
-      to_chained_mode_request_.clear();
-      from_chained_mode_request_.clear();
-    };
-
     // if a preceding controller is deactivated, all first-level controllers should be switched
     // 'from' chained mode
     propagate_deactivation_of_chained_mode(controllers);
 
-    // check if controllers should be switched 'to' chained mode when controllers are activated
-    for (auto ctrl_it = activate_request_.begin(); ctrl_it != activate_request_.end(); ++ctrl_it)
+    if (const auto result = check_activate_requests(controllers, strictness);
+        result != CheckDeActivateRequestResult::OK)
     {
-      auto controller_it = std::find_if(
-        controllers.begin(), controllers.end(),
-        std::bind(controller_name_compare, std::placeholders::_1, *ctrl_it));
-      controller_interface::return_type status = controller_interface::return_type::OK;
-
-      // if controller is not inactive then do not do any following-controllers checks
-      if (!is_controller_inactive(controller_it->c))
-      {
-        RCLCPP_WARN(
-          get_logger(),
-          "Controller with name '%s' is not inactive so its following "
-          "controllers do not have to be checked, because it cannot be activated.",
-          controller_it->info.name.c_str());
-        status = controller_interface::return_type::ERROR;
-      }
-      else
-      {
-        status = check_following_controllers_for_activate(controllers, strictness, controller_it);
-      }
-
-      if (status != controller_interface::return_type::OK)
-      {
-        RCLCPP_WARN(
-          get_logger(),
-          "Could not activate controller with name '%s'. Check above warnings for more details. "
-          "Check the state of the controllers and their required interfaces using "
-          "`ros2 control list_controllers -v` CLI to get more information.",
-          (*ctrl_it).c_str());
-        if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
-        {
-          // TODO(destogl): automatic manipulation of the chain:
-          // || strictness ==
-          //  controller_manager_msgs::srv::SwitchController::Request::MANIPULATE_CONTROLLERS_CHAIN);
-          // remove controller that can not be activated from the activation request and step-back
-          // iterator to correctly step to the next element in the list in the loop
-          activate_request_.erase(ctrl_it);
-          // reset chained mode request lists and will retry the creation of the request
-          clear_chained_mode_requests();
-          return CreateRequestResult::RETRY;
-        }
-        if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
-        {
-          RCLCPP_ERROR(get_logger(), "Aborting, no controller is switched! (::STRICT switch)");
-          // reset all lists
-          clear_requests();
-          return CreateRequestResult::ERROR;
-        }
-      }
+      return result;
+    }
+    if (const auto result = check_deactivate_requests(controllers, strictness);
+        result != CheckDeActivateRequestResult::OK)
+    {
+      return result;
     }
 
-    // check if controllers should be deactivated if used in chained mode
-    for (auto ctrl_it = deactivate_request_.begin(); ctrl_it != deactivate_request_.end();
-         ++ctrl_it)
-    {
-      auto controller_it = std::find_if(
-        controllers.begin(), controllers.end(),
-        std::bind(controller_name_compare, std::placeholders::_1, *ctrl_it));
-      controller_interface::return_type status = controller_interface::return_type::OK;
-
-      // if controller is not active then skip preceding-controllers checks
-      if (!is_controller_active(controller_it->c))
-      {
-        RCLCPP_WARN(
-          get_logger(), "Controller with name '%s' can not be deactivated since it is not active.",
-          controller_it->info.name.c_str());
-        status = controller_interface::return_type::ERROR;
-      }
-      else
-      {
-        status =
-          check_preceeding_controllers_for_deactivate(controllers, strictness, controller_it);
-      }
-
-      if (status != controller_interface::return_type::OK)
-      {
-        RCLCPP_WARN(
-          get_logger(),
-          "Could not deactivate controller with name '%s'. Check above warnings for more details. "
-          "Check the state of the controllers and their required interfaces using "
-          "`ros2 control list_controllers -v` CLI to get more information.",
-          (*ctrl_it).c_str());
-        if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
-        {
-          // remove controller that can not be activated from the activation request and step-back
-          // iterator to correctly step to the next element in the list in the loop
-          deactivate_request_.erase(ctrl_it);
-          // reset chained mode request lists and will retry the creation of the request
-          clear_chained_mode_requests();
-          return CreateRequestResult::RETRY;
-        }
-        if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
-        {
-          RCLCPP_ERROR(get_logger(), "Aborting, no controller is switched! (::STRICT switch)");
-          // reset all lists
-          clear_requests();
-          return CreateRequestResult::ERROR;
-        }
-      }
-    }
-
-    return CreateRequestResult::OK;
+    return CheckDeActivateRequestResult::OK;
   };
 
   // Validate the (de)activate request and create from/to chained mode requests as needed.
@@ -1104,15 +998,15 @@ controller_interface::return_type ControllerManager::switch_controller(
   while (true)
   {
     const auto result = check_de_activate_request_and_create_chained_mode_request();
-    if (result == CreateRequestResult::RETRY)
+    if (result == CheckDeActivateRequestResult::RETRY)
     {
       continue;
     }
-    if (result == CreateRequestResult::ERROR)
+    if (result == CheckDeActivateRequestResult::ERROR)
     {
       return controller_interface::return_type::ERROR;
     }
-    // if result == CreateRequestResult::OK -> break the loop
+    // if result == CheckDeActivateRequestResult::OK -> break the loop
     break;
   }
 
@@ -2550,6 +2444,68 @@ controller_interface::return_type ControllerManager::check_following_controllers
   return controller_interface::return_type::OK;
 };
 
+ControllerManager::CheckDeActivateRequestResult ControllerManager::check_activate_requests(
+  const std::vector<ControllerSpec> & controllers, int strictness)
+{
+  // check if controllers should be switched 'to' chained mode when controllers are activated
+  for (auto ctrl_it = activate_request_.begin(); ctrl_it != activate_request_.end(); ++ctrl_it)
+  {
+    auto controller_it = std::find_if(
+      controllers.begin(), controllers.end(),
+      std::bind(controller_name_compare, std::placeholders::_1, *ctrl_it));
+    controller_interface::return_type status = controller_interface::return_type::OK;
+
+    // if controller is not inactive then do not do any following-controllers checks
+    if (
+      !is_controller_inactive(controller_it->c) &&
+      std::find(deactivate_request_.begin(), deactivate_request_.end(), *ctrl_it) ==
+        deactivate_request_.end())
+    {
+      RCLCPP_WARN(
+        get_logger(),
+        "Controller with name '%s' is not inactive so its following "
+        "controllers do not have to be checked, because it cannot be activated.",
+        controller_it->info.name.c_str());
+      status = controller_interface::return_type::ERROR;
+    }
+    else
+    {
+      status = check_following_controllers_for_activate(controllers, strictness, controller_it);
+    }
+
+    if (status != controller_interface::return_type::OK)
+    {
+      RCLCPP_WARN(
+        get_logger(),
+        "Could not activate controller with name '%s'. Check above warnings for more details. "
+        "Check the state of the controllers and their required interfaces using "
+        "`ros2 control list_controllers -v` CLI to get more information.",
+        (*ctrl_it).c_str());
+      if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
+      {
+        // TODO(destogl): automatic manipulation of the chain:
+        // || strictness ==
+        //  controller_manager_msgs::srv::SwitchController::Request::MANIPULATE_CONTROLLERS_CHAIN);
+        // remove controller that can not be activated from the activation request and step-back
+        // iterator to correctly step to the next element in the list in the loop
+        activate_request_.erase(ctrl_it);
+        // reset chained mode request lists and will retry the creation of the request
+        clear_chained_mode_requests();
+        return CheckDeActivateRequestResult::RETRY;
+      }
+      if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
+      {
+        RCLCPP_ERROR(get_logger(), "Aborting, no controller is switched! (::STRICT switch)");
+        // reset all lists
+        clear_requests();
+        return CheckDeActivateRequestResult::ERROR;
+      }
+    }
+  }
+
+  return CheckDeActivateRequestResult::OK;
+}
+
 controller_interface::return_type ControllerManager::check_preceeding_controllers_for_deactivate(
   const std::vector<ControllerSpec> & controllers, int /*strictness*/,
   const ControllersListIterator controller_it)
@@ -2634,6 +2590,60 @@ controller_interface::return_type ControllerManager::check_preceeding_controller
     }
   }
   return controller_interface::return_type::OK;
+}
+
+ControllerManager::CheckDeActivateRequestResult ControllerManager::check_deactivate_requests(
+  const std::vector<ControllerSpec> & controllers, int strictness)
+{
+  // check if controllers should be deactivated if used in chained mode
+  for (auto ctrl_it = deactivate_request_.begin(); ctrl_it != deactivate_request_.end(); ++ctrl_it)
+  {
+    auto controller_it = std::find_if(
+      controllers.begin(), controllers.end(),
+      std::bind(controller_name_compare, std::placeholders::_1, *ctrl_it));
+    controller_interface::return_type status = controller_interface::return_type::OK;
+
+    // if controller is not active then skip preceding-controllers checks
+    if (!is_controller_active(controller_it->c))
+    {
+      RCLCPP_WARN(
+        get_logger(), "Controller with name '%s' can not be deactivated since it is not active.",
+        controller_it->info.name.c_str());
+      status = controller_interface::return_type::ERROR;
+    }
+    else
+    {
+      status = check_preceeding_controllers_for_deactivate(controllers, strictness, controller_it);
+    }
+
+    if (status != controller_interface::return_type::OK)
+    {
+      RCLCPP_WARN(
+        get_logger(),
+        "Could not deactivate controller with name '%s'. Check above warnings for more details. "
+        "Check the state of the controllers and their required interfaces using "
+        "`ros2 control list_controllers -v` CLI to get more information.",
+        (*ctrl_it).c_str());
+      if (strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
+      {
+        // remove controller that can not be activated from the activation request and step-back
+        // iterator to correctly step to the next element in the list in the loop
+        deactivate_request_.erase(ctrl_it);
+        // reset chained mode request lists and will retry the creation of the request
+        clear_chained_mode_requests();
+        return CheckDeActivateRequestResult::RETRY;
+      }
+      if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
+      {
+        RCLCPP_ERROR(get_logger(), "Aborting, no controller is switched! (::STRICT switch)");
+        // reset all lists
+        clear_requests();
+        return CheckDeActivateRequestResult::ERROR;
+      }
+    }
+  }
+
+  return CheckDeActivateRequestResult::OK;
 }
 
 void ControllerManager::controller_activity_diagnostic_callback(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2458,7 +2458,7 @@ controller_interface::return_type ControllerManager::check_following_controllers
     }
   }
   return controller_interface::return_type::OK;
-};
+}
 
 ControllerManager::CheckDeActivateRequestResult ControllerManager::check_activate_requests(
   const std::vector<ControllerSpec> & controllers, int strictness)
@@ -2522,7 +2522,7 @@ ControllerManager::CheckDeActivateRequestResult ControllerManager::check_activat
   return CheckDeActivateRequestResult::OK;
 }
 
-controller_interface::return_type ControllerManager::check_preceeding_controllers_for_deactivate(
+controller_interface::return_type ControllerManager::check_preceding_controllers_for_deactivate(
   const std::vector<ControllerSpec> & controllers, int /*strictness*/,
   const ControllersListIterator controller_it)
 {
@@ -2648,7 +2648,7 @@ ControllerManager::CheckDeActivateRequestResult ControllerManager::check_deactiv
     }
     else
     {
-      status = check_preceeding_controllers_for_deactivate(controllers, strictness, controller_it);
+      status = check_preceding_controllers_for_deactivate(controllers, strictness, controller_it);
     }
 
     if (status != controller_interface::return_type::OK)

--- a/controller_manager/test/test_chainable_controller/test_chainable_controller.cpp
+++ b/controller_manager/test/test_chainable_controller/test_chainable_controller.cpp
@@ -134,12 +134,21 @@ CallbackReturn TestChainableController::on_configure(
 CallbackReturn TestChainableController::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  ++activate_calls;
+
   if (!is_in_chained_mode())
   {
     auto msg = rt_command_ptr_.readFromRT();
     (*msg)->data = reference_interfaces_;
   }
 
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn TestChainableController::on_deactivate(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  ++deactivate_calls;
   return CallbackReturn::SUCCESS;
 }
 

--- a/controller_manager/test/test_chainable_controller/test_chainable_controller.hpp
+++ b/controller_manager/test/test_chainable_controller/test_chainable_controller.hpp
@@ -58,6 +58,9 @@ public:
   CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
@@ -80,7 +83,12 @@ public:
   CONTROLLER_MANAGER_PUBLIC
   void set_reference_interface_names(const std::vector<std::string> & reference_interface_names);
 
-  size_t internal_counter;
+  size_t internal_counter = 0;
+
+  // Variable where we store when activate or deactivate was called
+  size_t activate_calls = 0;
+  size_t deactivate_calls = 0;
+
   controller_interface::InterfaceConfiguration cmd_iface_cfg_;
   controller_interface::InterfaceConfiguration state_iface_cfg_;
   std::vector<std::string> reference_interface_names_;

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -101,6 +101,18 @@ CallbackReturn TestController::on_configure(const rclcpp_lifecycle::State & /*pr
   return CallbackReturn::SUCCESS;
 }
 
+CallbackReturn TestController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  ++activate_calls;
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn TestController::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  ++deactivate_calls;
+  return CallbackReturn::SUCCESS;
+}
+
 CallbackReturn TestController::on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   if (simulate_cleanup_failure)

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -57,6 +57,12 @@ public:
   CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
 
   CONTROLLER_MANAGER_PUBLIC
@@ -69,6 +75,11 @@ public:
   const std::string & getRobotDescription() const;
 
   unsigned int internal_counter = 0;
+
+  // Variable where we store when activate or deactivate was called
+  size_t activate_calls = 0;
+  size_t deactivate_calls = 0;
+
   bool simulate_cleanup_failure = false;
   // Variable where we store when cleanup was called, pointer because the controller
   // is usually destroyed after cleanup

--- a/controller_manager/test/test_controller_with_command/test_controller_with_command.cpp
+++ b/controller_manager/test/test_controller_with_command/test_controller_with_command.cpp
@@ -1,0 +1,74 @@
+// Copyright 2024 Tokyo Robotics Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_controller_with_command.hpp"
+
+#include <memory>
+#include <string>
+
+#include "lifecycle_msgs/msg/transition.hpp"
+
+namespace test_controller_with_command
+{
+TestControllerWithCommand::TestControllerWithCommand() : controller_interface::ControllerInterface()
+{
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestControllerWithCommand::on_init()
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type TestControllerWithCommand::update(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  return controller_interface::return_type::OK;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestControllerWithCommand::on_configure(const rclcpp_lifecycle::State & /*previous_state&*/)
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestControllerWithCommand::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  simulate_command = SIMULATE_COMMAND_ACTIVATE_VALUE;
+  ++activate_calls;
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestControllerWithCommand::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  simulate_command = SIMULATE_COMMAND_DEACTIVATE_VALUE;
+  ++deactivate_calls;
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+TestControllerWithCommand::on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+}  // namespace test_controller_with_command
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  test_controller_with_command::TestControllerWithCommand,
+  controller_interface::ControllerInterface)

--- a/controller_manager/test/test_controller_with_command/test_controller_with_command.hpp
+++ b/controller_manager/test/test_controller_with_command/test_controller_with_command.hpp
@@ -1,0 +1,85 @@
+// Copyright 2024 Tokyo Robotics Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEST_CONTROLLER_WITH_COMMAND__TEST_CONTROLLER_WITH_COMMAND_HPP_
+#define TEST_CONTROLLER_WITH_COMMAND__TEST_CONTROLLER_WITH_COMMAND_HPP_
+
+#include <limits>
+
+#include "controller_interface/visibility_control.h"
+#include "controller_manager/controller_manager.hpp"
+
+namespace test_controller_with_command
+{
+// Corresponds to the name listed within the pluginlib xml
+constexpr char TEST_CONTROLLER_CLASS_NAME[] = "controller_manager/test_controller_with_command";
+// Corresponds to the command interface to claim
+constexpr char TEST_CONTROLLER_COMMAND_INTERFACE[] = "joint/position";
+
+constexpr double SIMULATE_COMMAND_DEACTIVATE_VALUE = 25252525.0;
+constexpr double SIMULATE_COMMAND_ACTIVATE_VALUE = 27272727.0;
+
+class TestControllerWithCommand : public controller_interface::ControllerInterface
+{
+public:
+  CONTROLLER_MANAGER_PUBLIC
+  TestControllerWithCommand();
+
+  CONTROLLER_MANAGER_PUBLIC
+  virtual ~TestControllerWithCommand() = default;
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override
+  {
+    return controller_interface::InterfaceConfiguration{
+      controller_interface::interface_configuration_type::NONE};
+  }
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override
+  {
+    return controller_interface::InterfaceConfiguration{
+      controller_interface::interface_configuration_type::NONE};
+  }
+
+  CONTROLLER_MANAGER_PUBLIC
+  controller_interface::return_type update(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init() override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  CONTROLLER_MANAGER_PUBLIC
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State & previous_state) override;
+
+  // Variable where we store when activate or deactivate was called
+  size_t activate_calls = 0;
+  size_t deactivate_calls = 0;
+
+  // Simulate command value for test
+  double simulate_command = std::numeric_limits<double>::quiet_NaN();
+};
+
+}  // namespace test_controller_with_command
+
+#endif  // TEST_CONTROLLER_WITH_COMMAND__TEST_CONTROLLER_WITH_COMMAND_HPP_

--- a/controller_manager/test/test_controller_with_command/test_controller_with_command.xml
+++ b/controller_manager/test/test_controller_with_command/test_controller_with_command.xml
@@ -1,0 +1,9 @@
+<library path="test_controller_with_command">
+
+  <class name="controller_manager/test_controller_with_command" type="test_controller_with_command::TestControllerWithCommand" base_class_type="controller_interface::ControllerInterface">
+    <description>
+      Controller used for testing
+    </description>
+  </class>
+
+</library>

--- a/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
+++ b/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define TEST_BUG1
-#define TEST_BUG2
-#define TEST_BUG3
-
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
@@ -786,15 +782,10 @@ TEST_P(
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, diff_drive_controller->get_state().id());
 
-  // !---- <BUG1> ----
-#ifdef TEST_BUG1
   // Check if the controllers are not in chained mode
-  ASSERT_FALSE(pid_left_wheel_controller
-                 ->is_in_chained_mode());  // !BUG: should be not in chained mode but is in
+  ASSERT_FALSE(pid_left_wheel_controller->is_in_chained_mode());
   ASSERT_FALSE(pid_right_wheel_controller->is_in_chained_mode());
   ASSERT_FALSE(diff_drive_controller->is_in_chained_mode());
-#endif
-  // !---- </BUG1> ----
 }
 
 TEST_P(
@@ -832,8 +823,6 @@ TEST_P(
   EXPECT_FALSE(pid_right_wheel_controller->is_in_chained_mode());
   ASSERT_FALSE(diff_drive_controller->is_in_chained_mode());
 
-  // !---- <BUG2> ----
-#ifdef TEST_BUG2
   // Test Case: Trying to activate a preceding controller and one of the following controller
   // --> return error; preceding controller are not activated,
   // BUT following controller IS activated
@@ -866,12 +855,9 @@ TEST_P(
     position_tracking_controller->get_state().id());
 
   // Check if the controllers are not in chained mode
-  ASSERT_FALSE(pid_left_wheel_controller
-                 ->is_in_chained_mode());  // !BUG: should be not in chained mode but is in
+  ASSERT_FALSE(pid_left_wheel_controller->is_in_chained_mode());
   ASSERT_FALSE(pid_right_wheel_controller->is_in_chained_mode());
   ASSERT_FALSE(diff_drive_controller->is_in_chained_mode());
-#endif
-  // !---- </BUG2> ----
 }
 
 TEST_P(
@@ -1075,8 +1061,6 @@ TEST_P(
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, diff_drive_controller->get_state().id());
 
-  // !---- <BUG3> ----
-#ifdef TEST_BUG3
   // Test Case: middle preceding/following controller deactivation but the most preceding and the
   // lowest following controllers are active
   // --> return error; controllers stay in the same state as they were
@@ -1100,10 +1084,7 @@ TEST_P(
   // Attempt to deactivate the middle preceding/following controller
   switch_test_controllers(
     {}, {DIFF_DRIVE_CONTROLLER}, test_param.strictness, std::future_status::ready,
-    expected.at(test_param.strictness)
-      .return_type);  // !BUG: If BEST_EFFORT, all controllers should stay the same state as they
-                      // were, but a deadlock may occur during the switch_controller process,
-                      // causing the test to timeout.
+    expected.at(test_param.strictness).return_type);
 
   // All controllers should still be active
   ASSERT_EQ(
@@ -1115,8 +1096,6 @@ TEST_P(
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
     position_tracking_controller->get_state().id());
-#endif
-  // !---- </BUG3> ----
 }
 
 TEST_P(TestControllerChainingWithControllerManager, test_chained_controllers_adding_in_random_order)

--- a/controller_manager/test/test_restart_controller.cpp
+++ b/controller_manager/test/test_restart_controller.cpp
@@ -1,0 +1,274 @@
+// Copyright 2024 Tokyo Robotics Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "controller_interface/controller_interface.hpp"
+#include "controller_manager/controller_manager.hpp"
+#include "controller_manager_test_common.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "test_controller_with_command/test_controller_with_command.hpp"
+
+using test_controller_with_command::SIMULATE_COMMAND_ACTIVATE_VALUE;
+using test_controller_with_command::SIMULATE_COMMAND_DEACTIVATE_VALUE;
+using test_controller_with_command::TEST_CONTROLLER_CLASS_NAME;
+using test_controller_with_command::TestControllerWithCommand;
+const auto CONTROLLER_NAME = "test_controller1";
+using strvec = std::vector<std::string>;
+
+namespace
+{
+struct TestRestControllerStrictness
+{
+  int strictness = STRICT;
+  std::future_status expected_future_status;
+  controller_interface::return_type expected_return;
+};
+TestRestControllerStrictness test_strict{
+  STRICT, std::future_status::ready, controller_interface::return_type::ERROR};
+TestRestControllerStrictness test_best_effort{
+  BEST_EFFORT, std::future_status::timeout, controller_interface::return_type::OK};
+}  // namespace
+
+class TestRestartController
+: public ControllerManagerFixture<controller_manager::ControllerManager>,
+  public testing::WithParamInterface<TestRestControllerStrictness>
+{
+public:
+  void SetUp() override
+  {
+    SetupController();
+    run_updater_ = false;
+  }
+
+  void SetupController()
+  {
+    // load controller
+    test_controller = std::make_shared<TestControllerWithCommand>();
+    cm_->add_controller(test_controller, CONTROLLER_NAME, TEST_CONTROLLER_CLASS_NAME);
+
+    EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
+    EXPECT_EQ(2u, test_controller.use_count());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, test_controller->get_state().id());
+  }
+
+  void configure_and_check_test_controller()
+  {
+    // configure controller
+    cm_->configure_controller(CONTROLLER_NAME);
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_state().id());
+
+    // validate initial states
+    EXPECT_EQ(0u, test_controller->activate_calls);
+    EXPECT_EQ(0u, test_controller->deactivate_calls);
+    EXPECT_TRUE(std::isnan(test_controller->simulate_command));
+  }
+
+  void start_test_controller(
+    const int strictness,
+    const std::future_status expected_future_status = std::future_status::timeout,
+    const controller_interface::return_type expected_interface_status =
+      controller_interface::return_type::OK)
+  {
+    switch_test_controllers(
+      strvec{CONTROLLER_NAME}, strvec{}, strictness, expected_future_status,
+      expected_interface_status);
+  }
+
+  void start_and_check_test_controller(
+    const int strictness,
+    const std::future_status expected_future_status = std::future_status::timeout,
+    const controller_interface::return_type expected_interface_status =
+      controller_interface::return_type::OK)
+  {
+    // Start controller
+    start_test_controller(strictness, expected_future_status, expected_interface_status);
+
+    // State should be active
+    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_state().id());
+
+    // Only activate counter should be incremented
+    ASSERT_EQ(1u, test_controller->activate_calls);
+    ASSERT_EQ(0u, test_controller->deactivate_calls);
+
+    // Controller command should be restart to ACTIVATE_VALUE
+    ASSERT_EQ(SIMULATE_COMMAND_ACTIVATE_VALUE, test_controller->simulate_command);
+  }
+
+  void stop_test_controller(
+    const int strictness,
+    const std::future_status expected_future_status = std::future_status::timeout,
+    const controller_interface::return_type expected_interface_status =
+      controller_interface::return_type::OK)
+  {
+    switch_test_controllers(
+      strvec{}, strvec{CONTROLLER_NAME}, strictness, expected_future_status,
+      expected_interface_status);
+  }
+
+  void restart_test_controller(
+    const int strictness,
+    const std::future_status expected_future_status = std::future_status::timeout,
+    const controller_interface::return_type expected_interface_status =
+      controller_interface::return_type::OK)
+  {
+    switch_test_controllers(
+      strvec{CONTROLLER_NAME}, strvec{CONTROLLER_NAME}, strictness, expected_future_status,
+      expected_interface_status);
+  }
+
+  std::shared_ptr<TestControllerWithCommand> test_controller;
+};
+
+TEST_P(TestRestartController, starting_and_stopping_a_controller)
+{
+  const auto test_param = GetParam();
+
+  // Configure controller
+  configure_and_check_test_controller();
+
+  {
+    // Start controller
+    start_and_check_test_controller(test_param.strictness);
+  }
+
+  {
+    // Stop controller
+    stop_test_controller(test_param.strictness);
+
+    // State should be inactive
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_state().id());
+
+    // Only deactivate counter should be incremented
+    ASSERT_EQ(1u, test_controller->activate_calls);
+    ASSERT_EQ(1u, test_controller->deactivate_calls);
+
+    // Controller command should be restart to DEACTIVATE_VALUE
+    ASSERT_EQ(SIMULATE_COMMAND_DEACTIVATE_VALUE, test_controller->simulate_command);
+  }
+}
+
+TEST_P(TestRestartController, can_restart_active_controller)
+{
+  const auto test_param = GetParam();
+
+  // Configure controller
+  configure_and_check_test_controller();
+
+  {
+    // Start controller before restart
+    start_and_check_test_controller(test_param.strictness);
+    const double OVERRIDE_COMMAND_VALUE = 12121212.0;
+
+    // Override command to check restart behavior
+    test_controller->simulate_command = OVERRIDE_COMMAND_VALUE;
+    ASSERT_EQ(OVERRIDE_COMMAND_VALUE, test_controller->simulate_command);
+  }
+
+  {
+    // Restart controller
+    restart_test_controller(test_param.strictness);
+
+    // State should be return active immediately (active -> inactive -> active)
+    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_state().id());
+
+    // Both activate counter and deactivate counter are incremented
+    ASSERT_EQ(2u, test_controller->activate_calls);
+    ASSERT_EQ(1u, test_controller->deactivate_calls);
+
+    // Controller command should be restart to ACTIVATE_VALUE
+    ASSERT_EQ(SIMULATE_COMMAND_ACTIVATE_VALUE, test_controller->simulate_command);
+  }
+}
+
+TEST_P(TestRestartController, restart_inactive_controller)
+{
+  const auto test_param = GetParam();
+
+  // Configure controller
+  configure_and_check_test_controller();
+
+  // Restart controller without starting it
+  restart_test_controller(
+    test_param.strictness, test_param.expected_future_status, test_param.expected_return);
+
+  // STRICT: can not restart inactive controller
+  if (test_param.strictness == STRICT)
+  {
+    // State should not be changed
+    ASSERT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, test_controller->get_state().id());
+
+    // Both activate counter and deactivate counter should not be incremented
+    ASSERT_EQ(0u, test_controller->activate_calls);
+    ASSERT_EQ(0u, test_controller->deactivate_calls);
+  }
+
+  // BEST_EFFORT: If restart is executed while inactive, only the start_controller process will be
+  // effective, resulting in activation
+  if (test_param.strictness == BEST_EFFORT)
+  {
+    // State changed to active
+    ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, test_controller->get_state().id());
+
+    // Only activate counter and deactivate counter should not be incremented
+    ASSERT_EQ(1u, test_controller->activate_calls);
+    ASSERT_EQ(0u, test_controller->deactivate_calls);
+
+    // Controller command should be restart to ACTIVATE_VALUE
+    ASSERT_EQ(SIMULATE_COMMAND_ACTIVATE_VALUE, test_controller->simulate_command);
+  }
+}
+
+TEST_P(TestRestartController, can_not_restart_unconfigured_controller)
+{
+  const auto test_param = GetParam();
+
+  ASSERT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, test_controller->get_state().id());
+
+  // Can not restart unconfigured controller
+  restart_test_controller(
+    test_param.strictness, std::future_status::ready, test_param.expected_return);
+  ASSERT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, test_controller->get_state().id());
+}
+
+TEST_P(TestRestartController, can_not_restart_finalized_controller)
+{
+  const auto test_param = GetParam();
+
+  ASSERT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, test_controller->get_state().id());
+
+  // Shutdown controller on purpose for testing
+  ASSERT_EQ(
+    test_controller->get_node()->shutdown().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED);
+
+  // Can not restart finalized controller
+  restart_test_controller(
+    test_param.strictness, std::future_status::ready, test_param.expected_return);
+  ASSERT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, test_controller->get_state().id());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  test_strict_best_effort, TestRestartController, testing::Values(test_strict, test_best_effort));


### PR DESCRIPTION
This PR is related to #1568. Unlike it, this focuses on implementing the new restart controllers feature while minimizing changes to the master branch code. Additionally, this PR depends on #1591 and is expected to be merged after #1591 is merged.

Note: To focus on meaningful changes, it is recommended to compare the code using "hide whitespace" mode as follows.
https://github.com/ros-controls/ros2_control/compare/master...TakashiSato:ros2_control:feature/restart_controllers_minimal?diff=split&w=1

## Explanation code changes

Since comparing the final code changes with the master branch is complicated due to the large number of changes, I'll explain the key points of each change in the order of the commits.
The changes up to commit number 005a79fb7b961d3237e1b02b3edf0521ed866b61 are included in #1591, so I will only address the commits after that.

### 1. [refactor (de)activate request check](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65)[refactor (de)activate request check](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1)

In this commit, the following refactoring was performed:

- Renamed enum class `CreateRequestResult` to `CheckDeActivateRequestResult` and moved its definition [from](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094L966-L971) inside switch_controller [to](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-237968934b97816aa76493de4b5ef99282030b9951c89814438a2ad113fc5be5R332-R338) within the class definition in the header (private).
- Moved the implementation of `clear_chained_mode_request` [from](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094L978-L986) inside switch_controller [to](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R839-R849) a member function, and changed the part of clear_requests that performed the same processing to [this function call](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R834).
-  Moved the implementation of the check processing related to (de)activation from inside switch_controller to a member function.
    - check_activate: [from](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094L992-L1043) , [to](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R2447-R2507)
    - check_deactivate: [from](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094L1045-L1093), [to](https://github.com/ros-controls/ros2_control/commit/0115236067628a8d5e02d33b7e07fdce50db5d65?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R2595-R2647)
 
### 2. [add to support restart operations in switch_controller by specifying the same controller name in the start/stop requests](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094)

This commit implements the restart controllers feature and its tests.

To achieve the behavior of restart (deactivating first and then activating), I mainly made changes in the followings:
- [Swapped the order of checking `deactivate_request` and `activate_request`](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R978-R985) to ensure requests for restart (deactivate first, then activate) are not rejected as invalid requests.
- Similarly, changed the handling of `chained_mode_request` during `manage_switch` to process them in [the order of from and to](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R978-R985).
- To ensure that `reference_interfaces` can be used appropriately when the following controller is activated immediately after being deactivated, modified the `deactivate_controllers` function [not to execute `make_controller_reference_interfaces_unavailable` during restart requests](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R1367-R1379).
- Adjusted the validation process ([1](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R2380-R2401) ,  [2](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-51a3ffe225a0370e8b9026ea1cb8f0cf34fd5bf6547a239ce8418f445e22a094R2570-R2616)),  to avoid rejecting restart requests as invalid.

I made the following changes to the test implementation:
- Changed the test controller to record the number of times on_(de)activate is called for the purpose of verifying the restart behavior.
    - [`test_controller`](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-ee6ed15ea54a650b787244dc4372f1157c224b3671df59ea2910fecad20d61fcR80-R81)
    - [`test_chainable_controller`](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-8806f56532dea2d411a0d87fa42b1be104b8a925166f565b2dd3e9caa74b1b64R89-R90)
- Added the [TestControllerWithCommand class](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-9ee7fdca1776fd8967f0ea8d4eddc82e006539fbee5151afe24f4288b5c0f8a6R33-R81) to test that the reset of commands is correctly performed by the restart.
- Added tests to verify the basic behavior of restarting controllers ([test_restart_controllers.cpp](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-086b0fd14fb4e8cfaadb71604c3d7d010902238a41b15319f054fb50c6a2ec4e)).
- Added tests to cover restarting scenarios with controller chaining ([test_controllers_chaining_with_controller_manager.cpp](https://github.com/ros-controls/ros2_control/commit/6b447b220dd1f491f1fa13cb27e787635635268d?diff=split&w=1#diff-2c85084f6af6a160acc7921875f56ed318fe22768d092eff7edea636e0a92691))

### [fix typo and unnecessary semicolon](https://github.com/ros-controls/ros2_control/commit/4dbe5845a80d3c45e0cf9ef0c7f8c64881a10b07)

This commit contains minor fixes.

