### PR TITLE
Fix to properly propagate the controller NodeOptions

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -185,14 +185,15 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   virtual rclcpp::NodeOptions define_custom_node_options() const
   {
+    rclcpp::NodeOptions node_options;
 // \note The versions conditioning is added here to support the source-compatibility with Humble
 #if RCLCPP_VERSION_MAJOR >= 21
-    return rclcpp::NodeOptions().enable_logger_service(true);
+    node_options.enable_logger_service(true);
 #else
-    return rclcpp::NodeOptions()
-      .allow_undeclared_parameters(true)
-      .automatically_declare_parameters_from_overrides(true);
+    node_options.allow_undeclared_parameters(true);
+    node_options.automatically_declare_parameters_from_overrides(true);
 #endif
+    return node_options;
   }
 
   /// Declare and initialize a parameter with a type.


### PR DESCRIPTION
@bijoua29 pointed out in our Slack channel that the controllers are not exposing the logger_level setter and getter services. I tested out with demos, and I confirm that it is not working

```
/forward_position_controller/describe_parameters
/forward_position_controller/get_parameter_types
/forward_position_controller/get_parameters
/forward_position_controller/get_type_description
/forward_position_controller/list_parameters
/forward_position_controller/set_parameters
/forward_position_controller/set_parameters_atomically
/joint_state_broadcaster/describe_parameters
/joint_state_broadcaster/get_parameter_types
/joint_state_broadcaster/get_parameters
/joint_state_broadcaster/get_type_description
/joint_state_broadcaster/list_parameters
/joint_state_broadcaster/set_parameters
/joint_state_broadcaster/set_parameters_atomically
```

The fix proposed in this PR should enable the services properly and propagate it properly when overlayed

```
/forward_position_controller/describe_parameters
/forward_position_controller/get_logger_levels
/forward_position_controller/get_parameter_types
/forward_position_controller/get_parameters
/forward_position_controller/get_type_description
/forward_position_controller/list_parameters
/forward_position_controller/set_logger_levels
/forward_position_controller/set_parameters
/forward_position_controller/set_parameters_atomically
/joint_state_broadcaster/describe_parameters
/joint_state_broadcaster/get_logger_levels
/joint_state_broadcaster/get_parameter_types
/joint_state_broadcaster/get_parameters
/joint_state_broadcaster/get_type_description
/joint_state_broadcaster/list_parameters
/joint_state_broadcaster/set_logger_levels
/joint_state_broadcaster/set_parameters
/joint_state_broadcaster/set_parameters_atomically

```

This is because the rclcpp when we set the options returns a reference and this is not being used properly with the older version

```
 RCLCPP_PUBLIC
  NodeOptions &
  enable_logger_service(bool enable_log_service);
```