### PR TITLE
Check the update_rate set to the controllers to be a valid one

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -28,13 +28,14 @@ return_type ControllerInterfaceBase::init(
   const std::string & node_namespace, const rclcpp::NodeOptions & node_options)
 {
   urdf_ = urdf;
+  update_rate_ = cm_update_rate;
   node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>(
     controller_name, node_namespace, node_options,
     false);  // disable LifecycleNode service interfaces
 
   try
   {
-    auto_declare<int>("update_rate", cm_update_rate);
+    auto_declare<int>("update_rate", update_rate_);
     auto_declare<bool>("is_async", false);
   }
   catch (const std::exception & e)
@@ -85,7 +86,24 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
   // Other solution is to add check into the LifecycleNode if a transition is valid to trigger
   if (get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
   {
-    update_rate_ = static_cast<unsigned int>(get_node()->get_parameter("update_rate").as_int());
+    const auto update_rate = get_node()->get_parameter("update_rate").as_int();
+    if (update_rate < 0)
+    {
+      RCLCPP_ERROR(get_node()->get_logger(), "Update rate cannot be a negative value!");
+      return get_lifecycle_state();
+    }
+    if (update_rate_ != 0u && update_rate > update_rate_)
+    {
+      RCLCPP_WARN(
+        get_node()->get_logger(),
+        "The update rate of the controller : '%ld Hz' cannot be higher than the update rate of the "
+        "controller manager : '%d Hz'. Setting it to the update rate of the controller manager.",
+        update_rate, update_rate_);
+    }
+    else
+    {
+      update_rate_ = static_cast<unsigned int>(update_rate);
+    }
     is_async_ = get_node()->get_parameter("is_async").as_bool();
   }
 

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -398,7 +398,7 @@ TEST_P(TestControllerManagerWithUpdateRates, per_controller_equal_and_higher_upd
   // if we do 2 times of the controller_manager update rate, the internal counter should be
   // similarly incremented
   EXPECT_EQ(test_controller->internal_counter, pre_internal_counter + (2 * cm_->get_update_rate()));
-  EXPECT_EQ(test_controller->get_update_rate(), ctrl_update_rate);
+  EXPECT_EQ(test_controller->get_update_rate(), cm_->get_update_rate());
 
   auto deactivate_future = std::async(
     std::launch::async, &controller_manager::ControllerManager::switch_controller, cm_,

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -72,7 +72,7 @@ TEST_F(TestLoadController, can_set_and_get_non_default_update_rate)
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
 
-  EXPECT_EQ(cm_->get_update_rate(), controller_if->get_update_rate());
+  EXPECT_EQ(100u, controller_if->get_update_rate());
 }
 
 class TestLoadedController : public TestLoadController

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -66,13 +66,13 @@ TEST_F(TestLoadController, can_set_and_get_non_default_update_rate)
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     controller_if->get_lifecycle_state().id());
 
-  controller_if->get_node()->set_parameter({"update_rate", 1337});
+  controller_if->get_node()->set_parameter({"update_rate", 50});
 
   cm_->configure_controller("test_controller_01");
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
 
-  EXPECT_EQ(100u, controller_if->get_update_rate());
+  EXPECT_EQ(50u, controller_if->get_update_rate());
 }
 
 class TestLoadedController : public TestLoadController

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -72,7 +72,7 @@ TEST_F(TestLoadController, can_set_and_get_non_default_update_rate)
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
 
-  EXPECT_EQ(1337u, controller_if->get_update_rate());
+  EXPECT_EQ(cm_->get_update_rate(), controller_if->get_update_rate());
 }
 
 class TestLoadedController : public TestLoadController


### PR DESCRIPTION
Right now, if we have set an invalid value to the update_rate (rate ggreater than CM's rate) the internal variable still holds the invalid one. This PR aims to add some checks to detect these situations and set it to the CM's rate. 