### PR TITLE
[RM] Add `get_hardware_info` method to the Hardware Components

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,8 +21,7 @@ For details see the controller_manager section.
 * Pass controller manager update rate on the init of the controller interface  (`#1141 <https://github.com/ros-controls/ros2_control/pull/1141>`_)
 * A method to get node options to setup the controller node #api-breaking (`#1169 <https://github.com/ros-controls/ros2_control/pull/1169>`_)
 * Export state interfaces from the chainable controller #api-breaking (`#1021 <https://github.com/ros-controls/ros2_control/pull/1021>`_)
-
-  * All chainable controllers must implement the method ``export_state_interfaces`` to export the state interfaces, similar to ``export_reference_interfaces`` method that is exporting the reference interfaces.
+* All chainable controllers must implement the method ``export_state_interfaces`` to export the state interfaces, similar to ``export_reference_interfaces`` method that is exporting the reference interfaces.
 
 controller_manager
 ******************
@@ -99,6 +98,7 @@ hardware_interface
 
 * Soft limits are also parsed from the URDF into the ``HardwareInfo`` structure for the defined joints (`#1488 <https://github.com/ros-controls/ros2_control/pull/1488>`_)
 * Access to logger and clock through ``get_logger`` and ``get_clock`` methods in ResourceManager and HardwareComponents ``Actuator``, ``Sensor`` and ``System`` (`#1585 <https://github.com/ros-controls/ros2_control/pull/1585>`_)
+* Added ``get_hardware_info`` method to the hardware components interface to access the ``HardwareInfo`` instead of accessing the variable ``info_`` directly (`#1643 <https://github.com/ros-controls/ros2_control/pull/1643>`_)
 
 joint_limits
 ************

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -241,6 +241,12 @@ protected:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return clock_interface_->get_clock(); }
 
+  /// Get the hardware info of the ActuatorInterface.
+  /**
+   * \return hardware info of the ActuatorInterface.
+   */
+  const HardwareInfo & get_hardware_info() const { return info_; }
+
   HardwareInfo info_;
   rclcpp_lifecycle::State lifecycle_state_;
 

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -180,6 +180,12 @@ protected:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return clock_interface_->get_clock(); }
 
+  /// Get the hardware info of the SensorInterface.
+  /**
+   * \return hardware info of the SensorInterface.
+   */
+  const HardwareInfo & get_hardware_info() const { return info_; }
+
   HardwareInfo info_;
   rclcpp_lifecycle::State lifecycle_state_;
 

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -242,6 +242,12 @@ protected:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return clock_interface_->get_clock(); }
 
+  /// Get the hardware info of the SystemInterface.
+  /**
+   * \return hardware info of the SystemInterface.
+   */
+  const HardwareInfo & get_hardware_info() const { return info_; }
+
   HardwareInfo info_;
   rclcpp_lifecycle::State lifecycle_state_;
 

--- a/hardware_interface/test/test_hardware_components/test_force_torque_sensor.cpp
+++ b/hardware_interface/test/test_hardware_components/test_force_torque_sensor.cpp
@@ -33,7 +33,7 @@ class TestForceTorqueSensor : public SensorInterface
       return CallbackReturn::ERROR;
     }
 
