### PR TITLE
[CM] Fix controller missing update cycles in a real setup

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -160,7 +160,7 @@ public:
    * **The method called in the (real-time) control loop.**
    *
    * \param[in] time The time at the start of this control loop iteration
-   * \param[in] period The measured time taken by the last control loop iteration
+   * \param[in] period The measured time since the last control loop iteration
    * \returns return_type::OK if update is successfully, otherwise return_type::ERROR.
    */
   CONTROLLER_INTERFACE_PUBLIC

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -87,6 +87,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_controller_manager
     test/test_controller_manager.cpp
+    TIMEOUT 180
   )
   target_link_libraries(test_controller_manager
     controller_manager

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -123,7 +123,7 @@ public:
     controller_spec.c = controller;
     controller_spec.info.name = controller_name;
     controller_spec.info.type = controller_type;
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     return add_controller_impl(controller_spec);
   }
 

--- a/controller_manager/include/controller_manager/controller_spec.hpp
+++ b/controller_manager/include/controller_manager/controller_spec.hpp
@@ -37,7 +37,7 @@ struct ControllerSpec
 {
   hardware_interface::ControllerInfo info;
   controller_interface::ControllerInterfaceBaseSharedPtr c;
-  std::shared_ptr<rclcpp::Time> next_update_cycle_time;
+  std::shared_ptr<rclcpp::Time> last_update_cycle_time;
 };
 
 struct ControllerChainSpec

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2368,6 +2368,12 @@ controller_interface::return_type ControllerManager::update(
       const auto controller_actual_period =
         (current_time - *loaded_controller.last_update_cycle_time);
 
+      /// @note The factor 0.99 is used to avoid the controllers skipping update cycles due to the
+      /// jitter in the system sleep cycles.
+      // For instance, A controller running at 50 Hz and the CM running at 100Hz, then when we have
+      // an update cycle at 0.019s (ideally, the controller should only trigger >= 0.02s), if we
+      // wait for next cycle, then trigger will happen at ~0.029 sec and this is creating an issue
+      // to keep up with the controller update rate (see issue #1769).
       const bool controller_go =
         run_controller_at_cm_rate ||
         (time ==

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2379,7 +2379,6 @@ controller_interface::return_type ControllerManager::update(
         update_loop_counter_, controller_go ? "True" : "False",
         loaded_controller.info.name.c_str());
 
-      RCLCPP_DEBUG(get_logger(), "The update time is %f", time.seconds());
       if (controller_go)
       {
         auto controller_ret = controller_interface::return_type::OK;
@@ -2406,9 +2405,6 @@ controller_interface::return_type ControllerManager::update(
         }
 
         *loaded_controller.last_update_cycle_time = current_time;
-        RCLCPP_DEBUG(
-          get_logger(), "[%s] Setting last_update_cycle_time to %fs for the controller",
-          loaded_controller.info.name.c_str(), loaded_controller.last_update_cycle_time->seconds());
 
         if (controller_ret != controller_interface::return_type::OK)
         {

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -696,7 +696,7 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
     EXPECT_THAT(
       test_controller->update_period_.seconds(),
       testing::AllOf(
-        testing::Ge(0.99 * controller_period),
+        testing::Gt(0.99 * controller_period),
         testing::Lt((1.05 * controller_period) + PERIOD.seconds())))
       << "update_counter: " << update_counter << " desired controller period: " << controller_period
       << " actual controller period: " << test_controller->update_period_.seconds();

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -769,7 +769,7 @@ TEST_F(TestControllerManagerFallbackControllers, test_failure_on_fallback_contro
     controller_spec.info.name = test_controller_1_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {test_controller_2_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -777,7 +777,7 @@ TEST_F(TestControllerManagerFallbackControllers, test_failure_on_fallback_contro
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
   }
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
@@ -851,7 +851,7 @@ TEST_F(TestControllerManagerFallbackControllers, test_fallback_controllers_activ
     controller_spec.info.name = test_controller_1_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {test_controller_2_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -859,7 +859,7 @@ TEST_F(TestControllerManagerFallbackControllers, test_fallback_controllers_activ
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
   }
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
@@ -949,7 +949,7 @@ TEST_F(
     controller_spec.info.name = test_controller_1_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {test_controller_2_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -957,7 +957,7 @@ TEST_F(
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
   }
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
@@ -1038,7 +1038,7 @@ TEST_F(
     controller_spec.info.name = test_controller_1_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {test_controller_2_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -1046,7 +1046,7 @@ TEST_F(
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
   }
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
@@ -1134,7 +1134,7 @@ TEST_F(
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {
       test_controller_2_name, test_controller_3_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -1142,14 +1142,14 @@ TEST_F(
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
 
     controller_spec.c = test_controller_3;
     controller_spec.info.name = test_controller_3_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_3
   }
 
@@ -1284,7 +1284,7 @@ TEST_F(
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {
       test_controller_2_name, test_controller_3_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -1292,21 +1292,21 @@ TEST_F(
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
 
     controller_spec.c = test_controller_3;
     controller_spec.info.name = test_controller_3_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_3
 
     controller_spec.c = test_controller_4;
     controller_spec.info.name = test_controller_4_name;
     controller_spec.info.type = "test_chainable_controller::TestChainableController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_4
   }
 
@@ -1386,7 +1386,7 @@ TEST_F(
     controller_spec.info.name = test_controller_1_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {test_controller_3_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_1
 
     EXPECT_EQ(
@@ -1418,7 +1418,7 @@ TEST_F(
     // available
     controller_spec.info.fallback_controllers_names = {
       test_controller_4_name, test_controller_3_name, test_controller_2_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_1
 
     EXPECT_EQ(
@@ -1514,7 +1514,7 @@ TEST_F(
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {
       test_controller_2_name, test_controller_4_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     ControllerManagerRunner cm_runner(this);
     cm_->add_controller(controller_spec);  // add controller_1
 
@@ -1522,21 +1522,21 @@ TEST_F(
     controller_spec.info.name = test_controller_2_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_2
 
     controller_spec.c = test_controller_3;
     controller_spec.info.name = test_controller_3_name;
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_3
 
     controller_spec.c = test_controller_4;
     controller_spec.info.name = test_controller_4_name;
     controller_spec.info.type = "test_chainable_controller::TestChainableController";
     controller_spec.info.fallback_controllers_names = {};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_4
   }
 
@@ -1622,7 +1622,7 @@ TEST_F(
     controller_spec.info.type = "test_controller::TestController";
     controller_spec.info.fallback_controllers_names = {
       test_controller_3_name, test_controller_4_name};
-    controller_spec.next_update_cycle_time = std::make_shared<rclcpp::Time>(0);
+    controller_spec.last_update_cycle_time = std::make_shared<rclcpp::Time>(0);
     cm_->add_controller(controller_spec);  // add controller_1
 
     EXPECT_EQ(


### PR DESCRIPTION
When we introduced supporting different update rates to the controllers. I realized that inside the tests I assumed a perfect system without any jitter and it was performing well. 

https://github.com/ros-controls/ros2_control/blob/ab84b74b079a9b6df887d36a84d8965b5342d19c/controller_manager/test/test_controller_manager.cpp#L512

However, this is not the case in reality. We have some influence of system jitter, and due to the jitter if the system sleeps a bit less than what it should, then it skips and waits for the next cycle, and that's the reason we have double the period in most occasions. 

https://github.com/ros-controls/ros2_control/blob/3c985db3c696e4fdce8f2153339d20bf4e1ddb9f/controller_manager/test/test_controller_manager.cpp#L502-L504

This PR introduces a new approach to solving this issue and the tests have been updated to be more realistic than earlier version

Fixes: #1769 
Fixes: https://github.com/ros-controls/ros2_control/issues/1574