### PR TITLE
[Spawner] Accept parsing multiple `--param-file` arguments to spawner 

### DIFF
--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -23,9 +23,9 @@ from .controller_manager_services import (
     set_hardware_component_state,
     switch_controllers,
     unload_controller,
-    get_parameter_from_param_file,
+    get_parameter_from_param_files,
     set_controller_parameters,
-    set_controller_parameters_from_param_file,
+    set_controller_parameters_from_param_files,
     bcolors,
 )
 
@@ -40,8 +40,8 @@ __all__ = [
     "set_hardware_component_state",
     "switch_controllers",
     "unload_controller",
-    "get_parameter_from_param_file",
+    "get_parameter_from_param_files",
     "set_controller_parameters",
-    "set_controller_parameters_from_param_file",
+    "set_controller_parameters_from_param_files",
     "bcolors",
 ]

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -253,6 +253,39 @@ def unload_controller(node, controller_manager_name, controller_name, service_ti
     )
 
 
+def get_params_files_with_controller_parameters(
+    node, controller_name: str, namespace: str, parameter_files: list
+):
+    controller_parameter_files = []
+    for parameter_file in parameter_files:
+        if parameter_file in controller_parameter_files:
+            continue
+        with open(parameter_file) as f:
+            namespaced_controller = (
+                f"/{controller_name}" if namespace == "/" else f"{namespace}/{controller_name}"
+            )
+            WILDCARD_KEY = "/**"
+            parameters = yaml.safe_load(f)
+            # check for the parameter in 'controller_name' or 'namespaced_controller' or '/**/namespaced_controller' or '/**/controller_name'
+            for key in [
+                controller_name,
+                namespaced_controller,
+                f"{WILDCARD_KEY}/{controller_name}",
+                f"{WILDCARD_KEY}{namespaced_controller}",
+            ]:
+                if key in parameters:
+                    if key == controller_name and namespace != "/":
+                        node.get_logger().fatal(
+                            f"{bcolors.FAIL}Missing namespace : {namespace} or wildcard in parameter file for controller : {controller_name}{bcolors.ENDC}"
+                        )
+                        break
+                    controller_parameter_files.append(parameter_file)
+
+                if WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:
+                    controller_parameter_files.append(parameter_file)
+    return controller_parameter_files
+
+
 def get_parameter_from_param_files(
     node, controller_name: str, namespace: str, parameter_files: list, parameter_name: str
 ):
