### PR TITLE
[RM] Execute `error` callback of component on returning ERROR or with exception

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1804,6 +1804,7 @@ HardwareReadWriteStatus ResourceManager::read(
       }
       if (ret_val == return_type::ERROR)
       {
+        component.error();
         read_write_status.ok = false;
         read_write_status.failed_hardware_names.push_back(component.get_name());
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component.get_name());
@@ -1864,6 +1865,7 @@ HardwareReadWriteStatus ResourceManager::write(
       }
       if (ret_val == return_type::ERROR)
       {
+        component.error();
         read_write_status.ok = false;
         read_write_status.failed_hardware_names.push_back(component.get_name());
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component.get_name());


### PR DESCRIPTION
As described in the issue https://github.com/ros-controls/ros2_control/issues/1728, calling the `method` when we have return value as ERROR should fix the log. The issue explained in issue #1728 happens when there is an exception thrown during the `read` and `write` cycles and the error method withing the components are not triggered by default. So, we would need this fix here