### PR TITLE
Adapt controller Reference/StateInterfaces to New Way of Exporting (variant support)

### DIFF
--- a/controller_interface/include/controller_interface/chainable_controller_interface.hpp
+++ b/controller_interface/include/controller_interface/chainable_controller_interface.hpp
@@ -134,13 +134,20 @@ protected:
 
   /// Storage of values for state interfaces
   std::vector<std::string> exported_state_interface_names_;
+  std::vector<std::shared_ptr<hardware_interface::StateInterface>>
+    ordered_exported_state_interfaces_;
+  std::unordered_map<std::string, std::shared_ptr<hardware_interface::StateInterface>>
+    exported_state_interfaces_;
+  // BEGIN (Handle export change): for backward compatibility
   std::vector<double> state_interfaces_values_;
+  // END
 
   /// Storage of values for reference interfaces
   std::vector<std::string> exported_reference_interface_names_;
   // BEGIN (Handle export change): for backward compatibility
   std::vector<double> reference_interfaces_;
   // END
+  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> ordered_reference_interfaces_;
   std::unordered_map<std::string, std::shared_ptr<hardware_interface::CommandInterface>>
     reference_interfaces_ptrs_;
 

--- a/controller_interface/include/controller_interface/chainable_controller_interface.hpp
+++ b/controller_interface/include/controller_interface/chainable_controller_interface.hpp
@@ -15,7 +15,9 @@
 #ifndef CONTROLLER_INTERFACE__CHAINABLE_CONTROLLER_INTERFACE_HPP_
 #define CONTROLLER_INTERFACE__CHAINABLE_CONTROLLER_INTERFACE_HPP_
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "controller_interface/controller_interface_base.hpp"
@@ -57,10 +59,11 @@ public:
   bool is_chainable() const final;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() final;
+  std::vector<std::shared_ptr<hardware_interface::StateInterface>> export_state_interfaces() final;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<hardware_interface::CommandInterface> export_reference_interfaces() final;
+  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> export_reference_interfaces()
+    final;
 
   CONTROLLER_INTERFACE_PUBLIC
   bool set_chained_mode(bool chained_mode) final;
@@ -135,7 +138,11 @@ protected:
 
   /// Storage of values for reference interfaces
   std::vector<std::string> exported_reference_interface_names_;
+  // BEGIN (Handle export change): for backward compatibility
   std::vector<double> reference_interfaces_;
+  // END
+  std::unordered_map<std::string, std::shared_ptr<hardware_interface::CommandInterface>>
+    reference_interfaces_ptrs_;
 
 private:
   /// A flag marking if a chainable controller is currently preceded by another controller.

--- a/controller_interface/include/controller_interface/chainable_controller_interface.hpp
+++ b/controller_interface/include/controller_interface/chainable_controller_interface.hpp
@@ -59,11 +59,10 @@ public:
   bool is_chainable() const final;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<std::shared_ptr<hardware_interface::StateInterface>> export_state_interfaces() final;
+  std::vector<hardware_interface::StateInterface::SharedPtr> export_state_interfaces() final;
 
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> export_reference_interfaces()
-    final;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> export_reference_interfaces() final;
 
   CONTROLLER_INTERFACE_PUBLIC
   bool set_chained_mode(bool chained_mode) final;
@@ -134,9 +133,8 @@ protected:
 
   /// Storage of values for state interfaces
   std::vector<std::string> exported_state_interface_names_;
-  std::vector<std::shared_ptr<hardware_interface::StateInterface>>
-    ordered_exported_state_interfaces_;
-  std::unordered_map<std::string, std::shared_ptr<hardware_interface::StateInterface>>
+  std::vector<hardware_interface::StateInterface::SharedPtr> ordered_exported_state_interfaces_;
+  std::unordered_map<std::string, hardware_interface::StateInterface::SharedPtr>
     exported_state_interfaces_;
   // BEGIN (Handle export change): for backward compatibility
   std::vector<double> state_interfaces_values_;
@@ -147,8 +145,8 @@ protected:
   // BEGIN (Handle export change): for backward compatibility
   std::vector<double> reference_interfaces_;
   // END
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> ordered_reference_interfaces_;
-  std::unordered_map<std::string, std::shared_ptr<hardware_interface::CommandInterface>>
+  std::vector<hardware_interface::CommandInterface::SharedPtr> ordered_reference_interfaces_;
+  std::unordered_map<std::string, hardware_interface::CommandInterface::SharedPtr>
     reference_interfaces_ptrs_;
 
 private:

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -47,7 +47,7 @@ public:
    * \returns empty list.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<hardware_interface::StateInterface> export_state_interfaces() final;
