### PR TITLE
Fix gmock CMP0115

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -195,7 +195,7 @@ if(BUILD_TESTING)
   )
 
   ament_add_gmock(test_hardware_spawner
-    test/test_hardware_spawner
+    test/test_hardware_spawner.cpp
     TIMEOUT 120
   )
   target_link_libraries(test_hardware_spawner


### PR DESCRIPTION
Fixes
```
--- stderr: controller_manager                                           
CMake Warning (dev) at /opt/ros/rolling/share/ament_cmake_gmock/cmake/ament_add_gmock_executable.cmake:50 (add_executable):
  Policy CMP0115 is not set: Source file extensions must be explicit.  Run
  "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  File:

    /workspaces/ros2_rolling_ws/src/ros2_control/controller_manager/test/test_hardware_spawner.cpp
Call Stack (most recent call first):
  /opt/ros/rolling/share/ament_cmake_gmock/cmake/ament_add_gmock_executable.cmake:37 (_ament_add_gmock_executable)
  /opt/ros/rolling/share/ament_cmake_gmock/cmake/ament_add_gmock.cmake:65 (ament_add_gmock_executable)
  CMakeLists.txt:197 (ament_add_gmock)
This warning is for project developers.  Use -Wno-dev to suppress it.
```