### PR TITLE
[CM] Handle other exceptions while loading the controller plugin

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -480,7 +480,7 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
       get_logger(),
       "Caught unknown exception while loading the controller '%s' of plugin type '%s'",
       controller_name.c_str(), controller_type.c_str());
-    return nullptr;
+    throw;
   }
 
   ControllerSpec controller_spec;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -467,11 +467,19 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
       controller = chainable_loader_->createSharedInstance(controller_type);
     }
   }
-  catch (const pluginlib::CreateClassException & e)
+  catch (const std::exception & e)
   {
     RCLCPP_ERROR(
-      get_logger(), "Error happened during creation of controller '%s' with type '%s':\n%s",
+      get_logger(), "Caught exception while loading the controller '%s' of plugin type '%s':\n%s",
       controller_name.c_str(), controller_type.c_str(), e.what());
+    return nullptr;
+  }
+  catch (...)
+  {
+    RCLCPP_ERROR(
+      get_logger(),
+      "Caught unknown exception while loading the controller '%s' of plugin type '%s'",
+      controller_name.c_str(), controller_type.c_str());
     return nullptr;
   }
 


### PR DESCRIPTION
As of now, we are only handling the exceptions of the `pluginlib::CreateClassException` there are [many other exceptions defined by the pluginlib](https://github.com/ros/pluginlib/blob/jazzy/pluginlib/include/pluginlib/exceptions.hpp), that might be also interesting to catch. I'm using std::exception as the main PluginlibException is derived from std::runtime_error and which is derived from std::exception, and this gives us way to be generic (https://github.com/ros/pluginlib/blob/jazzy/pluginlib/include/pluginlib/exceptions.hpp#L43)