### PR TITLE
[CM] Throw an exception when the components initially fail to be in the required state

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -351,7 +351,8 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
             hardware_interface::return_type::ERROR)
           {
             throw std::runtime_error(
-              "Failed to set the initial state of the component : " + component + " to " + state.label());
+              "Failed to set the initial state of the component : " + component + " to " +
+              state.label());
           }
           components_to_activate.erase(component);
         }
@@ -381,7 +382,8 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       hardware_interface::return_type::ERROR)
     {
       throw std::runtime_error(
-        "Failed to set the initial state of the component : " + component + " to " + active_state.label());
+        "Failed to set the initial state of the component : " + component + " to " +
+        active_state.label());
     }
   }
   robot_description_notification_timer_->cancel();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -351,7 +351,7 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
             hardware_interface::return_type::ERROR)
           {
             throw std::runtime_error(
-              "Failed to set the state of the component : " + component + " to " + state.label());
+              "Failed to set the initial state of the component : " + component + " to " + state.label());
           }
           components_to_activate.erase(component);
         }
@@ -381,7 +381,7 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       hardware_interface::return_type::ERROR)
     {
       throw std::runtime_error(
-        "Failed to set the state of the component : " + component + " to " + active_state.label());
+        "Failed to set the initial state of the component : " + component + " to " + active_state.label());
     }
   }
   robot_description_notification_timer_->cancel();

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -346,7 +346,13 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
           RCLCPP_INFO(
             get_logger(), "Setting component '%s' to '%s' state.", component.c_str(),
             state.label().c_str());
-          resource_manager_->set_component_state(component, state);
+          if (
+            resource_manager_->set_component_state(component, state) ==
+            hardware_interface::return_type::ERROR)
+          {
+            throw std::runtime_error(
+              "Failed to set the state of the component : " + component + " to " + state.label());
+          }
           components_to_activate.erase(component);
         }
       }
@@ -370,7 +376,13 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
   {
     rclcpp_lifecycle::State active_state(
       State::PRIMARY_STATE_ACTIVE, hardware_interface::lifecycle_state_names::ACTIVE);
-    resource_manager_->set_component_state(component, active_state);
+    if (
+      resource_manager_->set_component_state(component, active_state) ==
+      hardware_interface::return_type::ERROR)
+    {
+      throw std::runtime_error(
+        "Failed to set the state of the component : " + component + " to " + active_state.label());
+    }
   }
   robot_description_notification_timer_->cancel();
 }


### PR DESCRIPTION
We faced another bug during our testing when the HW component failed to configure at the beginning, the CM prints that the Resource Manager is successfully initialized and exposes it's internal services and the spawner calls are being processed on startup.

I believe, If the user's initial intent is supposed to be in a particular state, it is better to have failed when this is not the case rather than continue to expose services and then fail again. Usually, when the services are exposed, it is expected that HW components are successfully initialized. 