+  std::vector<std::shared_ptr<hardware_interface::StateInterface>> export_state_interfaces() final;
 
   /**
    * Controller has no reference interfaces.
@@ -55,7 +55,8 @@ public:
    * \returns empty list.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<hardware_interface::CommandInterface> export_reference_interfaces() final;
+  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> export_reference_interfaces()
+    final;
 
   /**
    * Controller is not chainable, therefore no chained mode can be set.

--- a/controller_interface/include/controller_interface/controller_interface.hpp
+++ b/controller_interface/include/controller_interface/controller_interface.hpp
@@ -47,7 +47,7 @@ public:
    * \returns empty list.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<std::shared_ptr<hardware_interface::StateInterface>> export_state_interfaces() final;
+  std::vector<hardware_interface::StateInterface::SharedPtr> export_state_interfaces() final;
 
   /**
    * Controller has no reference interfaces.
@@ -55,8 +55,7 @@ public:
    * \returns empty list.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> export_reference_interfaces()
-    final;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> export_reference_interfaces() final;
 
   /**
    * Controller is not chainable, therefore no chained mode can be set.

--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -235,7 +235,8 @@ public:
    * \returns list of command interfaces for preceding controllers.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  virtual std::vector<hardware_interface::CommandInterface> export_reference_interfaces() = 0;
+  virtual std::vector<std::shared_ptr<hardware_interface::CommandInterface>>
+  export_reference_interfaces() = 0;
 
   /**
    * Export interfaces for a chainable controller that can be used as state interface by other
@@ -244,7 +245,8 @@ public:
    * \returns list of state interfaces for preceding controllers.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  virtual std::vector<hardware_interface::StateInterface> export_state_interfaces() = 0;
+  virtual std::vector<std::shared_ptr<hardware_interface::StateInterface>>
+  export_state_interfaces() = 0;
 
   /**
    * Set chained mode of a chainable controller. This method triggers internal processes to switch

--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -235,7 +235,7 @@ public:
    * \returns list of command interfaces for preceding controllers.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  virtual std::vector<std::shared_ptr<hardware_interface::CommandInterface>>
+  virtual std::vector<hardware_interface::CommandInterface::SharedPtr>
   export_reference_interfaces() = 0;
 
   /**
@@ -245,8 +245,7 @@ public:
    * \returns list of state interfaces for preceding controllers.
    */
   CONTROLLER_INTERFACE_PUBLIC
