### PR TITLE
[ControllerInterface] Move critical variables to the private context

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -258,12 +258,12 @@ public:
 protected:
   std::vector<hardware_interface::LoanedCommandInterface> command_interfaces_;
   std::vector<hardware_interface::LoanedStateInterface> state_interfaces_;
-  unsigned int update_rate_ = 0;
-  bool is_async_ = false;
-  std::string urdf_ = "";
 
 private:
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
+  unsigned int update_rate_ = 0;
+  bool is_async_ = false;
+  std::string urdf_ = "";
 };
 
 using ControllerInterfaceBaseSharedPtr = std::shared_ptr<ControllerInterfaceBase>;


### PR DESCRIPTION
I think we should move these critical variables to the private context to avoid the overidding classes to be able to modify them. Some of these parameters might affect the CM

We could already access the data of these variables through the provided methods

https://github.com/ros-controls/ros2_control/blob/9d1aff96291302c6db153f863792350e352f66a9/controller_interface/src/controller_interface_base.cpp#L133-L137