### PR TITLE
Fix spam of logs on failed hardware component initialization

### DIFF
--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -247,6 +247,7 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
     return return_type::OK;
   }
   if (
+    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {
@@ -277,6 +278,7 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
     return return_type::OK;
   }
   if (
+    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -225,6 +225,7 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
     return return_type::OK;
   }
   if (
+    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -243,6 +243,7 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
     return return_type::OK;
   }
   if (
+    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {
@@ -273,6 +274,7 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
     return return_type::OK;
   }
   if (
+    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
   {


### PR DESCRIPTION
When the hardware component fails, it continues to stay in the UNKNOWN lifecycle state, if the state is other than the UNCONFIGURED or FINALIZED the return_type is ERROR as default and then replaced by the outcome from read and write method. So, returning ERROR, makes it continuously spam with the following logs

https://github.com/ros-controls/ros2_control/blob/8f7374faf482e83c94c0a477bfbe8b2e672f241c/controller_manager/src/controller_manager.cpp#L2178-L2181

https://github.com/ros-controls/ros2_control/blob/8f7374faf482e83c94c0a477bfbe8b2e672f241c/controller_manager/src/controller_manager.cpp#L2359-L2363

```
[ros2_control_node-2] [INFO] [1724675998.045345227] [controller_manager.resource_manager]: Loaded hardware 'ros2_control_tiago_system' from plugin 'robot_control/RobotControl'
[ros2_control_node-2] [INFO] [1724675998.045399502] [controller_manager.resource_manager]: Initialize hardware 'ros2_control_tiago_system' 
[ros2_control_node-2] [ERROR] [1724675999.154326093] [controller_manager.resource_manager]: Exception occurred while initializing hardware 'ros2_control_tiago_system': std::bad_alloc
[ros2_control_node-2] [WARN] [1724675999.158483059] [controller_manager.resource_manager]: System hardware component 'ros2_control_tiago_system' from plugin 'robot_control/RobotControl' failed to initialize.
[ros2_control_node-2] [ERROR] [1724675999.162434111] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.162489926] [controller_manager]: Deactivating following hardware components as their write cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.172426457] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.172483207] [controller_manager]: Deactivating following hardware components as their write cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.182431039] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.182491207] [controller_manager]: Deactivating following hardware components as their write cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.192426473] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.192488350] [controller_manager]: Deactivating following hardware components as their write cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.202426093] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.202480027] [controller_manager]: Deactivating following hardware components as their write cycle resulted in an error: [ ros2_control_tiago_system ]
[ros2_control_node-2] [ERROR] [1724675999.212425084] [controller_manager]: Deactivating following hardware components as their read cycle resulted in an error: [ ros2_control_tiago_system ]
````
This PR proposes fix for the above issue