-    const auto & state_interfaces = info_.sensors[0].state_interfaces;
+    const auto & state_interfaces = get_hardware_info().sensors[0].state_interfaces;
     if (state_interfaces.size() != 6)
     {
       return CallbackReturn::ERROR;
@@ -57,7 +57,7 @@ class TestForceTorqueSensor : public SensorInterface
   {
     std::vector<StateInterface> state_interfaces;
 
-    const auto & sensor_name = info_.sensors[0].name;
+    const auto & sensor_name = get_hardware_info().sensors[0].name;
     state_interfaces.emplace_back(
       hardware_interface::StateInterface(sensor_name, "fx", &values_.fx));
     state_interfaces.emplace_back(

--- a/hardware_interface/test/test_hardware_components/test_imu_sensor.cpp
+++ b/hardware_interface/test/test_hardware_components/test_imu_sensor.cpp
@@ -38,7 +38,7 @@ class TestIMUSensor : public SensorInterface
       return CallbackReturn::ERROR;
     }
 
-    const auto & state_interfaces = info_.sensors[0].state_interfaces;
+    const auto & state_interfaces = get_hardware_info().sensors[0].state_interfaces;
     if (state_interfaces.size() != 10)
     {
       return CallbackReturn::ERROR;
@@ -65,7 +65,7 @@ class TestIMUSensor : public SensorInterface
   {
     std::vector<StateInterface> state_interfaces;
 
-    const std::string & sensor_name = info_.sensors[0].name;
+    const std::string & sensor_name = get_hardware_info().sensors[0].name;
     state_interfaces.emplace_back(
       hardware_interface::StateInterface(sensor_name, "orientation.x", &orientation_.x));
     state_interfaces.emplace_back(

--- a/hardware_interface/test/test_hardware_components/test_single_joint_actuator.cpp
+++ b/hardware_interface/test/test_hardware_components/test_single_joint_actuator.cpp
@@ -34,12 +34,12 @@ class TestSingleJointActuator : public ActuatorInterface
     }
 
     // can only control one joint
-    if (info_.joints.size() != 1)
+    if (get_hardware_info().joints.size() != 1)
     {
       return CallbackReturn::ERROR;
     }
     // can only control in position
-    const auto & command_interfaces = info_.joints[0].command_interfaces;
+    const auto & command_interfaces = get_hardware_info().joints[0].command_interfaces;
     if (command_interfaces.size() != 1)
     {
       return CallbackReturn::ERROR;
@@ -49,7 +49,7 @@ class TestSingleJointActuator : public ActuatorInterface
       return CallbackReturn::ERROR;
     }
     // can only give feedback state for position and velocity
-    const auto & state_interfaces = info_.joints[0].state_interfaces;
+    const auto & state_interfaces = get_hardware_info().joints[0].state_interfaces;
     if (state_interfaces.size() < 1)
     {
       return CallbackReturn::ERROR;
@@ -71,7 +71,7 @@ class TestSingleJointActuator : public ActuatorInterface
   {
     std::vector<StateInterface> state_interfaces;
 
-    const auto & joint_name = info_.joints[0].name;
+    const auto & joint_name = get_hardware_info().joints[0].name;
     state_interfaces.emplace_back(hardware_interface::StateInterface(
       joint_name, hardware_interface::HW_IF_POSITION, &position_state_));
     state_interfaces.emplace_back(hardware_interface::StateInterface(
@@ -84,7 +84,7 @@ class TestSingleJointActuator : public ActuatorInterface
   {
     std::vector<CommandInterface> command_interfaces;
 
-    const auto & joint_name = info_.joints[0].name;
+    const auto & joint_name = get_hardware_info().joints[0].name;
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
       joint_name, hardware_interface::HW_IF_POSITION, &position_command_));
 

--- a/hardware_interface/test/test_hardware_components/test_system_with_command_modes.cpp
+++ b/hardware_interface/test/test_hardware_components/test_system_with_command_modes.cpp
@@ -32,11 +32,11 @@ public:
     }
 
     // Can only control two joints
-    if (info_.joints.size() != 2)
+    if (get_hardware_info().joints.size() != 2)
     {
       return CallbackReturn::ERROR;
     }
-    for (const hardware_interface::ComponentInfo & joint : info_.joints)
+    for (const hardware_interface::ComponentInfo & joint : get_hardware_info().joints)
     {
       // Can control in position or velocity
       const auto & command_interfaces = joint.command_interfaces;
@@ -77,14 +77,17 @@ public:
   std::vector<hardware_interface::StateInterface> export_state_interfaces() override
   {
     std::vector<hardware_interface::StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); i++)
+    for (auto i = 0u; i < get_hardware_info().joints.size(); i++)
     {
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_POSITION,
+        &position_state_[i]));
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_VELOCITY,
+        &velocity_state_[i]));
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_ACCELERATION,
+        &acceleration_state_[i]));
     }
 
     return state_interfaces;
@@ -93,12 +96,14 @@ public:
   std::vector<hardware_interface::CommandInterface> export_command_interfaces() override
   {
     std::vector<hardware_interface::CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); i++)
+    for (auto i = 0u; i < get_hardware_info().joints.size(); i++)
     {
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_POSITION,
+        &position_command_[i]));
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_VELOCITY,
+        &velocity_command_[i]));
     }
 
     return command_interfaces;
@@ -127,20 +132,20 @@ public:
     stop_modes_.clear();
     for (const auto & key : start_interfaces)
     {
-      for (auto i = 0u; i < info_.joints.size(); i++)
+      for (auto i = 0u; i < get_hardware_info().joints.size(); i++)
       {
-        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION)
+        if (key == get_hardware_info().joints[i].name + "/" + hardware_interface::HW_IF_POSITION)
         {
           start_modes_.push_back(hardware_interface::HW_IF_POSITION);
         }
-        if (key == info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY)
+        if (key == get_hardware_info().joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY)
         {
           start_modes_.push_back(hardware_interface::HW_IF_VELOCITY);
         }
       }
     }
     // Example Criteria 1 - Starting: All interfaces must be given a new mode at the same time
-    if (start_modes_.size() != 0 && start_modes_.size() != info_.joints.size())
+    if (start_modes_.size() != 0 && start_modes_.size() != get_hardware_info().joints.size())
     {
       return hardware_interface::return_type::ERROR;
     }