-  virtual std::vector<std::shared_ptr<hardware_interface::StateInterface>>
-  export_state_interfaces() = 0;
+  virtual std::vector<hardware_interface::StateInterface::SharedPtr> export_state_interfaces() = 0;
 
   /**
    * Set chained mode of a chainable controller. This method triggers internal processes to switch

--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -107,8 +107,6 @@ ChainableControllerInterface::export_reference_interfaces()
   // check if the "reference_interfaces_" variable is resized to number of interfaces
   if (reference_interfaces_.size() != reference_interfaces.size())
   {
-    // TODO(destogl): Should here be "FATAL"? It is fatal in terms of controller but not for the
-    // framework
     std::string error_msg =
       "The internal storage for reference values 'reference_interfaces_' variable has size '" +
       std::to_string(reference_interfaces_.size()) + "', but it is expected to have the size '" +

--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -44,11 +44,11 @@ return_type ChainableControllerInterface::update(
   return ret;
 }
 
-std::vector<std::shared_ptr<hardware_interface::StateInterface>>
+std::vector<hardware_interface::StateInterface::SharedPtr>
 ChainableControllerInterface::export_state_interfaces()
 {
   auto state_interfaces = on_export_state_interfaces();
-  std::vector<std::shared_ptr<hardware_interface::StateInterface>> state_interfaces_ptrs_vec;
+  std::vector<hardware_interface::StateInterface::SharedPtr> state_interfaces_ptrs_vec;
   state_interfaces_ptrs_vec.reserve(state_interfaces.size());
   ordered_exported_state_interfaces_.reserve(state_interfaces.size());
   exported_state_interface_names_.reserve(state_interfaces.size());
@@ -94,11 +94,11 @@ ChainableControllerInterface::export_state_interfaces()
   return state_interfaces_ptrs_vec;
 }
 
-std::vector<std::shared_ptr<hardware_interface::CommandInterface>>
+std::vector<hardware_interface::CommandInterface::SharedPtr>
 ChainableControllerInterface::export_reference_interfaces()
 {
   auto reference_interfaces = on_export_reference_interfaces();
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> reference_interfaces_ptrs_vec;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> reference_interfaces_ptrs_vec;
   reference_interfaces_ptrs_vec.reserve(reference_interfaces.size());
   exported_reference_interface_names_.reserve(reference_interfaces.size());
   ordered_reference_interfaces_.reserve(reference_interfaces.size());
@@ -134,7 +134,7 @@ ChainableControllerInterface::export_reference_interfaces()
       throw std::runtime_error(error_msg);
     }
 
-    std::shared_ptr<hardware_interface::CommandInterface> reference_interface =
+    hardware_interface::CommandInterface::SharedPtr reference_interface =
       std::make_shared<hardware_interface::CommandInterface>(std::move(interface));
     const auto inteface_name = reference_interface->get_name();
     // check the exported interface name is unique

--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -68,14 +68,14 @@ ChainableControllerInterface::export_state_interfaces()
     }
     auto state_interface = std::make_shared<hardware_interface::StateInterface>(interface);
     const auto interface_name = state_interface->get_name();
-    auto [it, succ] = exported_state_interfaces_.insert({inteface_name, state_interface});
+    auto [it, succ] = exported_state_interfaces_.insert({interface_name, state_interface});
     // either we have name duplicate which we want to avoid under all circumstances since interfaces
     // need to be uniquely identify able or something else really went wrong. In any case abort and
     // inform cm by throwing exception
     if (!succ)
     {
       std::string error_msg =
-        "Could not insert StateInterface<" + inteface_name +
+        "Could not insert StateInterface<" + interface_name +
         "> into exported_state_interfaces_ map. Check if you export duplicates. The "
         "map returned iterator with interface_name<" +
         it->second->get_name() +

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -22,12 +22,14 @@ ControllerInterface::ControllerInterface() : ControllerInterfaceBase() {}
 
 bool ControllerInterface::is_chainable() const { return false; }
 
-std::vector<hardware_interface::StateInterface> ControllerInterface::export_state_interfaces()
+std::vector<std::shared_ptr<hardware_interface::StateInterface>>
+ControllerInterface::export_state_interfaces()
 {
   return {};
 }
 
-std::vector<hardware_interface::CommandInterface> ControllerInterface::export_reference_interfaces()
+std::vector<std::shared_ptr<hardware_interface::CommandInterface>>
+ControllerInterface::export_reference_interfaces()
 {
   return {};
 }

--- a/controller_interface/src/controller_interface.cpp
+++ b/controller_interface/src/controller_interface.cpp
@@ -22,13 +22,13 @@ ControllerInterface::ControllerInterface() : ControllerInterfaceBase() {}
 
 bool ControllerInterface::is_chainable() const { return false; }
 
-std::vector<std::shared_ptr<hardware_interface::StateInterface>>
+std::vector<hardware_interface::StateInterface::SharedPtr>
 ControllerInterface::export_state_interfaces()
 {
   return {};
 }
 
-std::vector<std::shared_ptr<hardware_interface::CommandInterface>>
+std::vector<hardware_interface::CommandInterface::SharedPtr>
 ControllerInterface::export_reference_interfaces()
 {
   return {};

--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -15,6 +15,7 @@
 #include "test_chainable_controller_interface.hpp"
 
 #include <gmock/gmock.h>
+#include <memory>
 
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
@@ -48,10 +49,10 @@ TEST_F(ChainableControllerInterfaceTest, export_state_interfaces)
   auto exported_state_interfaces = controller.export_state_interfaces();
 
   ASSERT_THAT(exported_state_interfaces, SizeIs(1));
-  EXPECT_EQ(exported_state_interfaces[0].get_prefix_name(), TEST_CONTROLLER_NAME);
-  EXPECT_EQ(exported_state_interfaces[0].get_interface_name(), "test_state");
+  EXPECT_EQ(exported_state_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);
+  EXPECT_EQ(exported_state_interfaces[0]->get_interface_name(), "test_state");
 
-  EXPECT_EQ(exported_state_interfaces[0].get_value(), EXPORTED_STATE_INTERFACE_VALUE);
+  EXPECT_EQ(exported_state_interfaces[0]->get_value(), EXPORTED_STATE_INTERFACE_VALUE);
 }
 
 TEST_F(ChainableControllerInterfaceTest, export_reference_interfaces)
@@ -68,10 +69,10 @@ TEST_F(ChainableControllerInterfaceTest, export_reference_interfaces)
   auto reference_interfaces = controller.export_reference_interfaces();
 
   ASSERT_THAT(reference_interfaces, SizeIs(1));
-  EXPECT_EQ(reference_interfaces[0].get_prefix_name(), TEST_CONTROLLER_NAME);
-  EXPECT_EQ(reference_interfaces[0].get_interface_name(), "test_itf");
+  EXPECT_EQ(reference_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);
+  EXPECT_EQ(reference_interfaces[0]->get_interface_name(), "test_itf");
 
-  EXPECT_EQ(reference_interfaces[0].get_value(), INTERFACE_VALUE);
+  EXPECT_EQ(reference_interfaces[0]->get_value(), INTERFACE_VALUE);
 }
 
 TEST_F(ChainableControllerInterfaceTest, interfaces_prefix_is_not_node_name)
@@ -88,10 +89,15 @@ TEST_F(ChainableControllerInterfaceTest, interfaces_prefix_is_not_node_name)
   controller.set_name_prefix_of_reference_interfaces("some_not_correct_interface_prefix");
 
   // expect empty return because interface prefix is not equal to the node name
-  auto reference_interfaces = controller.export_reference_interfaces();
-  ASSERT_THAT(reference_interfaces, IsEmpty());
+  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> exported_reference_interfaces;
+  EXPECT_THROW(
+    { exported_reference_interfaces = controller.export_reference_interfaces(); },
+    std::runtime_error);
+  ASSERT_THAT(exported_reference_interfaces, IsEmpty());
   // expect empty return because interface prefix is not equal to the node name
-  auto exported_state_interfaces = controller.export_state_interfaces();
+  std::vector<std::shared_ptr<hardware_interface::StateInterface>> exported_state_interfaces;
+  EXPECT_THROW(
+    { exported_state_interfaces = controller.export_state_interfaces(); }, std::runtime_error);
   ASSERT_THAT(exported_state_interfaces, IsEmpty());
 }
 
@@ -114,8 +120,7 @@ TEST_F(ChainableControllerInterfaceTest, setting_chained_mode)
   EXPECT_FALSE(controller.is_in_chained_mode());
 
   // Fail setting chained mode
-  EXPECT_EQ(reference_interfaces[0].get_value(), INTERFACE_VALUE);
-  EXPECT_EQ(exported_state_interfaces[0].get_value(), EXPORTED_STATE_INTERFACE_VALUE);
+  EXPECT_EQ(reference_interfaces[0]->get_value(), INTERFACE_VALUE);
 
   EXPECT_FALSE(controller.set_chained_mode(true));
   EXPECT_FALSE(controller.is_in_chained_mode());
@@ -124,11 +129,11 @@ TEST_F(ChainableControllerInterfaceTest, setting_chained_mode)
   EXPECT_FALSE(controller.is_in_chained_mode());
 
   // Success setting chained mode
-  reference_interfaces[0].set_value(0.0);
+  reference_interfaces[0]->set_value(0.0);
 
   EXPECT_TRUE(controller.set_chained_mode(true));
   EXPECT_TRUE(controller.is_in_chained_mode());
-  EXPECT_EQ(exported_state_interfaces[0].get_value(), EXPORTED_STATE_INTERFACE_VALUE_IN_CHAINMODE);
+  EXPECT_EQ(exported_state_interfaces[0]->get_value(), EXPORTED_STATE_INTERFACE_VALUE_IN_CHAINMODE);
 
   controller.configure();
   EXPECT_TRUE(controller.set_chained_mode(false));

--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -89,13 +89,13 @@ TEST_F(ChainableControllerInterfaceTest, interfaces_prefix_is_not_node_name)
   controller.set_name_prefix_of_reference_interfaces("some_not_correct_interface_prefix");
 
   // expect empty return because interface prefix is not equal to the node name
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> exported_reference_interfaces;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> exported_reference_interfaces;
   EXPECT_THROW(
     { exported_reference_interfaces = controller.export_reference_interfaces(); },
     std::runtime_error);
   ASSERT_THAT(exported_reference_interfaces, IsEmpty());
   // expect empty return because interface prefix is not equal to the node name
-  std::vector<std::shared_ptr<hardware_interface::StateInterface>> exported_state_interfaces;
+  std::vector<hardware_interface::StateInterface::SharedPtr> exported_state_interfaces;
   EXPECT_THROW(
     { exported_state_interfaces = controller.export_state_interfaces(); }, std::runtime_error);
   ASSERT_THAT(exported_state_interfaces, IsEmpty());

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -771,15 +771,28 @@ controller_interface::return_type ControllerManager::configure_controller(
       get_logger(),
       "Controller '%s' is chainable. Interfaces are being exported to resource manager.",
       controller_name.c_str());
-    auto state_interfaces = controller->export_state_interfaces();
-    auto ref_interfaces = controller->export_reference_interfaces();
-    if (ref_interfaces.empty() && state_interfaces.empty())
+    std::vector<std::shared_ptr<hardware_interface::StateInterface>> state_interfaces;
+    std::vector<std::shared_ptr<hardware_interface::CommandInterface>> ref_interfaces;
+    try
     {
-      // TODO(destogl): Add test for this!
-      RCLCPP_ERROR(
-        get_logger(),
-        "Controller '%s' is chainable, but does not export any state or reference interfaces.",
-        controller_name.c_str());
+      state_interfaces = controller->export_state_interfaces();
+      ref_interfaces = controller->export_reference_interfaces();
+      if (ref_interfaces.empty() && state_interfaces.empty())
+      {
+        // TODO(destogl): Add test for this!
+        RCLCPP_ERROR(
+          get_logger(),
+          "Controller '%s' is chainable, but does not export any reference interfaces. Did you "
+          "override the on_export_method() correctly?",
+          controller_name.c_str());
+        return controller_interface::return_type::ERROR;
+      }
+    }
+    catch (const std::runtime_error & e)
+    {
+      RCLCPP_FATAL(
+        get_logger(), "Creation of the reference interfaces failed with following error: %s",
+        e.what());
       return controller_interface::return_type::ERROR;
     }
     resource_manager_->import_controller_reference_interfaces(controller_name, ref_interfaces);

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -771,8 +771,8 @@ controller_interface::return_type ControllerManager::configure_controller(
       get_logger(),
       "Controller '%s' is chainable. Interfaces are being exported to resource manager.",
       controller_name.c_str());
-    std::vector<std::shared_ptr<hardware_interface::StateInterface>> state_interfaces;
-    std::vector<std::shared_ptr<hardware_interface::CommandInterface>> ref_interfaces;
+    std::vector<hardware_interface::StateInterface::SharedPtr> state_interfaces;
+    std::vector<hardware_interface::CommandInterface::SharedPtr> ref_interfaces;
     try
     {
       state_interfaces = controller->export_state_interfaces();

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -28,13 +28,20 @@ class LoanedCommandInterface
 public:
   using Deleter = std::function<void(void)>;
 
-  explicit LoanedCommandInterface(CommandInterface & command_interface)
+  [[deprecated("Replaced by the new version using shared_ptr")]] explicit LoanedCommandInterface(
+    CommandInterface & command_interface)
   : LoanedCommandInterface(command_interface, nullptr)
   {
   }
 
-  LoanedCommandInterface(CommandInterface & command_interface, Deleter && deleter)
+  [[deprecated("Replaced by the new version using shared_ptr")]] LoanedCommandInterface(
+    CommandInterface & command_interface, Deleter && deleter)
   : command_interface_(command_interface), deleter_(std::forward<Deleter>(deleter))
+  {
+  }
+
+  LoanedCommandInterface(CommandInterface::SharedPtr command_interface, Deleter && deleter)
+  : command_interface_(*command_interface), deleter_(std::forward<Deleter>(deleter))
   {
   }
 

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -40,6 +40,11 @@ public:
   {
   }
 
+  LoanedStateInterface(StateInterface::SharedPtr state_interface)
+  : LoanedStateInterface(state_interface, nullptr)
+  {
+  }
+
   LoanedStateInterface(StateInterface::SharedPtr state_interface, Deleter && deleter)
   : state_interface_(*state_interface), deleter_(std::forward<Deleter>(deleter))
   {

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -28,13 +28,20 @@ class LoanedStateInterface
 public:
   using Deleter = std::function<void(void)>;
 
-  explicit LoanedStateInterface(StateInterface & state_interface)
+  [[deprecated("Replaced by the new version using shared_ptr")]] explicit LoanedStateInterface(
+    StateInterface & state_interface)
   : LoanedStateInterface(state_interface, nullptr)
   {
   }
 
-  LoanedStateInterface(StateInterface & state_interface, Deleter && deleter)
+  [[deprecated("Replaced by the new version using shared_ptr")]] LoanedStateInterface(
+    StateInterface & state_interface, Deleter && deleter)
   : state_interface_(state_interface), deleter_(std::forward<Deleter>(deleter))
+  {
+  }
+
+  LoanedStateInterface(StateInterface::SharedPtr state_interface, Deleter && deleter)
+  : state_interface_(*state_interface), deleter_(std::forward<Deleter>(deleter))
   {
   }
 

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -40,7 +40,7 @@ public:
   {
   }
 
-  LoanedStateInterface(StateInterface::SharedPtr state_interface)
+  explicit LoanedStateInterface(StateInterface::SharedPtr state_interface)
   : LoanedStateInterface(state_interface, nullptr)
   {
   }

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -141,7 +141,7 @@ public:
    * \param[in] interfaces list of controller's state interfaces as StateInterfaces.
    */
   void import_controller_exported_state_interfaces(
-    const std::string & controller_name, std::vector<std::shared_ptr<StateInterface>> & interfaces);
+    const std::string & controller_name, std::vector<StateInterface::SharedPtr> & interfaces);
 
   /// Get list of exported tate interface of a controller.
   /**

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -141,7 +141,7 @@ public:
    * \param[in] interfaces list of controller's state interfaces as StateInterfaces.
    */
   void import_controller_exported_state_interfaces(
-    const std::string & controller_name, std::vector<StateInterface> & interfaces);
+    const std::string & controller_name, std::vector<std::shared_ptr<StateInterface>> & interfaces);
 
   /// Get list of exported tate interface of a controller.
   /**
@@ -195,7 +195,7 @@ public:
    */
   void import_controller_reference_interfaces(
     const std::string & controller_name,
-    std::vector<hardware_interface::CommandInterface> & interfaces);
+    const std::vector<hardware_interface::CommandInterface::SharedPtr> & interfaces);
 
   /// Get list of reference interface of a controller.
   /**

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -656,10 +656,10 @@ public:
   {
     try
     {
-      std::vector<CommandInterface::SharedPtr> interfaces = hardware.export_command_interfaces();
-
+      auto interfaces = hardware.export_command_interfaces();
       hardware_info_map_[hardware.get_name()].command_interfaces =
         add_command_interfaces(interfaces);
+      // TODO(Manuel) END: for backward compatibility
     }
     catch (const std::exception & ex)
     {
@@ -1241,16 +1241,10 @@ bool ResourceManager::state_interface_is_available(const std::string & name) con
 
 // CM API: Called in "callback/slow"-thread
 void ResourceManager::import_controller_exported_state_interfaces(
-  const std::string & controller_name, std::vector<StateInterface> & interfaces)
+  const std::string & controller_name, std::vector<std::shared_ptr<StateInterface>> & interfaces)
 {
   std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
-  std::vector<StateInterface::SharedPtr> interface_ptrs;
-  interface_ptrs.reserve(interfaces.size());
-  for (auto & interface : interfaces)
-  {
-    interface_ptrs.push_back(std::make_shared<StateInterface>(interface));
-  }
-  auto interface_names = resource_storage_->add_state_interfaces(interface_ptrs);
+  auto interface_names = resource_storage_->add_state_interfaces(interfaces);
   resource_storage_->controllers_exported_state_interfaces_map_[controller_name] = interface_names;
 }
 
@@ -1310,16 +1304,10 @@ void ResourceManager::remove_controller_exported_state_interfaces(
 // CM API: Called in "callback/slow"-thread
 void ResourceManager::import_controller_reference_interfaces(
   const std::string & controller_name,
-  std::vector<hardware_interface::CommandInterface> & interfaces)
+  const std::vector<hardware_interface::CommandInterface::SharedPtr> & interfaces)
 {
   std::scoped_lock guard(resource_interfaces_lock_, claimed_command_interfaces_lock_);
-  std::vector<CommandInterface::SharedPtr> interface_ptrs;
-  interface_ptrs.reserve(interfaces.size());
-  for (auto & interface : interfaces)
-  {
-    interface_ptrs.push_back(std::make_shared<CommandInterface>(std::move(interface)));
-  }
-  auto interface_names = resource_storage_->add_command_interfaces(interface_ptrs);
+  auto interface_names = resource_storage_->add_command_interfaces(interfaces);
   resource_storage_->controllers_reference_interfaces_map_[controller_name] = interface_names;
 }
 

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1241,7 +1241,7 @@ bool ResourceManager::state_interface_is_available(const std::string & name) con
 
 // CM API: Called in "callback/slow"-thread
 void ResourceManager::import_controller_exported_state_interfaces(
-  const std::string & controller_name, std::vector<std::shared_ptr<StateInterface>> & interfaces)
+  const std::string & controller_name, std::vector<StateInterface::SharedPtr> & interfaces)
 {
   std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
   auto interface_names = resource_storage_->add_state_interfaces(interfaces);

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1207,7 +1207,7 @@ LoanedStateInterface ResourceManager::claim_state_interface(const std::string & 
   }
 
   std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
-  return LoanedStateInterface(*(resource_storage_->state_interface_map_.at(key)));
+  return LoanedStateInterface(resource_storage_->state_interface_map_.at(key));
 }
 
 // CM API: Called in "callback/slow"-thread
@@ -1440,7 +1440,7 @@ LoanedCommandInterface ResourceManager::claim_command_interface(const std::strin
   resource_storage_->claimed_command_interface_map_[key] = true;
   std::lock_guard<std::recursive_mutex> guard(resource_interfaces_lock_);
   return LoanedCommandInterface(
-    *(resource_storage_->command_interface_map_.at(key)),
+    resource_storage_->command_interface_map_.at(key),
     std::bind(&ResourceManager::release_command_interface, this, key));
 }
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1230,12 +1230,12 @@ TEST_F(ResourceManagerTest, managing_controllers_reference_interfaces)
     CONTROLLER_NAME + "/" + REFERENCE_INTERFACE_NAMES[1],
     CONTROLLER_NAME + "/" + REFERENCE_INTERFACE_NAMES[2]};
 
-  std::vector<hardware_interface::CommandInterface> reference_interfaces;
+  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> reference_interfaces;
   std::vector<double> reference_interface_values = {1.0, 2.0, 3.0};
 
   for (size_t i = 0; i < REFERENCE_INTERFACE_NAMES.size(); ++i)
   {
-    reference_interfaces.push_back(hardware_interface::CommandInterface(
+    reference_interfaces.push_back(std::make_shared<hardware_interface::CommandInterface>(
       CONTROLLER_NAME, REFERENCE_INTERFACE_NAMES[i], &(reference_interface_values[i])));
   }
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1230,7 +1230,7 @@ TEST_F(ResourceManagerTest, managing_controllers_reference_interfaces)
     CONTROLLER_NAME + "/" + REFERENCE_INTERFACE_NAMES[1],
     CONTROLLER_NAME + "/" + REFERENCE_INTERFACE_NAMES[2]};
 
-  std::vector<std::shared_ptr<hardware_interface::CommandInterface>> reference_interfaces;
+  std::vector<hardware_interface::CommandInterface::SharedPtr> reference_interfaces;
   std::vector<double> reference_interface_values = {1.0, 2.0, 3.0};
 
   for (size_t i = 0; i < REFERENCE_INTERFACE_NAMES.size(); ++i)


### PR DESCRIPTION
This PR is the fith and last part of multiple breaking down #1240 in smaller changes. For an overview explanation and a lot of comments/discussion, please refer to #1240.
This PR adapts the controller interface to the new way of exporting Reference and StateInterfaces. ReferenceInterfaces now are created as shared_ptr and shared to controller manager as shared_ptr. The memory is still allocated in the controller (old way) but a unordered_map for the interfaces is added.

* Needs https://github.com/ros-controls/ros2_controllers/pull/1103 to be merged as well

**NOTE: Everything is fully backward compatible at this point. At this point variant supports only double at this point.**