### PR TITLE
Fix params_file typo in spawner and update release notes for use_global_arguments

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -174,12 +174,11 @@ public:
   {
 // \note The versions conditioning is added here to support the source-compatibility with Humble
 #if RCLCPP_VERSION_MAJOR >= 21
-    return rclcpp::NodeOptions().enable_logger_service(true).use_global_arguments(false);
+    return rclcpp::NodeOptions().enable_logger_service(true);
 #else
     return rclcpp::NodeOptions()
       .allow_undeclared_parameters(true)
-      .automatically_declare_parameters_from_overrides(true)
-      .use_global_arguments(false);
+      .automatically_declare_parameters_from_overrides(true);
 #endif
   }
 

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -312,7 +312,7 @@ def set_controller_parameters_from_param_file(
     if parameter_file:
         spawner_namespace = namespace if namespace else node.get_namespace()
         set_controller_parameters(
-            node, controller_manager_name, controller_name, "param_file", parameter_file
+            node, controller_manager_name, controller_name, "params_file", parameter_file
         )
 
         controller_type = get_parameter_from_param_file(

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2843,6 +2843,7 @@ rclcpp::NodeOptions ControllerManager::determine_controller_node_options(
   }
 
   controller_node_options = controller_node_options.arguments(node_options_arguments);
+  controller_node_options.use_global_arguments(false);
   return controller_node_options;
 }
 

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -2,6 +2,10 @@
 
 Iron to Jazzy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+controller_interface
+********************
+* The changes from `(PR #1694) <https://github.com/ros-controls/ros2_control/pull/1694>`__ will affect how the controllers will be loading the parameters. Defining parameters in a single yaml file and loading it to the controller_manager node alone will no longer work.
+  In order to load the parameters to the controllers properly, it is needed to use ``--param-file`` option from the spawner. This is because the controllers will now set ``use_global_arguments`` from NodeOptions to false, to avoid getting influenced by global arguments.
 
 controller_manager
 ******************

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,8 @@ For details see the controller_manager section.
 * A method to get node options to setup the controller node #api-breaking (`#1169 <https://github.com/ros-controls/ros2_control/pull/1169>`_)
 * Export state interfaces from the chainable controller #api-breaking (`#1021 <https://github.com/ros-controls/ros2_control/pull/1021>`_)
 * All chainable controllers must implement the method ``export_state_interfaces`` to export the state interfaces, similar to ``export_reference_interfaces`` method that is exporting the reference interfaces.
+* The controllers will now set ``use_global_arguments`` from NodeOptions to false, to avoid getting influenced by global arguments (Issue : `#1684 <https://github.com/ros-controls/ros2_control/issues/1684>`_) (`#1694 <https://github.com/ros-controls/ros2_control/pull/1694>`_).
+  From now on, in order to set the parameters to the controller, the ``--param-file`` option from spawner should be used.
 
 controller_manager
 ******************


### PR DESCRIPTION
The typo was introduced in https://github.com/ros-controls/ros2_control/pull/1661

https://github.com/ros-controls/ros2_control/blob/4498d25ff7cfdc40780a34b36cf4d1fea40f7521/controller_manager/src/controller_manager.cpp#L484-L495

Fixes: https://github.com/ros-controls/ros2_control_ci/issues/118
Fixes: https://github.com/ros-controls/ros2_control_ci/issues/119
Fixes: https://github.com/ros-controls/ros2_control_ci/issues/120
Fixes: https://github.com/ros-controls/ros2_control_ci/issues/121
Fixes: https://github.com/ros-controls/ros2_control_demos/issues/569
Fixes: https://github.com/ros-controls/ros2_control_demos/issues/570
Fixes: https://github.com/ros-controls/ros2_control_demos/issues/571
Fixes: https://github.com/ros-controls/ros2_control_demos/issues/572