### PR TITLE
Fix flaky transmission_interface tests by making them deterministic.

### DIFF
--- a/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.hpp
+++ b/transmission_interface/include/transmission_interface/four_bar_linkage_transmission.hpp
@@ -289,7 +289,7 @@ inline void FourBarLinkageTransmission::actuator_to_joint()
 
     joint_eff[0].set_value(jr[0] * act_eff[0].get_value() * ar[0]);
     joint_eff[1].set_value(
-      jr[1] * (act_eff[1].get_value() * ar[1] - act_eff[0].get_value() * ar[0] * jr[0]));
+      jr[1] * (act_eff[1].get_value() * ar[1] - jr[0] * act_eff[0].get_value() * ar[0]));
   }
 }
 

--- a/transmission_interface/test/random_generator_utils.hpp
+++ b/transmission_interface/test/random_generator_utils.hpp
@@ -26,12 +26,14 @@ using std::vector;
 /// \brief Generator of pseudo-random double in the range [min_val, max_val].
 // NOTE: Based on example code available at:
 // http://stackoverflow.com/questions/2860673/initializing-a-c-vector-to-random-values-fast
+// Use a user specified seed instead of system time for deterministic tests
 struct RandomDoubleGenerator
 {
 public:
-  RandomDoubleGenerator(double min_val, double max_val) : min_val_(min_val), max_val_(max_val)
+  RandomDoubleGenerator(double min_val, double max_val, unsigned int seed=1234) 
+  : min_val_(min_val), max_val_(max_val)
   {
-    srand(static_cast<unsigned int>(time(nullptr)));
+    srand(seed);
   }
   double operator()()
   {

--- a/transmission_interface/test/random_generator_utils.hpp
+++ b/transmission_interface/test/random_generator_utils.hpp
@@ -30,7 +30,7 @@ using std::vector;
 struct RandomDoubleGenerator
 {
 public:
-  RandomDoubleGenerator(double min_val, double max_val, unsigned int seed=1234) 
+  RandomDoubleGenerator(double min_val, double max_val, unsigned int seed = 1234)
   : min_val_(min_val), max_val_(max_val)
   {
     srand(seed);


### PR DESCRIPTION
Fixes #1555 

The transmission_interface tests would give non deterministic spurious failures. The non determinism was because tests were randomly generated using the system time to seed the random number generator. The spurious failures were due to occasionally occurring tiny rounding errors from floating point math.

By seeding the random number generator the tests become deterministic and we avoid the spurious failures. 
Additionally, changing the order of some of the multiplications seems to reduce the rounding error.


Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [ ] Fork the repository.
- [ ] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [ ] Commit to your fork using clear commit messages.
- [ ] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
