### PR TITLE
Fix logic error in informing user about real-time in ros2_control_node

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -60,12 +60,20 @@ int main(int argc, char ** argv)
             "for details on how to enable realtime scheduling.",
             errno, strerror(errno));
         }
+        else
+        {
+          RCLCPP_INFO(
+            cm->get_logger(), "Successful set up FIFO RT scheduling policy with priority %i.",
+            kSchedPriority);
+        }
       }
       else
       {
-        RCLCPP_INFO(
-          cm->get_logger(), "Successful set up FIFO RT scheduling policy with priority %i.",
-          kSchedPriority);
+        RCLCPP_WARN(
+          cm->get_logger(),
+          "No real-time kernel detected on this system. See "
+          "[https://control.ros.org/master/doc/ros2_control/controller_manager/doc/userdoc.html] "
+          "for details on how to enable realtime scheduling.");
       }
 
       // for calculating sleep time


### PR DESCRIPTION
The logic in informing user about rt capabilities had logic error. User was informed that rt scheduling is set up when in fact is not setup.