### PR TITLE
fix: typo use thread_priority

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -79,7 +79,7 @@ int main(int argc, char ** argv)
       {
         RCLCPP_INFO(
           cm->get_logger(), "Successful set up FIFO RT scheduling policy with priority %i.",
-          kSchedPriority);
+          thread_priority);
       }
 
       // for calculating sleep time


### PR DESCRIPTION
Fixed typo with the logs with the thread priority usage. Use the user set parameter thread priority rather than default `kSchedPriority`.  If user doesn't set the thread_priority it will be defaulted to the kSchedPriority.