### PR TITLE
[ros2_control_node] add thread_priority option to the ros2_control_node

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -58,11 +58,15 @@ int main(int argc, char ** argv)
     executor, manager_node_name, "", cm_node_options);
 
   RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
+  const int thread_priority = cm->get_parameter_or<int>("thread_priority", kSchedPriority);
+  RCLCPP_INFO(
+    cm->get_logger(), "Spawning %s RT thread with scheduler priority: %d", cm->get_name(),
+    thread_priority);
 
   std::thread cm_thread(
-    [cm]()
+    [cm, thread_priority]()
     {
-      if (!realtime_tools::configure_sched_fifo(kSchedPriority))
+      if (!realtime_tools::configure_sched_fifo(thread_priority))
       {
         RCLCPP_WARN(
           cm->get_logger(),

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -76,6 +76,7 @@ controller_manager
 * The ``--controller-type`` or ``-t`` spawner arg is removed. Now the controller type is defined in the controller configuration file with ``type`` field (`#1639 <https://github.com/ros-controls/ros2_control/pull/1639>`_).
 * The ``--namespace`` or ``-n`` spawner arg is deprecated. Now the spawner namespace can be defined using the ROS 2 standard way (`#1640 <https://github.com/ros-controls/ros2_control/pull/1640>`_).
 * Added support for the wildcard entries for the controller configuration files (`#1724 <https://github.com/ros-controls/ros2_control/pull/1724>`_).
+* The ``ros2_control_node`` node now accepts the ``thread_priority`` parameter to set the scheduler priority of the controller_manager's RT thread (`#1820 <https://github.com/ros-controls/ros2_control/pull/1820>`_).
 
 hardware_interface
 ******************


### PR DESCRIPTION
Right now, the thread_priority is hard-coded to 50, this PR allows the users to be able to choose their desired priority by setting a parameter at launch time

https://github.com/ros-controls/ros2_control/blob/b0da4a16201b7429444a094f236449b1469c229e/controller_manager/src/ros2_control_node.cpp#L32