@@ -148,9 +153,9 @@ public:
     // Stopping interfaces
     for (const auto & key : stop_interfaces)
     {
-      for (auto i = 0u; i < info_.joints.size(); i++)
+      for (auto i = 0u; i < get_hardware_info().joints.size(); i++)
       {
-        if (key.find(info_.joints[i].name) != std::string::npos)
+        if (key.find(get_hardware_info().joints[i].name) != std::string::npos)
         {
           stop_modes_.push_back(true);
         }

--- a/hardware_interface/test/test_hardware_components/test_two_joint_system.cpp
+++ b/hardware_interface/test/test_hardware_components/test_two_joint_system.cpp
@@ -35,11 +35,11 @@ class TestTwoJointSystem : public SystemInterface
     }
 
     // can only control two joint
-    if (info_.joints.size() != 2)
+    if (get_hardware_info().joints.size() != 2)
     {
       return CallbackReturn::ERROR;
     }
-    for (const auto & joint : info_.joints)
+    for (const auto & joint : get_hardware_info().joints)
     {
       // can only control in position
       const auto & command_interfaces = joint.command_interfaces;
@@ -70,10 +70,11 @@ class TestTwoJointSystem : public SystemInterface
   std::vector<StateInterface> export_state_interfaces() override
   {
     std::vector<StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i)
+    for (auto i = 0u; i < get_hardware_info().joints.size(); ++i)
     {
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_POSITION,
+        &position_state_[i]));
     }
 
     return state_interfaces;
@@ -82,10 +83,11 @@ class TestTwoJointSystem : public SystemInterface
   std::vector<CommandInterface> export_command_interfaces() override
   {
     std::vector<CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i)
+    for (auto i = 0u; i < get_hardware_info().joints.size(); ++i)
     {
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_command_[i]));
+        get_hardware_info().joints[i].name, hardware_interface::HW_IF_POSITION,
+        &position_command_[i]));
     }
 
     return command_interfaces;

--- a/hardware_interface_testing/test/test_components/test_actuator.cpp
+++ b/hardware_interface_testing/test/test_components/test_actuator.cpp
@@ -31,7 +31,7 @@ class TestActuator : public ActuatorInterface
       return CallbackReturn::ERROR;
     }
 
-    if (info_.joints[0].state_interfaces[1].name == "does_not_exist")
+    if (get_hardware_info().joints[0].state_interfaces[1].name == "does_not_exist")
     {
       return CallbackReturn::ERROR;
     }
@@ -40,12 +40,12 @@ class TestActuator : public ActuatorInterface
      * a hardware can optional prove for incorrect info here.
      *
      * // can only control one joint
-     * if (info_.joints.size() != 1) {return CallbackReturn::ERROR;}
+     * if (get_hardware_info().joints.size() != 1) {return CallbackReturn::ERROR;}
      * // can only control in position
-     * if (info_.joints[0].command_interfaces.size() != 1) {return
+     * if (get_hardware_info().joints[0].command_interfaces.size() != 1) {return
      * CallbackReturn::ERROR;}
      * // can only give feedback state for position and velocity
-     * if (info_.joints[0].state_interfaces.size() != 2) {return
+     * if (get_hardware_info().joints[0].state_interfaces.size() != 2) {return
      * CallbackReturn::ERROR;}
      */
 
@@ -56,11 +56,13 @@ class TestActuator : public ActuatorInterface
   {
     std::vector<StateInterface> state_interfaces;
     state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[0].name, info_.joints[0].state_interfaces[0].name, &position_state_));
+      get_hardware_info().joints[0].name, get_hardware_info().joints[0].state_interfaces[0].name,
+      &position_state_));
     state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.joints[0].name, info_.joints[0].state_interfaces[1].name, &velocity_state_));
-    state_interfaces.emplace_back(
-      hardware_interface::StateInterface(info_.joints[0].name, "some_unlisted_interface", nullptr));
+      get_hardware_info().joints[0].name, get_hardware_info().joints[0].state_interfaces[1].name,
+      &velocity_state_));
+    state_interfaces.emplace_back(hardware_interface::StateInterface(
+      get_hardware_info().joints[0].name, "some_unlisted_interface", nullptr));
 
     return state_interfaces;
   }
@@ -69,12 +71,14 @@ class TestActuator : public ActuatorInterface
   {
     std::vector<CommandInterface> command_interfaces;
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[0].name, info_.joints[0].command_interfaces[0].name, &velocity_command_));
+      get_hardware_info().joints[0].name, get_hardware_info().joints[0].command_interfaces[0].name,
+      &velocity_command_));
 
