### PR TITLE
Fix hardware component unconfiguration

### DIFF
--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -96,12 +96,12 @@ const rclcpp_lifecycle::State & Actuator::cleanup()
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
+    impl_->set_lifecycle_state(rclcpp_lifecycle::State(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+      lifecycle_state_names::UNCONFIGURED));
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
-        impl_->set_lifecycle_state(rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
-          lifecycle_state_names::UNCONFIGURED));
         break;
       case CallbackReturn::FAILURE:
       case CallbackReturn::ERROR:

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -95,12 +95,12 @@ const rclcpp_lifecycle::State & Sensor::cleanup()
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
+    impl_->set_lifecycle_state(rclcpp_lifecycle::State(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+      lifecycle_state_names::UNCONFIGURED));
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
-        impl_->set_lifecycle_state(rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
-          lifecycle_state_names::UNCONFIGURED));
         break;
       case CallbackReturn::FAILURE:
       case CallbackReturn::ERROR:

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -73,7 +73,7 @@ const rclcpp_lifecycle::State & System::configure()
     switch (impl_->on_configure(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
-              impl_->set_lifecycle_state(rclcpp_lifecycle::State(
+        impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_state_names::INACTIVE));
         break;
       case CallbackReturn::FAILURE:

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -73,7 +73,7 @@ const rclcpp_lifecycle::State & System::configure()
     switch (impl_->on_configure(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
-        impl_->set_lifecycle_state(rclcpp_lifecycle::State(
+              impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_state_names::INACTIVE));
         break;
       case CallbackReturn::FAILURE:
@@ -94,12 +94,12 @@ const rclcpp_lifecycle::State & System::cleanup()
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
+    impl_->set_lifecycle_state(rclcpp_lifecycle::State(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+      lifecycle_state_names::UNCONFIGURED));
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
-        impl_->set_lifecycle_state(rclcpp_lifecycle::State(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
-          lifecycle_state_names::UNCONFIGURED));
         break;
       case CallbackReturn::FAILURE:
       case CallbackReturn::ERROR:


### PR DESCRIPTION
**Summary**
Unconfiguring a hardware component using the `~/set_hardware_component_state` service results in code failures. This occurs because the `on_cleanup()` function removes resources while the read and write functions of the hardware component are still attempting to access those resources. The issue arises because the primary state is not set to `UNCONFIGURED` until after the `on_cleanup` function is executed, rather than before it is called.

**Problem Description**

1. After `~/set_hardware_component_state` [service](https://github.com/ros-controls/ros2_control/blob/humble/controller_manager/src/controller_manager.cpp#L514) call is invoked, the `set_hardware_component_state_srv_cb()` [function](https://github.com/ros-controls/ros2_control/blob/humble/controller_manager/src/controller_manager.cpp#L1972) is executed. This function then calls `set_component_state()` [function](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/resource_manager.cpp#L314). In this function,  the `cleanup_hardware() `function is called when the target state is `PRIMARY_STATE_UNCONFIGURED`.
2. The `cleanup_hardware` [function](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/resource_manager.cpp#L253) uses the bind method to call the `cleanup` method of either the [SystemInterface](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/system.cpp#L81), [SensorInterface](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/sensor.cpp#L81), or [ActuatorInterface](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/actuator.cpp#L83) class, depending on the type of hardware component. The `cleanup()` function, in turn, calls the `on_cleanup` function of the hardware component class. In this context, the `on_cleanup` [function](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/humble/ur_robot_driver/src/hardware_interface.cpp#L472) is called in the `URPositionHardwareInterface` class, which is defined in the `Universal_Robots_ROS2_Driver` repository and inherits from `hardware_interface::SystemInterface`.
3. The `on_cleanup` function removes and unassigns pointers, as well as cleans up threads, while the read and write [functions](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/humble/ur_robot_driver/src/ur_ros2_control_node.cpp#L79) of the `ControllerManager` class continue running. The read and write [functions](https://github.com/ros-controls/ros2_control/blob/humble/controller_manager/src/controller_manager.cpp#L2019) in the `ControllerManager` class call the corresponding read and write [functions](https://github.com/ros-controls/ros2_control/blob/humble/hardware_interface/src/resource_manager.cpp#L1232) in the `ResourceManager` class, which then invoke the read and write functions of the hardware components from the `SystemInterface`, `SensorInterface`, or `ActuatorInterface` classes. These functions first check if the state is  `PRIMARY_STATE_INACTIVE`  or `PRIMARY_STATE_ACTIVE` before executing the read and write operations on the hardware component.
4. If the `on_cleanup` function is called and removes some of the resources while the state of the robot has not yet been set to `UNCONFIGURED`, the read and write functions of the hardware component can still be called. Since these functions attempt to access resources that have already been removed, this can result in code crashes.

**Environment:**
 - OS: Ubuntu 20.04
 - Version: Humble

**Proposed Solution**
To prevent such crashes, it's suggested to ensure that the state is properly set to `UNCONFIGURED` before any resources are cleaned up. This way, the read and write functions will not be invoked after resources have been removed, avoiding access to invalid or dangling pointers. Therefore, it is suggested to modify the `cleanup()` function in `SystemInterface`, `SensorInterface` or `ActuatorInterface`