### PR TITLE
Fix spawner tests timeout on source builds

### DIFF
--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -255,6 +255,7 @@ TEST_F(TestLoadController, spawner_test_type_in_params_file)
   const std::string test_file_path = ament_index_cpp::get_package_prefix("controller_manager") +
                                      "/test/test_controller_spawner_with_type.yaml";
 
+  ControllerManagerRunner cm_runner(this);
   // Provide controller type via the parsed file
   EXPECT_EQ(
     call_spawner(
@@ -306,6 +307,7 @@ TEST_F(TestLoadController, unload_on_kill)
 {
   // Launch spawner with unload on kill
   // timeout command will kill it after the specified time with signal SIGINT
+  ControllerManagerRunner cm_runner(this);
   cm_->set_parameter(rclcpp::Parameter("ctrl_3.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
   std::stringstream ss;
   ss << "timeout --signal=INT 5 "
@@ -629,6 +631,7 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
   const std::string test_file_path = ament_index_cpp::get_package_prefix("controller_manager") +
                                      "/test/test_controller_spawner_with_type.yaml";
 
+  ControllerManagerRunner cm_runner(this);
   // Provide controller type via the parsed file
   EXPECT_EQ(
     call_spawner(
@@ -689,6 +692,7 @@ TEST_F(
   const std::string test_file_path = ament_index_cpp::get_package_prefix("controller_manager") +
                                      "/test/test_controller_spawner_with_type.yaml";
 
+  ControllerManagerRunner cm_runner(this);
   // Provide controller type via the parsed file
   EXPECT_EQ(
     call_spawner(


### PR DESCRIPTION
As reported by @christophfroehlich in https://github.com/ros-controls/ros2_control/issues/1685, it seems that spawner tests are inconsistent and timing out after some time. I was able to reproduce it locally and upon checking it seems like the CM's internal mutexes are blcoking as there is no ControllerManagerRunner in some of these tests. Adding these should fix the above timeout issues. I've tested it locally and it seems to work

Fixes #1685 