### PR TITLE
Log exception type when catching the exception

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -470,8 +470,9 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
   catch (const std::exception & e)
   {
     RCLCPP_ERROR(
-      get_logger(), "Caught exception while loading the controller '%s' of plugin type '%s':\n%s",
-      controller_name.c_str(), controller_type.c_str(), e.what());
+      get_logger(),
+      "Caught exception of type : %s while loading the controller '%s' of plugin type '%s':\n%s",
+      typeid(e).name(), controller_name.c_str(), controller_type.c_str(), e.what());
     return nullptr;
   }
   catch (...)
@@ -615,8 +616,9 @@ controller_interface::return_type ControllerManager::unload_controller(
     catch (const std::exception & e)
     {
       RCLCPP_ERROR(
-        get_logger(), "Failed to clean-up the controller '%s' before unloading: %s",
-        controller_name.c_str(), e.what());
+        get_logger(),
+        "Caught exception of type : %s while cleaning up the controller '%s' before unloading: %s",
+        typeid(e).name(), controller_name.c_str(), e.what());
     }
     catch (...)
     {
@@ -720,8 +722,8 @@ controller_interface::return_type ControllerManager::configure_controller(
   catch (const std::exception & e)
   {
     RCLCPP_ERROR(
-      get_logger(), "Caught exception while configuring controller '%s': %s",
-      controller_name.c_str(), e.what());
+      get_logger(), "Caught exception of type : %s while configuring controller '%s': %s",
+      typeid(e).name(), controller_name.c_str(), e.what());
     return controller_interface::return_type::ERROR;
   }
   catch (...)
@@ -1432,8 +1434,8 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::add_co
   {
     to.clear();
     RCLCPP_ERROR(
-      get_logger(), "Caught exception while initializing controller '%s': %s",
-      controller.info.name.c_str(), e.what());
+      get_logger(), "Caught exception of type : %s while initializing controller '%s': %s",
+      typeid(e).name(), controller.info.name.c_str(), e.what());
     return nullptr;
   }
   catch (...)
@@ -1508,8 +1510,8 @@ void ControllerManager::deactivate_controllers(
       catch (const std::exception & e)
       {
         RCLCPP_ERROR(
-          get_logger(), "Caught exception while deactivating the  controller '%s': %s",
-          controller_name.c_str(), e.what());
+          get_logger(), "Caught exception of type : %s while deactivating the  controller '%s': %s",
+          typeid(e).name(), controller_name.c_str(), e.what());
         continue;
       }
       catch (...)
@@ -1626,7 +1628,10 @@ void ControllerManager::activate_controllers(
       catch (const std::exception & e)
       {
         RCLCPP_ERROR(
-          get_logger(), "Can't activate controller '%s': %s", controller_name.c_str(), e.what());
+          get_logger(),
+          "Caught exception of type : %s while claiming the command interfaces. Can't activate "
+          "controller '%s': %s",
+          typeid(e).name(), controller_name.c_str(), e.what());
         assignment_successful = false;
         break;
       }
@@ -1661,7 +1666,10 @@ void ControllerManager::activate_controllers(
       catch (const std::exception & e)
       {
         RCLCPP_ERROR(
-          get_logger(), "Can't activate controller '%s': %s", controller_name.c_str(), e.what());
+          get_logger(),
+          "Caught exception of type : %s while claiming the state interfaces. Can't activate "
+          "controller '%s': %s",
+          typeid(e).name(), controller_name.c_str(), e.what());
         assignment_successful = false;
         break;
       }
@@ -1689,8 +1697,8 @@ void ControllerManager::activate_controllers(
     catch (const std::exception & e)
     {
       RCLCPP_ERROR(
-        get_logger(), "Caught exception while activating the controller '%s': %s",
-        controller_name.c_str(), e.what());
+        get_logger(), "Caught exception of type : %s while activating the controller '%s': %s",
+        typeid(e).name(), controller_name.c_str(), e.what());
       continue;
     }
     catch (...)
