### PR TITLE
Add missing include for executors

### DIFF
--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -29,6 +29,7 @@
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
 
+#include "rclcpp/executors.hpp"
 #include "rclcpp/utilities.hpp"
 
 #include "std_msgs/msg/string.hpp"


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control_ci/issues/110

Not sure why it suddenly fails, we had green CI in the meantime after https://github.com/ros-controls/ros2_control/pull/1627