### PR TITLE
rqt_cm: Fix handling of unconfigured controllers during spawn action

### DIFF
--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -260,7 +260,7 @@ class ControllerManager(Plugin):
             if action is action_configure:
                 configure_controller(self._node, self._cm_name, ctrl.name)
             elif action is action_spawn:
-                load_controller(self._node, self._cm_name, ctrl.name)
+                configure_controller(self._node, self._cm_name, ctrl.name)
                 self._activate_controller(ctrl.name)
         else:
             # Assume controller isn't loaded


### PR DESCRIPTION
## Description:
This PR addresses an #1791  issue where controllers in the "unconfigured" state were being loaded rather than configured during the action_spawn process. The previous behavior could lead to errors when attempting to activate controllers that were not yet configured.

**Changes made:**
* Updated the handling of the "unconfigured" state to configure the controller when the action is action_spawn, ensuring proper configuration before activation.
* This replaces the previous use of load_controller during action_spawn.

## Testing:
I was unable to test the changes with `diffbot.launch.py` due to build issues with `ros2_controllers` on my system running ROS Iron, as the `rolling` build is not compatible with `iron`.
