### PR TITLE
add missing rclcpp logging include for Humble compatibility build

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -35,6 +35,7 @@
 #include "hardware_interface/system_interface.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "pluginlib/class_loader.hpp"
+#include "rclcpp/logging.hpp"
 #include "rcutils/logging_macros.h"
 
 namespace hardware_interface


### PR DESCRIPTION
Fixes failing "Rolling Compatibility on Humble" due to a missing include  

Fixes: https://github.com/ros-controls/ros2_control_ci/issues/104