### PR TITLE
Fix spawner unload on kill test

### DIFF
--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -298,11 +298,11 @@ TEST_F(TestLoadController, unload_on_kill)
 {
   // Launch spawner with unload on kill
   // timeout command will kill it after the specified time with signal SIGINT
+  cm_->set_parameter(rclcpp::Parameter("ctrl_3.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
   std::stringstream ss;
   ss << "timeout --signal=INT 5 "
-     << "ros2 run controller_manager spawner "
-     << "ctrl_3 -c test_controller_manager -t "
-     << std::string(test_controller::TEST_CONTROLLER_CLASS_NAME) << " --unload-on-kill";
+     << "ros2 run controller_manager spawner ctrl_3 -c test_controller_manager"
+     << " --unload-on-kill";
 
   EXPECT_NE(std::system(ss.str().c_str()), 0)
     << "timeout should have killed spawner and returned non 0 code";


### PR DESCRIPTION
This PR removed the removed `--controller-type` arg and this should fix #1674

```
1: [ RUN      ] TestLoadController.unload_on_kill
1: [WARN] [1723621281.285314383] [test_controller_manager]: 'update_rate' parameter not set, using default value of 100 Hz.
1: [INFO] [1723621281.285576429] [test_controller_manager]: Subscribing to '/robot_description' topic for robot description.
1: [INFO] [1723621281.285628469] [test_controller_manager]: Received robot description from topic.
1: [INFO] [1723621281.286638848] [ResourceManager.resource_manager]: Loading hardware 'TestActuatorHardware' 
1: [INFO] [1723621281.287215441] [ResourceManager.resource_manager]: Loaded hardware 'TestActuatorHardware' from plugin 'test_actuator'
1: [INFO] [1723621281.287257207] [ResourceManager.resource_manager]: Initialize hardware 'TestActuatorHardware' 
1: [INFO] [1723621281.287285122] [ResourceManager.resource_manager]: Successful initialization of hardware 'TestActuatorHardware'
1: [INFO] [1723621281.287339970] [ResourceManager.resource_manager]: Loading hardware 'TestSensorHardware' 
1: [INFO] [1723621281.287444969] [ResourceManager.resource_manager]: Loaded hardware 'TestSensorHardware' from plugin 'test_sensor'
1: [INFO] [1723621281.287473634] [ResourceManager.resource_manager]: Initialize hardware 'TestSensorHardware' 
1: [INFO] [1723621281.287504812] [ResourceManager.resource_manager]: Successful initialization of hardware 'TestSensorHardware'
1: [INFO] [1723621281.287529058] [ResourceManager.resource_manager]: Loading hardware 'TestSystemHardware' 
1: [INFO] [1723621281.287626232] [ResourceManager.resource_manager]: Loaded hardware 'TestSystemHardware' from plugin 'test_system'
1: [INFO] [1723621281.287651821] [ResourceManager.resource_manager]: Initialize hardware 'TestSystemHardware' 
1: [INFO] [1723621281.287686045] [ResourceManager.resource_manager]: Successful initialization of hardware 'TestSystemHardware'
1: [INFO] [1723621281.287920249] [resource_manager]: 'configure' hardware 'TestSystemHardware' 
1: [INFO] [1723621281.287928981] [resource_manager]: Successful 'configure' of hardware 'TestSystemHardware'
1: [INFO] [1723621281.287941251] [resource_manager]: 'activate' hardware 'TestSystemHardware' 
1: [INFO] [1723621281.287946200] [resource_manager]: Successful 'activate' of hardware 'TestSystemHardware'
1: [INFO] [1723621281.287957240] [resource_manager]: 'configure' hardware 'TestSensorHardware' 
1: [INFO] [1723621281.287961653] [resource_manager]: Successful 'configure' of hardware 'TestSensorHardware'
1: [INFO] [1723621281.287967852] [resource_manager]: 'activate' hardware 'TestSensorHardware' 
1: [INFO] [1723621281.287971254] [resource_manager]: Successful 'activate' of hardware 'TestSensorHardware'
1: [INFO] [1723621281.287979093] [resource_manager]: 'configure' hardware 'TestActuatorHardware' 
1: [INFO] [1723621281.287985027] [resource_manager]: Successful 'configure' of hardware 'TestActuatorHardware'
1: [INFO] [1723621281.287994292] [resource_manager]: 'activate' hardware 'TestActuatorHardware' 
1: [INFO] [1723621281.287998264] [resource_manager]: Successful 'activate' of hardware 'TestActuatorHardware'
1: [INFO] [1723621281.288009425] [test_controller_manager]: Resource Manager has been successfully initialized. Starting Controller Manager services...
1: [INFO] [1723621281.887493831] [test_controller_manager]: Loading controller 'ctrl_3'
1: [INFO] [1723621281.900996167] [spawner_ctrl_3]: Loaded ctrl_3
1: [INFO] [1723621281.901792560] [test_controller_manager]: Configuring controller 'ctrl_3'
1: [INFO] [1723621281.931057599] [spawner_ctrl_3]: Configured and activated ctrl_3
1: [INFO] [1723621281.931297701] [spawner_ctrl_3]: Waiting until interrupt to unload controllers
1: [INFO] [1723621286.353034818] [spawner_ctrl_3]: Interrupt captured, deactivating and unloading controller
1: [INFO] [1723621286.371612504] [spawner_ctrl_3]: Deactivated controller
1: [INFO] [1723621286.382513258] [spawner_ctrl_3]: Unloaded controller
1: [       OK ] TestLoadController.unload_on_kill (5304 ms)
```