### PR TITLE
[Spawner] Add support for wildcard entries in the controller param files 

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -262,6 +262,10 @@ def get_parameter_from_param_file(controller_name, namespace, parameter_file, pa
             f"{WILDCARD_KEY}/{namespaced_controller}",
         ]:
             if key in parameters:
+                if key == controller_name and controller_name != namespaced_controller:
+                    raise RuntimeError(
+                        f"YAML file : {parameter_file} is not a valid ROS parameter file for controller node : {namespaced_controller}"
+                    )
                 controller_param_dict = parameters[key]
                 break
             if WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:

--- a/controller_manager/test/test_controller_spawner_with_type.yaml
+++ b/controller_manager/test/test_controller_spawner_with_type.yaml
@@ -3,25 +3,40 @@ ctrl_with_parameters_and_type:
     type: "controller_manager/test_controller"
     joint_names: ["joint0"]
 
-chainable_ctrl_with_parameters_and_type:
-  ros__parameters:
-    type: "controller_manager/test_chainable_controller"
-    joint_names: ["joint1"]
+/**:
+  chainable_ctrl_with_parameters_and_type:
+    ros__parameters:
+      type: "controller_manager/test_chainable_controller"
+      joint_names: ["joint1"]
+
+  wildcard_ctrl_with_parameters_and_type:
+    ros__parameters:
+      type: "controller_manager/test_controller"
+      joint_names: ["joint1"]
 
 ctrl_with_parameters_and_no_type:
   ros__parameters:
     joint_names: ["joint2"]
 
-/foo_namespace/ctrl_with_parameters_and_type:
+/foo_namespace/ns_ctrl_with_parameters_and_type:
   ros__parameters:
     type: "controller_manager/test_controller"
     joint_names: ["joint1"]
 
-/foo_namespace/chainable_ctrl_with_parameters_and_type:
+/foo_namespace/ns_chainable_ctrl_with_parameters_and_type:
   ros__parameters:
     type: "controller_manager/test_chainable_controller"
     joint_names: ["joint1"]
 
-/foo_namespace/ctrl_with_parameters_and_no_type:
+/foo_namespace/ns_ctrl_with_parameters_and_no_type:
+  ros__parameters:
+    joint_names: ["joint2"]
+
+/**/wildcard_chainable_ctrl_with_parameters_and_type:
+  ros__parameters:
+    type: "controller_manager/test_chainable_controller"
+    joint_names: ["joint1"]
+
+/**/wildcard_ctrl_with_parameters_and_no_type:
   ros__parameters:
     joint_names: ["joint2"]

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -660,14 +660,14 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
   // Provide controller type via the parsed file
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager --controller-manager-timeout 1.0 -p " +
       test_file_path),
     256)
     << "Should fail without the namespacing it";
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager -p " +
       test_file_path + " --ros-args -r __ns:=/foo_namespace"),
     0);
@@ -675,7 +675,7 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
 
   auto ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[0];
-  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ns_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_with_parameters_and_type.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
@@ -683,7 +683,7 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
 
   auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(
-    chain_ctrl_with_parameters_and_type.info.name, "chainable_ctrl_with_parameters_and_type");
+    chain_ctrl_with_parameters_and_type.info.name, "ns_chainable_ctrl_with_parameters_and_type");
   ASSERT_EQ(
     chain_ctrl_with_parameters_and_type.info.type,
     test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -693,7 +693,7 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
 
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_no_type -c test_controller_manager -p " + test_file_path +
+      "ns_ctrl_with_parameters_and_no_type -c test_controller_manager -p " + test_file_path +
       " --ros-args -r __ns:=/foo_namespace"),
     256)
     << "Should fail as no type is defined!";
@@ -701,13 +701,13 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
 
   auto ctrl_1 = cm_->get_loaded_controllers()[0];
-  ASSERT_EQ(ctrl_1.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_1.info.name, "ns_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 
   auto ctrl_2 = cm_->get_loaded_controllers()[1];
-  ASSERT_EQ(ctrl_2.info.name, "chainable_ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_2.info.name, "ns_chainable_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_2.info.type, test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
@@ -723,28 +723,28 @@ TEST_F(
   // Provide controller type via the parsed file
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager --controller-manager-timeout 1.0 -p " +
       test_file_path),
     256)
     << "Should fail without the namespacing it";
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager --namespace foo_namespace --controller-manager-timeout 1.0 -p " +
       test_file_path + " --ros-args -r __ns:=/random_namespace"),
     256)
     << "Should fail when parsed namespace through both way with different namespaces";
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager --namespace foo_namespace --controller-manager-timeout 1.0 -p" +
       test_file_path + " --ros-args -r __ns:=/foo_namespace"),
     256)
     << "Should fail when parsed namespace through both ways even with same namespacing name";
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type --load-only -c "
+      "ns_ctrl_with_parameters_and_type ns_chainable_ctrl_with_parameters_and_type --load-only -c "
       "test_controller_manager --namespace foo_namespace -p " +
       test_file_path),
     0)
@@ -753,7 +753,7 @@ TEST_F(
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
 
   auto ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[0];
-  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ns_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_with_parameters_and_type.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
@@ -761,7 +761,7 @@ TEST_F(
 
   auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(
-    chain_ctrl_with_parameters_and_type.info.name, "chainable_ctrl_with_parameters_and_type");
+    chain_ctrl_with_parameters_and_type.info.name, "ns_chainable_ctrl_with_parameters_and_type");
   ASSERT_EQ(
     chain_ctrl_with_parameters_and_type.info.type,
     test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -771,7 +771,8 @@ TEST_F(
 
   EXPECT_EQ(
     call_spawner(
-      "ctrl_with_parameters_and_no_type -c test_controller_manager --namespace foo_namespace -p " +
+      "ns_ctrl_with_parameters_and_no_type -c test_controller_manager --namespace foo_namespace "
+      "-p " +
       test_file_path),
     256)
     << "Should fail as no type is defined!";
@@ -779,13 +780,17 @@ TEST_F(
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
 
   auto ctrl_1 = cm_->get_loaded_controllers()[0];
-  ASSERT_EQ(ctrl_1.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_1.info.name, "ns_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 
   auto ctrl_2 = cm_->get_loaded_controllers()[1];
-  ASSERT_EQ(ctrl_2.info.name, "chainable_ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_2.info.name, "ns_chainable_ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_2.info.type, test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+}
   ASSERT_EQ(ctrl_2.info.type, test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);


### PR DESCRIPTION
This PR aims to add support for the wildcard entries for the controller config files. This is very helpful, for instance, if we need to load the joint_state_broadcaster or any other controllers to different CM namespaces, we could reuse the configuration of the controllers or broadcaster by just having them with a wildcard. If not, we must generate multiple configuration files for each namespaced controller manager.

I've also added tests to test the same architecture. I've also made some tests with ros2_control_demos, and it works well.

Reference: https://docs.ros.org/en/humble/Tutorials/Intermediate/Launch/Using-ROS2-Launch-For-Large-Projects.html#using-wildcards-in-yaml-files