### PR TITLE
Refactor spawner to be able to reuse code for ros2controlcli

### DIFF
--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -25,6 +25,7 @@ from .controller_manager_services import (
     unload_controller,
     get_parameter_from_param_file,
     set_controller_parameters,
+    set_controller_parameters_from_param_file,
     bcolors,
 )
 
@@ -41,5 +42,6 @@ __all__ = [
     "unload_controller",
     "get_parameter_from_param_file",
     "set_controller_parameters",
+    "set_controller_parameters_from_param_file",
     "bcolors",
 ]

--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -24,6 +24,7 @@ from .controller_manager_services import (
     switch_controllers,
     unload_controller,
     get_parameter_from_param_file,
+    bcolors,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "switch_controllers",
     "unload_controller",
     "get_parameter_from_param_file",
+    "bcolors",
 ]

--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -24,6 +24,28 @@ from .controller_manager_services import (
     switch_controllers,
     unload_controller,
 )
+import yaml
+
+
+def get_parameter_from_param_file(controller_name, namespace, parameter_file, parameter_name):
+    with open(parameter_file) as f:
+        namespaced_controller = (
+            controller_name if namespace == "/" else f"{namespace}/{controller_name}"
+        )
+        parameters = yaml.safe_load(f)
+        if namespaced_controller in parameters:
+            value = parameters[namespaced_controller]
+            if not isinstance(value, dict) or "ros__parameters" not in value:
+                raise RuntimeError(
+                    f"YAML file : {parameter_file} is not a valid ROS parameter file for controller : {namespaced_controller}"
+                )
+            if parameter_name in parameters[namespaced_controller]["ros__parameters"]:
+                return parameters[namespaced_controller]["ros__parameters"][parameter_name]
+            else:
+                return None
+        else:
+            return None
+
 
 __all__ = [
     "configure_controller",
@@ -36,4 +58,5 @@ __all__ = [
     "set_hardware_component_state",
     "switch_controllers",
     "unload_controller",
+    "get_parameter_from_param_file",
 ]

--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -24,6 +24,7 @@ from .controller_manager_services import (
     switch_controllers,
     unload_controller,
     get_parameter_from_param_file,
+    set_controller_parameters,
     bcolors,
 )
 
@@ -39,5 +40,6 @@ __all__ = [
     "switch_controllers",
     "unload_controller",
     "get_parameter_from_param_file",
+    "set_controller_parameters",
     "bcolors",
 ]

--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -23,29 +23,8 @@ from .controller_manager_services import (
     set_hardware_component_state,
     switch_controllers,
     unload_controller,
+    get_parameter_from_param_file,
 )
-import yaml
-
-
-def get_parameter_from_param_file(controller_name, namespace, parameter_file, parameter_name):
-    with open(parameter_file) as f:
-        namespaced_controller = (
-            controller_name if namespace == "/" else f"{namespace}/{controller_name}"
-        )
-        parameters = yaml.safe_load(f)
-        if namespaced_controller in parameters:
-            value = parameters[namespaced_controller]
-            if not isinstance(value, dict) or "ros__parameters" not in value:
-                raise RuntimeError(
-                    f"YAML file : {parameter_file} is not a valid ROS parameter file for controller : {namespaced_controller}"
-                )
-            if parameter_name in parameters[namespaced_controller]["ros__parameters"]:
-                return parameters[namespaced_controller]["ros__parameters"][parameter_name]
-            else:
-                return None
-        else:
-            return None
-
 
 __all__ = [
     "configure_controller",

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -26,6 +26,7 @@ from controller_manager_msgs.srv import (
 )
 
 import rclpy
+import yaml
 
 
 class ServiceNotFoundError(Exception):
@@ -180,3 +181,23 @@ def unload_controller(node, controller_manager_name, controller_name, service_ti
         request,
         service_timeout,
     )
+
+
+def get_parameter_from_param_file(controller_name, namespace, parameter_file, parameter_name):
+    with open(parameter_file) as f:
+        namespaced_controller = (
+            controller_name if namespace == "/" else f"{namespace}/{controller_name}"
+        )
+        parameters = yaml.safe_load(f)
+        if namespaced_controller in parameters:
+            value = parameters[namespaced_controller]
+            if not isinstance(value, dict) or "ros__parameters" not in value:
+                raise RuntimeError(
+                    f"YAML file : {parameter_file} is not a valid ROS parameter file for controller : {namespaced_controller}"
+                )
+            if parameter_name in parameters[namespaced_controller]["ros__parameters"]:
+                return parameters[namespaced_controller]["ros__parameters"][parameter_name]
+            else:
+                return None
+        else:
+            return None

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -264,3 +264,36 @@ def set_controller_parameters(
         )
         return False
     return True
+
+
+def set_controller_parameters_from_param_file(
+    node, controller_manager_name, controller_name, parameter_file, namespace=None
+):
+    if parameter_file:
+        spawner_namespace = namespace if namespace else node.get_namespace()
+        set_controller_parameters(
+            node, controller_manager_name, controller_name, "param_file", parameter_file
+        )
+
+        controller_type = get_parameter_from_param_file(
+            controller_name, spawner_namespace, parameter_file, "type"
+        )
+        if controller_type:
+            if not set_controller_parameters(
+                node, controller_manager_name, controller_name, "type", controller_type
+            ):
+                return False
+
+        fallback_controllers = get_parameter_from_param_file(
+            controller_name, spawner_namespace, parameter_file, "fallback_controllers"
+        )
+        if fallback_controllers:
+            if not set_controller_parameters(
+                node,
+                controller_manager_name,
+                controller_name,
+                "fallback_controllers",
+                fallback_controllers,
+            ):
+                return False
+    return True

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -27,6 +27,15 @@ from controller_manager_msgs.srv import (
 
 import rclpy
 import yaml
+from rcl_interfaces.msg import Parameter
+
+# @note: The versions conditioning is added here to support the source-compatibility with Humble
+# The `get_parameter_value` function is moved to `rclpy.parameter` module from `ros2param.api` module from version 3.6.0
+try:
+    from rclpy.parameter import get_parameter_value
+except ImportError:
+    from ros2param.api import get_parameter_value
+from ros2param.api import call_set_parameters
 
 
 # from https://stackoverflow.com/a/287944
@@ -214,3 +223,43 @@ def get_parameter_from_param_file(controller_name, namespace, parameter_file, pa
                 return None
         else:
             return None
+
+
+def set_controller_parameters(
+    node, controller_manager_name, controller_name, parameter_name, parameter_value
+):
+    parameter = Parameter()
+    parameter.name = controller_name + "." + parameter_name
+    parameter.value = get_parameter_value(string_value=parameter_value)
+
+    response = call_set_parameters(
+        node=node, node_name=controller_manager_name, parameters=[parameter]
+    )
+    assert len(response.results) == 1
+    result = response.results[0]
+    if result.successful:
+        node.get_logger().info(
+            bcolors.OKCYAN
+            + 'Setting controller param "'
+            + parameter_name
+            + '" to "'
+            + parameter_value
+            + '" for '
+            + bcolors.BOLD
+            + controller_name
+            + bcolors.ENDC
+        )
+    else:
+        node.get_logger().fatal(
+            bcolors.FAIL
+            + 'Could not set controller param "'
+            + parameter_name
+            + '" to "'
+            + parameter_value
+            + '" for '
+            + bcolors.BOLD
+            + controller_name
+            + bcolors.ENDC
+        )
+        return False
+    return True

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -29,6 +29,19 @@ import rclpy
 import yaml
 
 
+# from https://stackoverflow.com/a/287944
+class bcolors:
+    MAGENTA = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
 class ServiceNotFoundError(Exception):
     pass
 

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -230,7 +230,8 @@ def set_controller_parameters(
 ):
     parameter = Parameter()
     parameter.name = controller_name + "." + parameter_name
-    parameter.value = get_parameter_value(string_value=parameter_value)
+    parameter_string = str(parameter_value)
+    parameter.value = get_parameter_value(string_value=parameter_string)
 
     response = call_set_parameters(
         node=node, node_name=controller_manager_name, parameters=[parameter]
@@ -243,7 +244,7 @@ def set_controller_parameters(
             + 'Setting controller param "'
             + parameter_name
             + '" to "'
-            + parameter_value
+            + parameter_string
             + '" for '
             + bcolors.BOLD
             + controller_name
@@ -255,7 +256,7 @@ def set_controller_parameters(
             + 'Could not set controller param "'
             + parameter_name
             + '" to "'
-            + parameter_value
+            + parameter_string
             + '" for '
             + bcolors.BOLD
             + controller_name

--- a/controller_manager/controller_manager/hardware_spawner.py
+++ b/controller_manager/controller_manager/hardware_spawner.py
@@ -19,6 +19,7 @@ import sys
 from controller_manager import (
     list_hardware_components,
     set_hardware_component_state,
+    bcolors,
 )
 from controller_manager.controller_manager_services import ServiceNotFoundError
 
@@ -26,19 +27,6 @@ from lifecycle_msgs.msg import State
 import rclpy
 from rclpy.node import Node
 from rclpy.signals import SignalHandlerOptions
-
-
-# from https://stackoverflow.com/a/287944
-class bcolors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
 
 
 def first_match(iterable, predicate):

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -26,8 +26,7 @@ from controller_manager import (
     load_controller,
     switch_controllers,
     unload_controller,
-    get_parameter_from_param_file,
-    set_controller_parameters,
+    set_controller_parameters_from_param_file,
     bcolors,
 )
 from controller_manager.controller_manager_services import ServiceNotFoundError
@@ -174,31 +173,14 @@ def main(args=None):
                 )
             else:
                 if param_file:
-                    set_controller_parameters(
-                        node, controller_manager_name, controller_name, "param_file", param_file
-                    )
-
-                    controller_type = get_parameter_from_param_file(
-                        controller_name, spawner_namespace, param_file, "type"
-                    )
-                    if controller_type:
-                        if not set_controller_parameters(
-                            node, controller_manager_name, controller_name, "type", controller_type
-                        ):
-                            return 1
-
-                    fallback_controllers = get_parameter_from_param_file(
-                        controller_name, spawner_namespace, param_file, "fallback_controllers"
-                    )
-                    if fallback_controllers:
-                        if not set_controller_parameters(
-                            node,
-                            controller_manager_name,
-                            controller_name,
-                            "fallback_controllers",
-                            fallback_controllers,
-                        ):
-                            return 1
+                    if not set_controller_parameters_from_param_file(
+                        node,
+                        controller_manager_name,
+                        controller_name,
+                        param_file,
+                        spawner_namespace,
+                    ):
+                        return 1
 
                 ret = load_controller(node, controller_manager_name, controller_name)
                 if not ret.ok:

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -144,14 +144,6 @@ def main(args=None):
         action="store_true",
         required=False,
     )
-    parser.add_argument(
-        "--fallback_controllers",
-        help="Fallback controllers list are activated as a fallback strategy when the"
-        " spawned controllers fail. When the argument is provided, it takes precedence over"
-        " the fallback_controllers list in the param file",
-        default=None,
-        nargs="+",
-    )
 
     command_line_args = rclpy.utilities.remove_ros_args(args=sys.argv)[1:]
     args = parser.parse_args(command_line_args)
@@ -192,7 +184,6 @@ def main(args=None):
 
     try:
         for controller_name in controller_names:
-            fallback_controllers = args.fallback_controllers
 
             if is_controller_loaded(
                 node, controller_manager_name, controller_name, controller_manager_timeout
@@ -274,11 +265,13 @@ def main(args=None):
                         )
                         return 1
 
-                if not fallback_controllers and param_file:
-                    fallback_controllers = get_parameter_from_param_file(
+                fallback_controllers = (
+                    None
+                    if param_file is None
+                    else get_parameter_from_param_file(
                         controller_name, spawner_namespace, param_file, "fallback_controllers"
                     )
-
+                )
                 if fallback_controllers:
                     parameter = Parameter()
                     parameter.name = controller_name + ".fallback_controllers"

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -27,6 +27,7 @@ from controller_manager import (
     switch_controllers,
     unload_controller,
     get_parameter_from_param_file,
+    bcolors,
 )
 from controller_manager.controller_manager_services import ServiceNotFoundError
 
@@ -42,20 +43,6 @@ except ImportError:
     from ros2param.api import get_parameter_value
 from rclpy.signals import SignalHandlerOptions
 from ros2param.api import call_set_parameters
-
-# from https://stackoverflow.com/a/287944
-
-
-class bcolors:
-    MAGENTA = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
 
 
 def first_match(iterable, predicate):

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -19,7 +19,6 @@ import os
 import sys
 import time
 import warnings
-import yaml
 
 from controller_manager import (
     configure_controller,
@@ -27,6 +26,7 @@ from controller_manager import (
     load_controller,
     switch_controllers,
     unload_controller,
+    get_parameter_from_param_file,
 )
 from controller_manager.controller_manager_services import ServiceNotFoundError
 
@@ -85,24 +85,6 @@ def has_service_names(node, node_name, node_namespace, service_names):
 def is_controller_loaded(node, controller_manager, controller_name, service_timeout=0.0):
     controllers = list_controllers(node, controller_manager, service_timeout).controller
     return any(c.name == controller_name for c in controllers)
-
-
-def get_parameter_from_param_file(controller_name, namespace, parameter_file, parameter_name):
-    with open(parameter_file) as f:
-        namespaced_controller = (
-            controller_name if namespace == "/" else f"{namespace}/{controller_name}"
-        )
-        parameters = yaml.safe_load(f)
-        if namespaced_controller in parameters:
-            value = parameters[namespaced_controller]
-            if not isinstance(value, dict) or "ros__parameters" not in value:
-                raise RuntimeError(
-                    f"YAML file : {parameter_file} is not a valid ROS parameter file for controller : {namespaced_controller}"
-                )
-            if parameter_name in parameters[namespaced_controller]["ros__parameters"]:
-                return parameters[namespaced_controller]["ros__parameters"][parameter_name]
-            else:
-                return None
 
 
 def main(args=None):

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -329,20 +329,14 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
   cm_->set_parameter(rclcpp::Parameter("ctrl_3.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
 
   ControllerManagerRunner cm_runner(this);
-  EXPECT_EQ(
-    call_spawner(
-      "ctrl_1 -c test_controller_manager --load-only --fallback_controllers ctrl_3 ctrl_4 ctrl_5 "
-      "-p " +
-      test_file_path),
-    0);
+  EXPECT_EQ(call_spawner("ctrl_1 -c test_controller_manager --load-only -p " + test_file_path), 0);
 
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
   {
     auto ctrl_1 = cm_->get_loaded_controllers()[0];
     ASSERT_EQ(ctrl_1.info.name, "ctrl_1");
     ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
-    ASSERT_THAT(
-      ctrl_1.info.fallback_controllers_names, testing::ElementsAre("ctrl_3", "ctrl_4", "ctrl_5"));
+    ASSERT_TRUE(ctrl_1.info.fallback_controllers_names.empty());
     ASSERT_EQ(ctrl_1.c->get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   }
 
@@ -355,8 +349,7 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
     auto ctrl_1 = cm_->get_loaded_controllers()[0];
     ASSERT_EQ(ctrl_1.info.name, "ctrl_1");
     ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
-    ASSERT_THAT(
-      ctrl_1.info.fallback_controllers_names, testing::ElementsAre("ctrl_3", "ctrl_4", "ctrl_5"));
+    ASSERT_TRUE(ctrl_1.info.fallback_controllers_names.empty());
     ASSERT_EQ(ctrl_1.c->get_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 
     auto ctrl_2 = cm_->get_loaded_controllers()[1];

--- a/ros2controlcli/ros2controlcli/verb/list_controllers.py
+++ b/ros2controlcli/ros2controlcli/verb/list_controllers.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller_manager import list_controllers
-from controller_manager.spawner import bcolors
+from controller_manager import list_controllers, bcolors
 
 from ros2cli.node.direct import add_arguments
 from ros2cli.node.strategy import NodeStrategy

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller_manager import list_hardware_components
-from controller_manager.spawner import bcolors
+from controller_manager import list_hardware_components, bcolors
 
 from lifecycle_msgs.msg import State
 

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_interfaces.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from controller_manager import list_hardware_interfaces
-from controller_manager.spawner import bcolors
+from controller_manager import list_hardware_interfaces, bcolors
 
 from ros2cli.node.direct import add_arguments
 from ros2cli.node.strategy import NodeStrategy


### PR DESCRIPTION
@christophfroehlich has mentioned that ros2 control CLI is missing the functionality to load controllers with the parameter files as we have now with the spawner. upon reviewing the code, the code would need some refactoring to reduce some duplication of code in both places and to be able also to load controllers with namespaced controller manager

This PR would be the first part of refactoring that can go along with #1562, once both the PRs are done, the ros2 control CLI can be modified to add the parameter parsing from the file and proper usage with namespacing.