### PR TITLE
Introduce Creation of Handles with InterfaceDescription (variant support)

### DIFF
--- a/hardware_interface/include/hardware_interface/component_parser.hpp
+++ b/hardware_interface/include/hardware_interface/component_parser.hpp
@@ -38,7 +38,7 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
  * which are exported
  */
 HARDWARE_INTERFACE_PUBLIC
-std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardware_info(
+std::vector<InterfaceDescription> parse_state_interface_descriptions(
   const std::vector<ComponentInfo> & component_info);
 
 /**
@@ -47,7 +47,7 @@ std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardwa
  * which are exported
  */
 HARDWARE_INTERFACE_PUBLIC
-std::vector<InterfaceDescription> parse_command_interface_descriptions_from_hardware_info(
+std::vector<InterfaceDescription> parse_command_interface_descriptions(
   const std::vector<ComponentInfo> & component_info);
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/component_parser.hpp
+++ b/hardware_interface/include/hardware_interface/component_parser.hpp
@@ -32,5 +32,23 @@ namespace hardware_interface
 HARDWARE_INTERFACE_PUBLIC
 std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & urdf);
 
+/**
+ * \param[in] component_info information about a component (gpio, joint, sensor)
+ * \return vector filled with information about hardware's StateInterfaces for the component
+ * which are exported
+ */
+HARDWARE_INTERFACE_PUBLIC
+std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardware_info(
+  const std::vector<ComponentInfo> & component_info);
+
+/**
+ * \param[in] component_info information about a component (gpio, joint, sensor)
+ * \return vector filled with information about hardware's CommandInterfaces for the component
+ * which are exported
+ */
+HARDWARE_INTERFACE_PUBLIC
+std::vector<InterfaceDescription> parse_command_interface_descriptions_from_hardware_info(
+  const std::vector<ComponentInfo> & component_info);
+
 }  // namespace hardware_interface
 #endif  // HARDWARE_INTERFACE__COMPONENT_PARSER_HPP_

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -15,9 +15,11 @@
 #ifndef HARDWARE_INTERFACE__HANDLE_HPP_
 #define HARDWARE_INTERFACE__HANDLE_HPP_
 
+#include <limits>
 #include <string>
 #include <variant>
 
