### PR TITLE
Fix timeout value in std output

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -114,7 +114,7 @@ def service_caller(
         if future.result() is None:
             node.get_logger().warning(
                 f"Failed getting a result from calling {fully_qualified_service_name} in "
-                f"{service_timeout}. (Attempt {attempt+1} of {max_attempts}.)"
+                f"{call_timeout}. (Attempt {attempt+1} of {max_attempts}.)"
             )
         else:
             return future.result()


### PR DESCRIPTION
We were using the wrong timeout in the terminal output there.

As pointed out in https://github.com/ros-controls/ros2_control/pull/1501#discussion_r1809082195

Thanks @tonynajjar for spotting this!