-    if (info_.joints[0].command_interfaces.size() > 1)
+    if (get_hardware_info().joints[0].command_interfaces.size() > 1)
     {
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[0].name, info_.joints[0].command_interfaces[1].name, &max_velocity_command_));
+        get_hardware_info().joints[0].name,
+        get_hardware_info().joints[0].command_interfaces[1].name, &max_velocity_command_));
     }
 
     return command_interfaces;

--- a/hardware_interface_testing/test/test_components/test_sensor.cpp
+++ b/hardware_interface_testing/test/test_components/test_sensor.cpp
@@ -29,7 +29,7 @@ class TestSensor : public SensorInterface
       return CallbackReturn::ERROR;
     }
     // can only give feedback state for velocity
-    if (info_.sensors[0].state_interfaces.size() == 2)
+    if (get_hardware_info().sensors[0].state_interfaces.size() == 2)
     {
       return CallbackReturn::ERROR;
     }
@@ -40,7 +40,8 @@ class TestSensor : public SensorInterface
   {
     std::vector<StateInterface> state_interfaces;
     state_interfaces.emplace_back(hardware_interface::StateInterface(
-      info_.sensors[0].name, info_.sensors[0].state_interfaces[0].name, &velocity_state_));
+      get_hardware_info().sensors[0].name, get_hardware_info().sensors[0].state_interfaces[0].name,
+      &velocity_state_));
 
     return state_interfaces;
   }

--- a/hardware_interface_testing/test/test_components/test_system.cpp
+++ b/hardware_interface_testing/test/test_components/test_system.cpp
@@ -34,7 +34,7 @@ class TestSystem : public SystemInterface
     }
 
     // Simulating initialization error
-    if (info_.joints[0].state_interfaces[1].name == "does_not_exist")
+    if (get_hardware_info().joints[0].state_interfaces[1].name == "does_not_exist")
     {
       return CallbackReturn::ERROR;
     }
@@ -44,22 +44,23 @@ class TestSystem : public SystemInterface
 
   std::vector<StateInterface> export_state_interfaces() override
   {
+    const auto info = get_hardware_info();
     std::vector<StateInterface> state_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i)
+    for (auto i = 0u; i < info.joints.size(); ++i)
     {
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
+        info.joints[i].name, hardware_interface::HW_IF_POSITION, &position_state_[i]));
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
+        info.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_state_[i]));
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
+        info.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &acceleration_state_[i]));
     }
 
-    if (info_.gpios.size() > 0)
+    if (info.gpios.size() > 0)
     {
       // Add configuration/max_tcp_jerk interface
       state_interfaces.emplace_back(hardware_interface::StateInterface(
-        info_.gpios[0].name, info_.gpios[0].state_interfaces[0].name, &configuration_state_));
+        info.gpios[0].name, info.gpios[0].state_interfaces[0].name, &configuration_state_));
     }
 
     return state_interfaces;
@@ -67,22 +68,22 @@ class TestSystem : public SystemInterface
 
   std::vector<CommandInterface> export_command_interfaces() override
   {
+    const auto info = get_hardware_info();
     std::vector<CommandInterface> command_interfaces;
-    for (auto i = 0u; i < info_.joints.size(); ++i)
+    for (auto i = 0u; i < info.joints.size(); ++i)
     {
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
+        info.joints[i].name, hardware_interface::HW_IF_VELOCITY, &velocity_command_[i]));
     }
     // Add max_acceleration command interface
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
-      info_.joints[0].name, info_.joints[0].command_interfaces[1].name,
-      &max_acceleration_command_));
+      info.joints[0].name, info.joints[0].command_interfaces[1].name, &max_acceleration_command_));
 
-    if (info_.gpios.size() > 0)
+    if (info.gpios.size() > 0)
     {
       // Add configuration/max_tcp_jerk interface
       command_interfaces.emplace_back(hardware_interface::CommandInterface(
-        info_.gpios[0].name, info_.gpios[0].command_interfaces[0].name, &configuration_command_));
+        info.gpios[0].name, info.gpios[0].command_interfaces[0].name, &configuration_command_));
     }
 
     return command_interfaces;


### PR DESCRIPTION
In order to go with the similar efforts of https://github.com/ros-controls/ros2_control/pull/1623, the idea is to protect the critical variables of the hardware components interfaces, as these variables are actively used within the ResourceManager inorder to call and define the components and it's group,. Modifying them might cause undesired behaviour and this is something we should strive to avoid happening. 

To give some context, until Iron, the `on_init` method was supposed to be overwritten and the user is kinda responsible to also call the base class implementation to set this `info_` variable, and if the user forgets to do this callback, this will affect the whole internal schema as it creates a new Hardware component internally with empty name etc. 

This PR aims to solve this by adding this new method, so users can get the hardware info from there, and then eventually move the `info_` and `lifecycle_state_` to private context to avoid such misuses or modifying the information.

Thank you