+#include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/macros.hpp"
 
 namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -29,6 +29,8 @@ using HANDLE_DATATYPE = std::variant<double>;
 class Handle
 {
 public:
+  [[deprecated("Use InterfaceDescription for initializing the Interface")]]
+
   Handle(
     const std::string & prefix_name, const std::string & interface_name,
     double * value_ptr = nullptr)
@@ -36,10 +38,24 @@ public:
   {
   }
 
+  explicit Handle(const InterfaceDescription & interface_description)
+  : prefix_name_(interface_description.prefix_name),
+    interface_name_(interface_description.interface_info.name)
+  {
+    // As soon as multiple datatypes are used in HANDLE_DATATYPE
+    // we need to initialize according the type passed in interface description
+    value_ = std::numeric_limits<double>::quiet_NaN();
+    value_ptr_ = std::get_if<double>(&value_);
+  }
+
+  [[deprecated("Use InterfaceDescription for initializing the Interface")]]
+
   explicit Handle(const std::string & interface_name)
   : interface_name_(interface_name), value_ptr_(nullptr)
   {
   }
+
+  [[deprecated("Use InterfaceDescription for initializing the Interface")]]
 
   explicit Handle(const char * interface_name)
   : interface_name_(interface_name), value_ptr_(nullptr)
@@ -103,10 +119,8 @@ protected:
 class StateInterface : public Handle
 {
 public:
-  explicit StateInterface(
-    const std::string & prefix_name, const std::string & interface_name,
-    double * value_ptr = nullptr)
-  : Handle(prefix_name, interface_name, value_ptr)
+  explicit StateInterface(const InterfaceDescription & interface_description)
+  : Handle(interface_description)
   {
   }
 
@@ -120,10 +134,8 @@ public:
 class CommandInterface : public Handle
 {
 public:
-  explicit CommandInterface(
-    const std::string & prefix_name, const std::string & interface_name,
-    double * value_ptr = nullptr)
-  : Handle(prefix_name, interface_name, value_ptr)
+  explicit CommandInterface(const InterfaceDescription & interface_description)
+  : Handle(interface_description)
   {
   }
   /// CommandInterface copy constructor is actively deleted.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -40,9 +40,9 @@ struct InterfaceInfo
   std::string max;
   /// (Optional) Initial value of the interface.
   std::string initial_value;
-  /// (Optional) The datatype of the interface, e.g. "bool", "int". Used by GPIOs.
+  /// (Optional) The datatype of the interface, e.g. "bool", "int".
   std::string data_type;
-  /// (Optional) If the handle is an array, the size of the array. Used by GPIOs.
+  /// (Optional) If the handle is an array, the size of the array.
   int size;
   /// (Optional) enable or disable the limits for the command interfaces
   bool enable_limits;
@@ -124,6 +124,32 @@ struct TransmissionInfo
   std::vector<ActuatorInfo> actuators;
   /// (Optional) Key-value pairs of custom parameters
   std::unordered_map<std::string, std::string> parameters;
+};
+
+/**
+ * This structure stores information about an interface for a specific hardware which should be
+ * instantiated internally.
+ */
+struct InterfaceDescription
+{
+  InterfaceDescription(const std::string & prefix_name_in, const InterfaceInfo & interface_info_in)
+  : prefix_name(prefix_name_in), interface_info(interface_info_in)
+  {
+  }
+
+  /**
+   * Name of the interface defined by the user.
+   */
+  std::string prefix_name;
+
+  /**
+   * Information about the Interface type (position, velocity,...) as well as limits and so on.
+   */
+  InterfaceInfo interface_info;
+
+  std::string get_name() const { return prefix_name + "/" + interface_info.name; }
+
+  std::string get_interface_type() const { return interface_info.name; }
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -133,7 +133,9 @@ struct TransmissionInfo
 struct InterfaceDescription
 {
   InterfaceDescription(const std::string & prefix_name_in, const InterfaceInfo & interface_info_in)
-  : prefix_name(prefix_name_in), interface_info(interface_info_in)
+  : prefix_name(prefix_name_in),
+    interface_info(interface_info_in),
+    interface_name(prefix_name + "/" + interface_info.name)
   {
   }
 
@@ -147,9 +149,16 @@ struct InterfaceDescription
    */
   InterfaceInfo interface_info;
 
-  std::string get_name() const { return prefix_name + "/" + interface_info.name; }
+  /**
+   * Name of the interface
+   */
+  std::string interface_name;
 
-  std::string get_interface_type() const { return interface_info.name; }
+  std::string get_prefix_name() const { return prefix_name; }
+
+  std::string get_interface_name() const { return interface_info.name; }
+
+  std::string get_name() const { return interface_name; }
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -905,7 +905,7 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
   return hardware_info;
 }
 
-std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardware_info(
+std::vector<InterfaceDescription> parse_state_interface_descriptions(
   const std::vector<ComponentInfo> & component_info)
 {
   std::vector<InterfaceDescription> component_state_interface_descriptions;
@@ -922,7 +922,7 @@ std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardwa
   return component_state_interface_descriptions;
 }
 
-std::vector<InterfaceDescription> parse_command_interface_descriptions_from_hardware_info(
+std::vector<InterfaceDescription> parse_command_interface_descriptions(
   const std::vector<ComponentInfo> & component_info)
 {
   std::vector<InterfaceDescription> component_command_interface_descriptions;

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -905,4 +905,38 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
   return hardware_info;
 }
 
+std::vector<InterfaceDescription> parse_state_interface_descriptions_from_hardware_info(
+  const std::vector<ComponentInfo> & component_info)
+{
+  std::vector<InterfaceDescription> component_state_interface_descriptions;
+  component_state_interface_descriptions.reserve(component_info.size());
+
+  for (const auto & component : component_info)
+  {
+    for (const auto & state_interface : component.state_interfaces)
+    {
+      component_state_interface_descriptions.emplace_back(
+        InterfaceDescription(component.name, state_interface));
+    }
+  }
+  return component_state_interface_descriptions;
+}
+
+std::vector<InterfaceDescription> parse_command_interface_descriptions_from_hardware_info(
+  const std::vector<ComponentInfo> & component_info)
+{
+  std::vector<InterfaceDescription> component_command_interface_descriptions;
+  component_command_interface_descriptions.reserve(component_info.size());
+
+  for (const auto & component : component_info)
+  {
+    for (const auto & command_interface : component.command_interfaces)
+    {
+      component_command_interface_descriptions.emplace_back(
+        InterfaceDescription(component.name, command_interface));
+    }
+  }
+  return component_command_interface_descriptions;
+}
+
 }  // namespace hardware_interface

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1416,11 +1416,11 @@ TEST_F(TestComponentParser, parse_joint_state_interface_descriptions_from_hardwa
   const auto joint_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].joints);
   EXPECT_EQ(joint_state_descriptions[0].prefix_name, "joint1");
-  EXPECT_EQ(joint_state_descriptions[0].get_interface_type(), "position");
+  EXPECT_EQ(joint_state_descriptions[0].get_name(), "position");
   EXPECT_EQ(joint_state_descriptions[0].get_name(), "joint1/position");
 
   EXPECT_EQ(joint_state_descriptions[1].prefix_name, "joint2");
-  EXPECT_EQ(joint_state_descriptions[1].get_interface_type(), "position");
+  EXPECT_EQ(joint_state_descriptions[1].get_name(), "position");
   EXPECT_EQ(joint_state_descriptions[1].get_name(), "joint2/position");
 }
 
@@ -1435,13 +1435,13 @@ TEST_F(TestComponentParser, parse_joint_command_interface_descriptions_from_hard
   const auto joint_command_descriptions =
     parse_command_interface_descriptions(control_hardware[0].joints);
   EXPECT_EQ(joint_command_descriptions[0].prefix_name, "joint1");
-  EXPECT_EQ(joint_command_descriptions[0].get_interface_type(), "position");
+  EXPECT_EQ(joint_command_descriptions[0].get_name(), "position");
   EXPECT_EQ(joint_command_descriptions[0].get_name(), "joint1/position");
   EXPECT_EQ(joint_command_descriptions[0].interface_info.min, "-1");
   EXPECT_EQ(joint_command_descriptions[0].interface_info.max, "1");
 
   EXPECT_EQ(joint_command_descriptions[1].prefix_name, "joint2");
-  EXPECT_EQ(joint_command_descriptions[1].get_interface_type(), "position");
+  EXPECT_EQ(joint_command_descriptions[1].get_name(), "position");
   EXPECT_EQ(joint_command_descriptions[1].get_name(), "joint2/position");
   EXPECT_EQ(joint_command_descriptions[1].interface_info.min, "-1");
   EXPECT_EQ(joint_command_descriptions[1].interface_info.max, "1");
@@ -1457,17 +1457,17 @@ TEST_F(TestComponentParser, parse_sensor_state_interface_descriptions_from_hardw
   const auto sensor_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].sensors);
   EXPECT_EQ(sensor_state_descriptions[0].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[0].get_interface_type(), "roll");
+  EXPECT_EQ(sensor_state_descriptions[0].get_name(), "roll");
   EXPECT_EQ(sensor_state_descriptions[0].get_name(), "sensor1/roll");
   EXPECT_EQ(sensor_state_descriptions[1].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[1].get_interface_type(), "pitch");
+  EXPECT_EQ(sensor_state_descriptions[1].get_name(), "pitch");
   EXPECT_EQ(sensor_state_descriptions[1].get_name(), "sensor1/pitch");
   EXPECT_EQ(sensor_state_descriptions[2].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[2].get_interface_type(), "yaw");
+  EXPECT_EQ(sensor_state_descriptions[2].get_name(), "yaw");
   EXPECT_EQ(sensor_state_descriptions[2].get_name(), "sensor1/yaw");
 
   EXPECT_EQ(sensor_state_descriptions[3].prefix_name, "sensor2");
-  EXPECT_EQ(sensor_state_descriptions[3].get_interface_type(), "image");
+  EXPECT_EQ(sensor_state_descriptions[3].get_name(), "image");
   EXPECT_EQ(sensor_state_descriptions[3].get_name(), "sensor2/image");
 }
 
@@ -1482,17 +1482,17 @@ TEST_F(TestComponentParser, parse_gpio_state_interface_descriptions_from_hardwar
   const auto gpio_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].gpios);
   EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
   EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[1].get_interface_type(), "analog_input1");