@@ -350,14 +383,21 @@ def set_controller_parameters(
 def set_controller_parameters_from_param_files(
     node, controller_manager_name: str, controller_name: str, parameter_files: list, namespace=None
 ):
-    if parameter_files:
-        spawner_namespace = namespace if namespace else node.get_namespace()
+    spawner_namespace = namespace if namespace else node.get_namespace()
+    controller_parameter_files = get_params_files_with_controller_parameters(
+        node, controller_name, spawner_namespace, parameter_files
+    )
+    if controller_parameter_files:
         set_controller_parameters(
-            node, controller_manager_name, controller_name, "params_file", parameter_files
+            node,
+            controller_manager_name,
+            controller_name,
+            "params_file",
+            controller_parameter_files,
         )
 
         controller_type = get_parameter_from_param_files(
-            node, controller_name, spawner_namespace, parameter_files, "type"
+            node, controller_name, spawner_namespace, controller_parameter_files, "type"
         )
         if controller_type and not set_controller_parameters(
             node, controller_manager_name, controller_name, "type", controller_type
@@ -365,7 +405,11 @@ def set_controller_parameters_from_param_files(
             return False
 
         fallback_controllers = get_parameter_from_param_files(
-            node, controller_name, spawner_namespace, parameter_files, "fallback_controllers"
+            node,
+            controller_name,
+            spawner_namespace,
+            controller_parameter_files,
+            "fallback_controllers",
         )
         if fallback_controllers:
             if not set_controller_parameters(

--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -20,7 +20,7 @@ from launch_ros.actions import Node
 
 
 def generate_controllers_spawner_launch_description(
-    controller_names: list, controller_params_file=None, extra_spawner_args=[]
+    controller_names: list, controller_params_files=None, extra_spawner_args=[]
 ):
     """
     Generate launch description for loading a controller using spawner.
@@ -37,8 +37,8 @@ def generate_controllers_spawner_launch_description(
       # Passing controller parameter file to load the controller (Controller type is retrieved from config file)
       generate_controllers_spawner_launch_description(
         ['joint_state_broadcaster'],
-        controller_params_file=os.path.join(get_package_share_directory('my_pkg'),
-                                            'config', 'controller_params.yaml'),
+        controller_params_files=[os.path.join(get_package_share_directory('my_pkg'),
+                                            'config', 'controller_params.yaml')],
         extra_spawner_args=[--load-only]
         )
 
@@ -62,8 +62,10 @@ def generate_controllers_spawner_launch_description(
         ]
     )
 
-    if controller_params_file:
-        spawner_arguments += ["--param-file", controller_params_file]
+    if controller_params_files:
+        for controller_params_file in controller_params_files:
+            if controller_params_file:
+                spawner_arguments += ["--param-file", controller_params_file]
 
     # Setting --unload-on-kill if launch arg unload_on_kill is "true"
     # See https://github.com/ros2/launch/issues/290
@@ -98,11 +100,51 @@ def generate_controllers_spawner_launch_description(
     )
 
 
+def generate_controllers_spawner_launch_description_from_dict(
+    controller_info_dict: dict, extra_spawner_args=[]
+):
+    """
+    Generate launch description for loading a controller using spawner.
+
+    controller_info_dict: dict
+        A dictionary with the following info:
+        - controller_name: str
+            The name of the controller to load as the key
+        - controller_params_file: str or list or None
+            The path to the controller parameter file or a list of paths to multiple parameter files
+            or None if no parameter file is needed as the value of the key
+            If a list is passed, the controller parameters will be overloaded in same order
+    extra_spawner_args: list
+        A list of extra arguments to pass to the controller spawner
+    """
+    if not type(controller_info_dict) is dict:
+        raise ValueError(f"Invalid controller_info_dict type parsed {controller_info_dict}")
+    controller_names = controller_info_dict.keys()
+    controller_params_files = []
+    for controller_name in controller_names:
+        controller_params_file = controller_info_dict[controller_name]
+        if controller_params_file:
+            if type(controller_params_file) is list:
+                controller_params_files.extend(controller_params_file)
+            elif type(controller_params_file) is str:
+                controller_params_files.append(controller_params_file)
+            else:
+                raise ValueError(
+                    f"Invalid controller_params_file type parsed in the dict {controller_params_file}"
+                )
+    return generate_controllers_spawner_launch_description(
+        controller_names=controller_names,
+        controller_params_files=controller_params_files,
+        extra_spawner_args=extra_spawner_args,
+    )
+
+
 def generate_load_controller_launch_description(
     controller_name: str, controller_params_file=None, extra_spawner_args=[]
 ):
+    controller_params_files = [controller_params_file] if controller_params_file else None
     return generate_controllers_spawner_launch_description(
         controller_names=[controller_name],
-        controller_params_file=controller_params_file,
+        controller_params_file=controller_params_files,
         extra_spawner_args=extra_spawner_args,
     )

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -79,7 +79,9 @@ def main(args=None):
     parser.add_argument(
         "-p",
         "--param-file",
-        help="Controller param file to be loaded into controller node before configure",
+        help="Controller param file to be loaded into controller node before configure. "
+        "Parse multiple times to load different files for different controllers or to "
+        "override the parameters of the same controller.",
         default=None,
         action="append",
         required=False,

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -26,7 +26,7 @@ from controller_manager import (
     load_controller,
     switch_controllers,
     unload_controller,
-    set_controller_parameters_from_param_file,
+    set_controller_parameters_from_param_files,
     bcolors,
 )
 from controller_manager.controller_manager_services import ServiceNotFoundError
@@ -81,6 +81,7 @@ def main(args=None):
         "--param-file",
         help="Controller param file to be loaded into controller node before configure",
         default=None,
+        action="append",
         required=False,
     )
     parser.add_argument(
@@ -136,12 +137,14 @@ def main(args=None):
     args = parser.parse_args(command_line_args)
     controller_names = args.controller_names
     controller_manager_name = args.controller_manager
-    param_file = args.param_file
+    param_files = args.param_file
     controller_manager_timeout = args.controller_manager_timeout
     switch_timeout = args.switch_timeout
 
-    if param_file and not os.path.isfile(param_file):
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
+    if param_files:
+        for param_file in param_files:
+            if not os.path.isfile(param_file):
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
 
     node = Node("spawner_" + controller_names[0])
 
@@ -182,12 +185,12 @@ def main(args=None):
                     + bcolors.ENDC
                 )
             else:
-                if param_file:
-                    if not set_controller_parameters_from_param_file(
+                if param_files:
+                    if not set_controller_parameters_from_param_files(
                         node,
                         controller_manager_name,
                         controller_name,
-                        param_file,
+                        param_files,
                         spawner_namespace,
                     ):
                         return 1

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -80,7 +80,7 @@ def main(args=None):
         "-p",
         "--param-file",
         help="Controller param file to be loaded into controller node before configure. "
-        "Parse multiple times to load different files for different controllers or to "
+        "Pass multiple times to load different files for different controllers or to "
         "override the parameters of the same controller.",
         default=None,
         action="append",

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -169,7 +169,7 @@ There are two scripts to interact with controller manager from launch files:
       -c CONTROLLER_MANAGER, --controller-manager CONTROLLER_MANAGER
                             Name of the controller manager ROS node
       -p PARAM_FILE, --param-file PARAM_FILE
-                            Controller param file to be loaded into controller node before configure. Parse multiple times to load different files for different controllers or to override the parameters of the same controller.
+                            Controller param file to be loaded into controller node before configure. Pass multiple times to load different files for different controllers or to override the parameters of the same controller.
       -n NAMESPACE, --namespace NAMESPACE
                             DEPRECATED Namespace for the controller_manager and the controller(s)
       --load-only           Only load the controller and leave unconfigured.

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -169,7 +169,7 @@ There are two scripts to interact with controller manager from launch files:
       -c CONTROLLER_MANAGER, --controller-manager CONTROLLER_MANAGER
                             Name of the controller manager ROS node
       -p PARAM_FILE, --param-file PARAM_FILE
-                            Controller param file to be loaded into controller node before configure
+                            Controller param file to be loaded into controller node before configure. Parse multiple times to load different files for different controllers or to override the parameters of the same controller.
       -n NAMESPACE, --namespace NAMESPACE
                             DEPRECATED Namespace for the controller_manager and the controller(s)
       --load-only           Only load the controller and leave unconfigured.

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -551,16 +551,16 @@ controller_interface::ControllerInterfaceBaseSharedPtr ControllerManager::load_c
   // read_only params, dynamic maps lists etc
   // Now check if the parameters_file parameter exist
   const std::string param_name = controller_name + ".params_file";
-  std::string parameters_file;
+  std::vector<std::string> parameters_files;
 
   // Check if parameter has been declared
   if (!has_parameter(param_name))
   {
-    declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_STRING);
+    declare_parameter(param_name, rclcpp::ParameterType::PARAMETER_STRING_ARRAY);
   }
-  if (get_parameter(param_name, parameters_file) && !parameters_file.empty())
+  if (get_parameter(param_name, parameters_files) && !parameters_files.empty())
   {
-    controller_spec.info.parameters_file = parameters_file;
+    controller_spec.info.parameters_files = parameters_files;
   }
 
   const std::string fallback_ctrl_param = controller_name + ".fallback_controllers";
@@ -3250,14 +3250,17 @@ rclcpp::NodeOptions ControllerManager::determine_controller_node_options(
     node_options_arguments.push_back(arg);
   }
 
-  if (controller.info.parameters_file.has_value())
+  if (controller.info.parameters_files.has_value())
   {
-    if (!check_for_element(node_options_arguments, RCL_ROS_ARGS_FLAG))
+    for (const auto & parameters_file : controller.info.parameters_files.value())
     {
-      node_options_arguments.push_back(RCL_ROS_ARGS_FLAG);
+      if (!check_for_element(node_options_arguments, RCL_ROS_ARGS_FLAG))
+      {
+        node_options_arguments.push_back(RCL_ROS_ARGS_FLAG);
+      }
+      node_options_arguments.push_back(RCL_PARAM_FILE_FLAG);
+      node_options_arguments.push_back(parameters_file);
     }
-    node_options_arguments.push_back(RCL_PARAM_FILE_FLAG);
-    node_options_arguments.push_back(controller.info.parameters_file.value());
   }
 
   // ensure controller's `use_sim_time` parameter matches controller_manager's

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -278,7 +278,8 @@ TEST_F(TestLoadController, spawner_test_type_in_params_file)
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string(), test_file_path);
+    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string_array()[0],
+    test_file_path);
 
   auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(
@@ -290,7 +291,7 @@ TEST_F(TestLoadController, spawner_test_type_in_params_file)
     chain_ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string(),
+    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string_array()[0],
     test_file_path);
 
   EXPECT_EQ(
@@ -308,7 +309,8 @@ TEST_F(TestLoadController, spawner_test_type_in_params_file)
   ASSERT_EQ(
     ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string(), test_file_path);
+    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string_array()[0],
+    test_file_path);
 
   auto ctrl_2 = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(ctrl_2.info.name, "chainable_ctrl_with_parameters_and_type");
@@ -316,7 +318,7 @@ TEST_F(TestLoadController, spawner_test_type_in_params_file)
   ASSERT_EQ(
     ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string(),
+    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string_array()[0],
     test_file_path);
 }
 
@@ -377,7 +379,7 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
     ASSERT_TRUE(ctrl_1.info.fallback_controllers_names.empty());
     ASSERT_EQ(
       ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-    ASSERT_EQ(cm_->get_parameter("ctrl_1.params_file").as_string(), test_file_path);
+    ASSERT_EQ(cm_->get_parameter("ctrl_1.params_file").as_string_array()[0], test_file_path);
   }
 
   // Try to spawn now the controller with fallback controllers inside the yaml
@@ -392,7 +394,7 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
     ASSERT_TRUE(ctrl_1.info.fallback_controllers_names.empty());
     ASSERT_EQ(
       ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-    ASSERT_EQ(cm_->get_parameter("ctrl_1.params_file").as_string(), test_file_path);
+    ASSERT_EQ(cm_->get_parameter("ctrl_1.params_file").as_string_array()[0], test_file_path);
 
     auto ctrl_2 = cm_->get_loaded_controllers()[1];
     ASSERT_EQ(ctrl_2.info.name, "ctrl_2");
@@ -401,7 +403,7 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
       ctrl_2.info.fallback_controllers_names, testing::ElementsAre("ctrl_6", "ctrl_7", "ctrl_8"));
     ASSERT_EQ(
       ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-    ASSERT_EQ(cm_->get_parameter("ctrl_2.params_file").as_string(), test_file_path);
+    ASSERT_EQ(cm_->get_parameter("ctrl_2.params_file").as_string_array()[0], test_file_path);
 
     auto ctrl_3 = cm_->get_loaded_controllers()[2];
     ASSERT_EQ(ctrl_3.info.name, "ctrl_3");
@@ -409,7 +411,7 @@ TEST_F(TestLoadController, spawner_test_fallback_controllers)
     ASSERT_THAT(ctrl_3.info.fallback_controllers_names, testing::ElementsAre("ctrl_9"));
     ASSERT_EQ(
       ctrl_3.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-    ASSERT_EQ(cm_->get_parameter("ctrl_3.params_file").as_string(), test_file_path);
+    ASSERT_EQ(cm_->get_parameter("ctrl_3.params_file").as_string_array()[0], test_file_path);
   }
 }
 
@@ -695,7 +697,8 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter(ctrl_with_parameters_and_type.info.name + ".params_file").as_string(),
+    cm_->get_parameter(ctrl_with_parameters_and_type.info.name + ".params_file")
+      .as_string_array()[0],
     test_file_path);
 
   auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
@@ -708,7 +711,8 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
     chain_ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter(chain_ctrl_with_parameters_and_type.info.name + ".params_file").as_string(),
+    cm_->get_parameter(chain_ctrl_with_parameters_and_type.info.name + ".params_file")
+      .as_string_array()[0],
     test_file_path);
 
   EXPECT_EQ(
@@ -725,14 +729,16 @@ TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_type_in_params_file)
   ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-  ASSERT_EQ(cm_->get_parameter(ctrl_1.info.name + ".params_file").as_string(), test_file_path);
+  ASSERT_EQ(
+    cm_->get_parameter(ctrl_1.info.name + ".params_file").as_string_array()[0], test_file_path);
 
   auto ctrl_2 = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(ctrl_2.info.name, "ns_chainable_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_2.info.type, test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-  ASSERT_EQ(cm_->get_parameter(ctrl_2.info.name + ".params_file").as_string(), test_file_path);
+  ASSERT_EQ(
+    cm_->get_parameter(ctrl_2.info.name + ".params_file").as_string_array()[0], test_file_path);
 }
 
 TEST_F(
@@ -781,7 +787,8 @@ TEST_F(
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter(ctrl_with_parameters_and_type.info.name + ".params_file").as_string(),
+    cm_->get_parameter(ctrl_with_parameters_and_type.info.name + ".params_file")
+      .as_string_array()[0],
     test_file_path);
 
   auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
@@ -794,7 +801,8 @@ TEST_F(
     chain_ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
   ASSERT_EQ(
-    cm_->get_parameter(chain_ctrl_with_parameters_and_type.info.name + ".params_file").as_string(),
+    cm_->get_parameter(chain_ctrl_with_parameters_and_type.info.name + ".params_file")
+      .as_string_array()[0],
     test_file_path);
 
   EXPECT_EQ(
@@ -812,14 +820,16 @@ TEST_F(
   ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-  ASSERT_EQ(cm_->get_parameter(ctrl_1.info.name + ".params_file").as_string(), test_file_path);
+  ASSERT_EQ(
+    cm_->get_parameter(ctrl_1.info.name + ".params_file").as_string_array()[0], test_file_path);
 
   auto ctrl_2 = cm_->get_loaded_controllers()[1];
   ASSERT_EQ(ctrl_2.info.name, "ns_chainable_ctrl_with_parameters_and_type");
   ASSERT_EQ(ctrl_2.info.type, test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
   ASSERT_EQ(
     ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
-  ASSERT_EQ(cm_->get_parameter(ctrl_2.info.name + ".params_file").as_string(), test_file_path);
+  ASSERT_EQ(
+    cm_->get_parameter(ctrl_2.info.name + ".params_file").as_string_array()[0], test_file_path);
 }
 
 TEST_F(TestLoadControllerWithNamespacedCM, spawner_test_with_wildcard_entries_in_params_file)

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -938,3 +938,138 @@ TEST_F(
     ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
 }
+
+TEST_F(TestLoadController, spawner_test_parsing_multiple_params_file)
+{
+  const std::string test_file_path = ament_index_cpp::get_package_prefix("controller_manager") +
+                                     "/test/test_controller_spawner_with_type.yaml";
+  const std::string fallback_test_file_path =
+    ament_index_cpp::get_package_prefix("controller_manager") +
+    "/test/test_controller_spawner_with_fallback_controllers.yaml";
+
+  cm_->set_parameter(rclcpp::Parameter("ctrl_1.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+  cm_->set_parameter(rclcpp::Parameter("ctrl_2.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+
+  ControllerManagerRunner cm_runner(this);
+  // Provide controller type via the parsed file
+  EXPECT_EQ(
+    call_spawner(
+      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type ctrl_2 ctrl_1 "
+      "--load-only -c "
+      "test_controller_manager -p " +
+      test_file_path + " -p" + fallback_test_file_path),
+    0);
+
+  ASSERT_EQ(cm_->get_loaded_controllers().size(), 4ul);
+
+  auto ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[0];
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  auto params_file_info =
+    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], test_file_path);
+
+  auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.info.name, "chainable_ctrl_with_parameters_and_type");
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.info.type,
+    test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info =
+    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], test_file_path);
+
+  auto ctrl_2 = cm_->get_loaded_controllers()[2];
+  ASSERT_EQ(ctrl_2.info.name, "ctrl_2");
+  ASSERT_EQ(ctrl_2.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info = cm_->get_parameter("ctrl_2.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], fallback_test_file_path);
+
+  auto ctrl_1 = cm_->get_loaded_controllers()[3];
+  ASSERT_EQ(ctrl_1.info.name, "ctrl_1");
+  ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info = cm_->get_parameter("ctrl_1.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], fallback_test_file_path);
+}
+
+TEST_F(TestLoadController, spawner_test_parsing_same_params_file_multiple_times)
+{
+  const std::string test_file_path = ament_index_cpp::get_package_prefix("controller_manager") +
+                                     "/test/test_controller_spawner_with_type.yaml";
+  const std::string fallback_test_file_path =
+    ament_index_cpp::get_package_prefix("controller_manager") +
+    "/test/test_controller_spawner_with_fallback_controllers.yaml";
+
+  cm_->set_parameter(rclcpp::Parameter("ctrl_1.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+  cm_->set_parameter(rclcpp::Parameter("ctrl_2.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+
+  ControllerManagerRunner cm_runner(this);
+  // Provide controller type via the parsed file
+  EXPECT_EQ(
+    call_spawner(
+      "ctrl_with_parameters_and_type chainable_ctrl_with_parameters_and_type ctrl_2 ctrl_1 "
+      "--load-only -c "
+      "test_controller_manager -p " +
+      test_file_path + " -p" + fallback_test_file_path + " -p" + fallback_test_file_path + " -p" +
+      test_file_path),
+    0);
+
+  ASSERT_EQ(cm_->get_loaded_controllers().size(), 4ul);
+
+  auto ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[0];
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.name, "ctrl_with_parameters_and_type");
+  ASSERT_EQ(ctrl_with_parameters_and_type.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  auto params_file_info =
+    cm_->get_parameter("ctrl_with_parameters_and_type.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], test_file_path);
+
+  auto chain_ctrl_with_parameters_and_type = cm_->get_loaded_controllers()[1];
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.info.name, "chainable_ctrl_with_parameters_and_type");
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.info.type,
+    test_chainable_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    chain_ctrl_with_parameters_and_type.c->get_lifecycle_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info =
+    cm_->get_parameter("chainable_ctrl_with_parameters_and_type.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], test_file_path);
+
+  auto ctrl_2 = cm_->get_loaded_controllers()[2];
+  ASSERT_EQ(ctrl_2.info.name, "ctrl_2");
+  ASSERT_EQ(ctrl_2.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_2.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info = cm_->get_parameter("ctrl_2.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], fallback_test_file_path);
+
+  auto ctrl_1 = cm_->get_loaded_controllers()[3];
+  ASSERT_EQ(ctrl_1.info.name, "ctrl_1");
+  ASSERT_EQ(ctrl_1.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(
+    ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED);
+  params_file_info = cm_->get_parameter("ctrl_1.params_file").as_string_array();
+  ASSERT_EQ(params_file_info.size(), 1ul);
+  ASSERT_EQ(params_file_info[0], fallback_test_file_path);
+}

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -76,6 +76,7 @@ controller_manager
 * The ``--controller-type`` or ``-t`` spawner arg is removed. Now the controller type is defined in the controller configuration file with ``type`` field (`#1639 <https://github.com/ros-controls/ros2_control/pull/1639>`_).
 * The ``--namespace`` or ``-n`` spawner arg is deprecated. Now the spawner namespace can be defined using the ROS 2 standard way (`#1640 <https://github.com/ros-controls/ros2_control/pull/1640>`_).
 * Added support for the wildcard entries for the controller configuration files (`#1724 <https://github.com/ros-controls/ros2_control/pull/1724>`_).
+* The spawner now supports parsing multiple ``-p`` or ``--param-file`` arguments, this should help in loading multiple parameter files for a controller or for multiple controllers (`#1805 <https://github.com/ros-controls/ros2_control/pull/1805>`_).
 * ``--switch-timeout`` was added as parameter to the helper scripts ``spawner.py`` and ``unspawner.py``. Useful if controllers cannot be switched immediately, e.g., paused simulations at startup (`#1790 <https://github.com/ros-controls/ros2_control/pull/1790>`_).
 * ``ros2_control_node`` can now handle the sim time used by different simulators, when ``use_sim_time`` is set to true (`#1810 <https://github.com/ros-controls/ros2_control/pull/1810>`_).
 * The ``ros2_control_node`` node now accepts the ``thread_priority`` parameter to set the scheduler priority of the controller_manager's RT thread (`#1820 <https://github.com/ros-controls/ros2_control/pull/1820>`_).

--- a/hardware_interface/include/hardware_interface/controller_info.hpp
+++ b/hardware_interface/include/hardware_interface/controller_info.hpp
@@ -34,7 +34,7 @@ struct ControllerInfo
   std::string type;
 
   /// Controller param file
-  std::optional<std::string> parameters_file;
+  std::optional<std::vector<std::string>> parameters_files;
 
   /// List of claimed interfaces by the controller.
   std::vector<std::string> claimed_interfaces;

--- a/ros2controlcli/ros2controlcli/verb/load_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_controller.py
@@ -17,7 +17,7 @@ from controller_manager import (
     load_controller,
     list_controllers,
     switch_controllers,
-    set_controller_parameters_from_param_file,
+    set_controller_parameters_from_param_files,
     bcolors,
 )
 
@@ -68,11 +68,11 @@ class LoadControllerVerb(VerbExtension):
                     if not os.path.isabs(args.param_file):
                         args.param_file = os.path.join(os.getcwd(), args.param_file)
 
-                    if not set_controller_parameters_from_param_file(
+                    if not set_controller_parameters_from_param_files(
                         node,
                         args.controller_manager,
                         args.controller_name,
-                        args.param_file,
+                        [args.param_file],
                         node.get_namespace(),
                     ):
                         return 1


### PR DESCRIPTION
When we use multiple controlers to activate or deactivate, it is quite cumbersome to accept only one `--param-file` arg as it is not very scalable. For this reason, now the spawner can accept multiple --param-file args and set the respective param_file to those corresponding controllers. 

Along with the above mentioned change, now the controllers can accept multiple param-file args as well, and this is very helpful to be able to override parameters between parameter files as how it is done with the standard ROS 2 nodes