### PR TITLE
[Controller Interface] Make assign and release interfaces virtual

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -105,12 +105,12 @@ public:
   virtual InterfaceConfiguration state_interface_configuration() const = 0;
 
   CONTROLLER_INTERFACE_PUBLIC
-  void assign_interfaces(
+  virtual void assign_interfaces(
     std::vector<hardware_interface::LoanedCommandInterface> && command_interfaces,
     std::vector<hardware_interface::LoanedStateInterface> && state_interfaces);
 
   CONTROLLER_INTERFACE_PUBLIC
-  void release_interfaces();
+  virtual void release_interfaces();
 
   CONTROLLER_INTERFACE_PUBLIC
   return_type init(


### PR DESCRIPTION
Hello!

I wanted to open this PR to see if making `assign_interfaces` and `release_interfaces` is fine or not. This would be helpful if the user wants to deal with a different type instead of having them inside the vectors as it is by default

https://github.com/ros-controls/ros2_control/blob/ce58faea325335206ab3be356c64a7868b72a338/controller_interface/include/controller_interface/controller_interface_base.hpp#L257-L259

https://github.com/ros-controls/ros2_control/blob/ce58faea325335206ab3be356c64a7868b72a338/controller_interface/src/controller_interface_base.cpp#L95-L107

By making them virtual, we can let the user able to define the internal structure and then clean them when the release interface is called 