+  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "analog_input1");
   EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_analog_IOs/analog_input1");
   EXPECT_EQ(gpio_state_descriptions[2].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[2].get_interface_type(), "analog_input2");
+  EXPECT_EQ(gpio_state_descriptions[2].get_name(), "analog_input2");
   EXPECT_EQ(gpio_state_descriptions[2].get_name(), "flange_analog_IOs/analog_input2");
 
   EXPECT_EQ(gpio_state_descriptions[3].prefix_name, "flange_vacuum");
-  EXPECT_EQ(gpio_state_descriptions[3].get_interface_type(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[3].get_name(), "vacuum");
   EXPECT_EQ(gpio_state_descriptions[3].get_name(), "flange_vacuum/vacuum");
 }
 
@@ -1507,10 +1507,10 @@ TEST_F(TestComponentParser, parse_gpio_command_interface_descriptions_from_hardw
   const auto gpio_state_descriptions =
     parse_command_interface_descriptions(control_hardware[0].gpios);
   EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
 
   EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_vacuum");
-  EXPECT_EQ(gpio_state_descriptions[1].get_interface_type(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "vacuum");
   EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_vacuum/vacuum");
 }

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1404,3 +1404,113 @@ TEST_F(TestComponentParser, urdf_incomplete_throws_error)
     std::string(ros2_control_test_assets::urdf_tail);
   ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
 }