@@ -2295,8 +2303,8 @@ controller_interface::return_type ControllerManager::update(
         catch (const std::exception & e)
         {
           RCLCPP_ERROR(
-            get_logger(), "Caught exception while updating controller '%s': %s",
-            loaded_controller.info.name.c_str(), e.what());
+            get_logger(), "Caught exception of type : %s while updating controller '%s': %s",
+            typeid(e).name(), loaded_controller.info.name.c_str(), e.what());
           controller_ret = controller_interface::return_type::ERROR;
         }
         catch (...)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -160,13 +160,15 @@ public:
     }
     catch (const pluginlib::PluginlibException & ex)
     {
-      RCLCPP_ERROR(get_logger(), "Exception while loading hardware: %s", ex.what());
+      RCLCPP_ERROR(
+        get_logger(), "Caught exception of type : %s while loading hardware: %s", typeid(ex).name(),
+        ex.what());
     }
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while loading hardware '%s': %s",
-        hardware_info.name.c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while loading hardware '%s': %s",
+        typeid(ex).name(), hardware_info.name.c_str(), ex.what());
     }
     catch (...)
     {
@@ -203,8 +205,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while initializing hardware '%s': %s",
-        hardware_info.name.c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while initializing hardware '%s': %s",
+        typeid(ex).name(), hardware_info.name.c_str(), ex.what());
     }
     catch (...)
     {
@@ -229,8 +231,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while configuring hardware '%s': %s",
-        hardware.get_name().c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while configuring hardware '%s': %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -378,8 +380,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while cleaning up hardware '%s': %s",
-        hardware.get_name().c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while cleaning up hardware '%s': %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -412,8 +414,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while shutting down hardware '%s': %s",
-        hardware.get_name().c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while shutting down hardware '%s': %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -451,8 +453,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while activating hardware '%s': %s",
-        hardware.get_name().c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while activating hardware '%s': %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -486,8 +488,8 @@ public:
     catch (const std::exception & ex)
     {
       RCLCPP_ERROR(
-        get_logger(), "Exception occurred while deactivating hardware '%s': %s",
-        hardware.get_name().c_str(), ex.what());
+        get_logger(), "Exception of type : %s occurred while deactivating hardware '%s': %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -625,8 +627,9 @@ public:
     {
       RCLCPP_ERROR(
         get_logger(),
-        "Exception occurred while importing state interfaces for the hardware '%s' : %s",
-        hardware.get_name().c_str(), e.what());
+        "Exception of type : %s occurred while importing state interfaces for the hardware '%s' : "
+        "%s",
+        typeid(e).name(), hardware.get_name().c_str(), e.what());
     }
     catch (...)
     {
@@ -650,8 +653,9 @@ public:
     {
       RCLCPP_ERROR(
         get_logger(),
-        "Exception occurred while importing command interfaces for the hardware '%s' : %s",
-        hardware.get_name().c_str(), ex.what());
+        "Exception of type : %s occurred while importing command interfaces for the hardware '%s' "
+        ": %s",
+        typeid(ex).name(), hardware.get_name().c_str(), ex.what());
     }
     catch (...)
     {
@@ -1568,9 +1572,9 @@ bool ResourceManager::prepare_command_mode_switch(
         {
           RCLCPP_ERROR(
             logger,
-            "Exception occurred while preparing command mode switch for component '%s' for the "
-            "interfaces: \n %s : %s",
-            component.get_name().c_str(),
+            "Exception of type : %s occurred while preparing command mode switch for component "
+            "'%s' for the interfaces: \n %s : %s",
+            typeid(e).name(), component.get_name().c_str(),
             interfaces_to_string(start_interfaces, stop_interfaces).c_str(), e.what());
           ret = false;
         }
@@ -1632,9 +1636,9 @@ bool ResourceManager::perform_command_mode_switch(
         {
           RCLCPP_ERROR(
             logger,
-            "Exception occurred while performing command mode switch for component '%s' for the "
-            "interfaces: \n %s : %s",
-            component.get_name().c_str(),
+            "Exception of type : %s occurred while performing command mode switch for component "
+            "'%s' for the interfaces: \n %s : %s",
+            typeid(e).name(), component.get_name().c_str(),
             interfaces_to_string(start_interfaces, stop_interfaces).c_str(), e.what());
           ret = false;
         }
@@ -1791,8 +1795,8 @@ HardwareReadWriteStatus ResourceManager::read(
       catch (const std::exception & e)
       {
         RCLCPP_ERROR(
-          get_logger(), "Exception thrown durind read of the component '%s': %s",
-          component.get_name().c_str(), e.what());
+          get_logger(), "Exception of type : %s thrown during read of the component '%s': %s",
+          typeid(e).name(), component.get_name().c_str(), e.what());
         ret_val = return_type::ERROR;
       }
       catch (...)
@@ -1851,8 +1855,8 @@ HardwareReadWriteStatus ResourceManager::write(
       catch (const std::exception & e)
       {
         RCLCPP_ERROR(
-          get_logger(), "Exception thrown during write of the component '%s': %s",
-          component.get_name().c_str(), e.what());
+          get_logger(), "Exception of type : %s thrown during write of the component '%s': %s",
+          typeid(e).name(), component.get_name().c_str(), e.what());
         ret_val = return_type::ERROR;
       }
       catch (...)


### PR DESCRIPTION
After some tests, it seems like there is no proper description of the exception message and it is clearer through the type of exception.

For instance, the issue we faced is: `InvalidParameterValueException` (https://github.com/ros2/rclcpp/blob/2f71d6e249f626772da3f8a1bb7c8d141d9d0d52/rclcpp/src/rclcpp/parameter_map.cpp#L147) and the error message is "No parameter value set" and it was not clear to use until we went to the source code and started looking, so to handle such situations, I think it is better also to log the type of the exceptions that are thrown.

Thank you!