### PR TITLE
Change the spamming checking interface ERROR to DEBUG

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2434,7 +2434,7 @@ controller_interface::return_type ControllerManager::check_following_controllers
     controller_state_interfaces.end());
   for (const auto & ctrl_itf_name : controller_interfaces)
   {
-    RCLCPP_ERROR(
+    RCLCPP_DEBUG(
       get_logger(), "Checking interface '%s' of controller '%s'.", ctrl_itf_name.c_str(),
       controller_it->info.name.c_str());
     ControllersListIterator following_ctrl_it;


### PR DESCRIPTION
@christophfroehlich pointed out that there is a spamming error of "Checking interface" while starting the controllers, this was not meant to be ERROR log, rather it must be a DEBUG log, it was introduced accidentally with #1021 changes.

Thank you for pointing it out @christophfroehlich 