+
+TEST_F(TestComponentParser, parse_joint_state_interface_descriptions_from_hardware_info)
+{
+  const std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_multi_joints_transmission +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+
+  const auto joint_state_descriptions =
+    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].joints);
+  EXPECT_EQ(joint_state_descriptions[0].prefix_name, "joint1");
+  EXPECT_EQ(joint_state_descriptions[0].get_interface_type(), "position");
+  EXPECT_EQ(joint_state_descriptions[0].get_name(), "joint1/position");
+
+  EXPECT_EQ(joint_state_descriptions[1].prefix_name, "joint2");
+  EXPECT_EQ(joint_state_descriptions[1].get_interface_type(), "position");
+  EXPECT_EQ(joint_state_descriptions[1].get_name(), "joint2/position");
+}
+
+TEST_F(TestComponentParser, parse_joint_command_interface_descriptions_from_hardware_info)
+{
+  const std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_multi_joints_transmission +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+
+  const auto joint_command_descriptions =
+    parse_command_interface_descriptions_from_hardware_info(control_hardware[0].joints);
+  EXPECT_EQ(joint_command_descriptions[0].prefix_name, "joint1");
+  EXPECT_EQ(joint_command_descriptions[0].get_interface_type(), "position");
+  EXPECT_EQ(joint_command_descriptions[0].get_name(), "joint1/position");
+  EXPECT_EQ(joint_command_descriptions[0].interface_info.min, "-1");
+  EXPECT_EQ(joint_command_descriptions[0].interface_info.max, "1");
+
+  EXPECT_EQ(joint_command_descriptions[1].prefix_name, "joint2");
+  EXPECT_EQ(joint_command_descriptions[1].get_interface_type(), "position");
+  EXPECT_EQ(joint_command_descriptions[1].get_name(), "joint2/position");
+  EXPECT_EQ(joint_command_descriptions[1].interface_info.min, "-1");
+  EXPECT_EQ(joint_command_descriptions[1].interface_info.max, "1");
+}
+
+TEST_F(TestComponentParser, parse_sensor_state_interface_descriptions_from_hardware_info)
+{
+  const std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
+                                   ros2_control_test_assets::valid_urdf_ros2_control_sensor_only +
+                                   ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+
+  const auto sensor_state_descriptions =
+    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].sensors);
+  EXPECT_EQ(sensor_state_descriptions[0].prefix_name, "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[0].get_interface_type(), "roll");
+  EXPECT_EQ(sensor_state_descriptions[0].get_name(), "sensor1/roll");
+  EXPECT_EQ(sensor_state_descriptions[1].prefix_name, "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[1].get_interface_type(), "pitch");
+  EXPECT_EQ(sensor_state_descriptions[1].get_name(), "sensor1/pitch");
+  EXPECT_EQ(sensor_state_descriptions[2].prefix_name, "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[2].get_interface_type(), "yaw");
+  EXPECT_EQ(sensor_state_descriptions[2].get_name(), "sensor1/yaw");
+
+  EXPECT_EQ(sensor_state_descriptions[3].prefix_name, "sensor2");
+  EXPECT_EQ(sensor_state_descriptions[3].get_interface_type(), "image");
+  EXPECT_EQ(sensor_state_descriptions[3].get_name(), "sensor2/image");
+}
+
+TEST_F(TestComponentParser, parse_gpio_state_interface_descriptions_from_hardware_info)
+{
+  const std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_robot_with_gpio +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+
+  const auto gpio_state_descriptions =
+    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].gpios);
+  EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[1].get_interface_type(), "analog_input1");
+  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_analog_IOs/analog_input1");
+  EXPECT_EQ(gpio_state_descriptions[2].prefix_name, "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[2].get_interface_type(), "analog_input2");
+  EXPECT_EQ(gpio_state_descriptions[2].get_name(), "flange_analog_IOs/analog_input2");
+
+  EXPECT_EQ(gpio_state_descriptions[3].prefix_name, "flange_vacuum");
+  EXPECT_EQ(gpio_state_descriptions[3].get_interface_type(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[3].get_name(), "flange_vacuum/vacuum");
+}
+
+TEST_F(TestComponentParser, parse_gpio_command_interface_descriptions_from_hardware_info)
+{
+  const std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::valid_urdf_ros2_control_system_robot_with_gpio +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+
+  const auto gpio_state_descriptions =
+    parse_command_interface_descriptions_from_hardware_info(control_hardware[0].gpios);
+  EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
+
+  EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_vacuum");
+  EXPECT_EQ(gpio_state_descriptions[1].get_interface_type(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_vacuum/vacuum");
+}

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1414,7 +1414,7 @@ TEST_F(TestComponentParser, parse_joint_state_interface_descriptions_from_hardwa
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
 
   const auto joint_state_descriptions =
-    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].joints);
+    parse_state_interface_descriptions(control_hardware[0].joints);
   EXPECT_EQ(joint_state_descriptions[0].prefix_name, "joint1");
   EXPECT_EQ(joint_state_descriptions[0].get_interface_type(), "position");
   EXPECT_EQ(joint_state_descriptions[0].get_name(), "joint1/position");
@@ -1433,7 +1433,7 @@ TEST_F(TestComponentParser, parse_joint_command_interface_descriptions_from_hard
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
 
   const auto joint_command_descriptions =
-    parse_command_interface_descriptions_from_hardware_info(control_hardware[0].joints);
+    parse_command_interface_descriptions(control_hardware[0].joints);
   EXPECT_EQ(joint_command_descriptions[0].prefix_name, "joint1");
   EXPECT_EQ(joint_command_descriptions[0].get_interface_type(), "position");
   EXPECT_EQ(joint_command_descriptions[0].get_name(), "joint1/position");
@@ -1455,7 +1455,7 @@ TEST_F(TestComponentParser, parse_sensor_state_interface_descriptions_from_hardw
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
 
   const auto sensor_state_descriptions =
-    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].sensors);
+    parse_state_interface_descriptions(control_hardware[0].sensors);
   EXPECT_EQ(sensor_state_descriptions[0].prefix_name, "sensor1");
   EXPECT_EQ(sensor_state_descriptions[0].get_interface_type(), "roll");
   EXPECT_EQ(sensor_state_descriptions[0].get_name(), "sensor1/roll");
@@ -1480,7 +1480,7 @@ TEST_F(TestComponentParser, parse_gpio_state_interface_descriptions_from_hardwar
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
 
   const auto gpio_state_descriptions =
-    parse_state_interface_descriptions_from_hardware_info(control_hardware[0].gpios);
+    parse_state_interface_descriptions(control_hardware[0].gpios);
   EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
   EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
@@ -1505,7 +1505,7 @@ TEST_F(TestComponentParser, parse_gpio_command_interface_descriptions_from_hardw
   const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
 
   const auto gpio_state_descriptions =
-    parse_command_interface_descriptions_from_hardware_info(control_hardware[0].gpios);
+    parse_command_interface_descriptions(control_hardware[0].gpios);
   EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
   EXPECT_EQ(gpio_state_descriptions[0].get_interface_type(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1415,12 +1415,12 @@ TEST_F(TestComponentParser, parse_joint_state_interface_descriptions_from_hardwa
 
   const auto joint_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].joints);
-  EXPECT_EQ(joint_state_descriptions[0].prefix_name, "joint1");
-  EXPECT_EQ(joint_state_descriptions[0].get_name(), "position");
+  EXPECT_EQ(joint_state_descriptions[0].get_prefix_name(), "joint1");
+  EXPECT_EQ(joint_state_descriptions[0].get_interface_name(), "position");
   EXPECT_EQ(joint_state_descriptions[0].get_name(), "joint1/position");
 
-  EXPECT_EQ(joint_state_descriptions[1].prefix_name, "joint2");
-  EXPECT_EQ(joint_state_descriptions[1].get_name(), "position");
+  EXPECT_EQ(joint_state_descriptions[1].get_prefix_name(), "joint2");
+  EXPECT_EQ(joint_state_descriptions[1].get_interface_name(), "position");
   EXPECT_EQ(joint_state_descriptions[1].get_name(), "joint2/position");
 }
 
@@ -1434,14 +1434,14 @@ TEST_F(TestComponentParser, parse_joint_command_interface_descriptions_from_hard
 
   const auto joint_command_descriptions =
     parse_command_interface_descriptions(control_hardware[0].joints);
-  EXPECT_EQ(joint_command_descriptions[0].prefix_name, "joint1");
-  EXPECT_EQ(joint_command_descriptions[0].get_name(), "position");
+  EXPECT_EQ(joint_command_descriptions[0].get_prefix_name(), "joint1");
+  EXPECT_EQ(joint_command_descriptions[0].get_interface_name(), "position");
   EXPECT_EQ(joint_command_descriptions[0].get_name(), "joint1/position");
   EXPECT_EQ(joint_command_descriptions[0].interface_info.min, "-1");
   EXPECT_EQ(joint_command_descriptions[0].interface_info.max, "1");
 
-  EXPECT_EQ(joint_command_descriptions[1].prefix_name, "joint2");
-  EXPECT_EQ(joint_command_descriptions[1].get_name(), "position");
+  EXPECT_EQ(joint_command_descriptions[1].get_prefix_name(), "joint2");
+  EXPECT_EQ(joint_command_descriptions[1].get_interface_name(), "position");
   EXPECT_EQ(joint_command_descriptions[1].get_name(), "joint2/position");
   EXPECT_EQ(joint_command_descriptions[1].interface_info.min, "-1");
   EXPECT_EQ(joint_command_descriptions[1].interface_info.max, "1");
@@ -1456,18 +1456,18 @@ TEST_F(TestComponentParser, parse_sensor_state_interface_descriptions_from_hardw
 
   const auto sensor_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].sensors);
-  EXPECT_EQ(sensor_state_descriptions[0].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[0].get_name(), "roll");
+  EXPECT_EQ(sensor_state_descriptions[0].get_prefix_name(), "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[0].get_interface_name(), "roll");
   EXPECT_EQ(sensor_state_descriptions[0].get_name(), "sensor1/roll");
-  EXPECT_EQ(sensor_state_descriptions[1].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[1].get_name(), "pitch");
+  EXPECT_EQ(sensor_state_descriptions[1].get_prefix_name(), "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[1].get_interface_name(), "pitch");
   EXPECT_EQ(sensor_state_descriptions[1].get_name(), "sensor1/pitch");
-  EXPECT_EQ(sensor_state_descriptions[2].prefix_name, "sensor1");
-  EXPECT_EQ(sensor_state_descriptions[2].get_name(), "yaw");
+  EXPECT_EQ(sensor_state_descriptions[2].get_prefix_name(), "sensor1");
+  EXPECT_EQ(sensor_state_descriptions[2].get_interface_name(), "yaw");
   EXPECT_EQ(sensor_state_descriptions[2].get_name(), "sensor1/yaw");
 
-  EXPECT_EQ(sensor_state_descriptions[3].prefix_name, "sensor2");
-  EXPECT_EQ(sensor_state_descriptions[3].get_name(), "image");
+  EXPECT_EQ(sensor_state_descriptions[3].get_prefix_name(), "sensor2");
+  EXPECT_EQ(sensor_state_descriptions[3].get_interface_name(), "image");
   EXPECT_EQ(sensor_state_descriptions[3].get_name(), "sensor2/image");
 }
 
@@ -1481,18 +1481,18 @@ TEST_F(TestComponentParser, parse_gpio_state_interface_descriptions_from_hardwar
 
   const auto gpio_state_descriptions =
     parse_state_interface_descriptions(control_hardware[0].gpios);
-  EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_prefix_name(), "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[0].get_interface_name(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
-  EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "analog_input1");
+  EXPECT_EQ(gpio_state_descriptions[1].get_prefix_name(), "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[1].get_interface_name(), "analog_input1");
   EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_analog_IOs/analog_input1");
-  EXPECT_EQ(gpio_state_descriptions[2].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[2].get_name(), "analog_input2");
+  EXPECT_EQ(gpio_state_descriptions[2].get_prefix_name(), "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[2].get_interface_name(), "analog_input2");
   EXPECT_EQ(gpio_state_descriptions[2].get_name(), "flange_analog_IOs/analog_input2");
 
-  EXPECT_EQ(gpio_state_descriptions[3].prefix_name, "flange_vacuum");
-  EXPECT_EQ(gpio_state_descriptions[3].get_name(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[3].get_prefix_name(), "flange_vacuum");
+  EXPECT_EQ(gpio_state_descriptions[3].get_interface_name(), "vacuum");
   EXPECT_EQ(gpio_state_descriptions[3].get_name(), "flange_vacuum/vacuum");
 }
 
@@ -1506,11 +1506,11 @@ TEST_F(TestComponentParser, parse_gpio_command_interface_descriptions_from_hardw
 
   const auto gpio_state_descriptions =
     parse_command_interface_descriptions(control_hardware[0].gpios);
-  EXPECT_EQ(gpio_state_descriptions[0].prefix_name, "flange_analog_IOs");
-  EXPECT_EQ(gpio_state_descriptions[0].get_name(), "analog_output1");
+  EXPECT_EQ(gpio_state_descriptions[0].get_prefix_name(), "flange_analog_IOs");
+  EXPECT_EQ(gpio_state_descriptions[0].get_interface_name(), "analog_output1");
   EXPECT_EQ(gpio_state_descriptions[0].get_name(), "flange_analog_IOs/analog_output1");
 
-  EXPECT_EQ(gpio_state_descriptions[1].prefix_name, "flange_vacuum");
-  EXPECT_EQ(gpio_state_descriptions[1].get_name(), "vacuum");
+  EXPECT_EQ(gpio_state_descriptions[1].get_prefix_name(), "flange_vacuum");
+  EXPECT_EQ(gpio_state_descriptions[1].get_interface_name(), "vacuum");
   EXPECT_EQ(gpio_state_descriptions[1].get_name(), "flange_vacuum/vacuum");
 }

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -14,8 +14,11 @@
 
 #include <gmock/gmock.h>
 #include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
 
 using hardware_interface::CommandInterface;
+using hardware_interface::InterfaceDescription;
+using hardware_interface::InterfaceInfo;
 using hardware_interface::StateInterface;
 
 namespace
@@ -63,4 +66,32 @@ TEST(TestHandle, value_methods_work_on_non_nullptr)
   EXPECT_DOUBLE_EQ(handle.get_value(), value);
   EXPECT_NO_THROW(handle.set_value(0.0));
   EXPECT_DOUBLE_EQ(handle.get_value(), 0.0);
+}
+
+TEST(TestHandle, interface_description_state_interface_name_getters_work)
+{
+  const std::string POSITION_INTERFACE = "position";
+  const std::string JOINT_NAME_1 = "joint1";
+  InterfaceInfo info;
+  info.name = POSITION_INTERFACE;
+  InterfaceDescription interface_descr(JOINT_NAME_1, info);
+  StateInterface handle{interface_descr};
+
+  EXPECT_EQ(handle.get_name(), JOINT_NAME_1 + "/" + POSITION_INTERFACE);
+  EXPECT_EQ(handle.get_interface_name(), POSITION_INTERFACE);
+  EXPECT_EQ(handle.get_prefix_name(), JOINT_NAME_1);
+}
+
+TEST(TestHandle, interface_description_command_interface_name_getters_work)
+{
+  const std::string POSITION_INTERFACE = "position";
+  const std::string JOINT_NAME_1 = "joint1";
+  InterfaceInfo info;
+  info.name = POSITION_INTERFACE;
+  InterfaceDescription interface_descr(JOINT_NAME_1, info);
+  CommandInterface handle{interface_descr};
+
+  EXPECT_EQ(handle.get_name(), JOINT_NAME_1 + "/" + POSITION_INTERFACE);
+  EXPECT_EQ(handle.get_interface_name(), POSITION_INTERFACE);
+  EXPECT_EQ(handle.get_prefix_name(), JOINT_NAME_1);
 }


### PR DESCRIPTION
This PR is the second part of multiple breaking down #1240 in smaller changes. For an overview explanation and a lot of comments/discussion, please refer to #1240.
This prepares the handle to be constructed with a description of an Interface (InterfaceDescription). The old ways of creating a Command-/StateInterface is kept as is but deprecated.  If the Command-/StateInterface is constructed with the InterfaceDescription no pointer is given anymore but the pointer points to the internal storage of the handle. Variant is still only double and get/set is only available for double as well. One important thing here is that the internal value can not be practically used at this point, since the hardware has not access to the handle after exporting, so creating one with an InterfaceDescription is pointless at this time but will be useful in the next step.

**NOTE: Everything is fully backward compatible at this point. There is no change visible to Controllers. For Hardware there are changes visible (additional way of construction of the Handles) but not usable since they have no access to Handles after exporting. Tests are included. Demos can not be adapted since hw has no access to Handles at this point.**

- [ ] @Anyone: Please check if sufficiently tested in your opinion. Otherwise leave a comment.