### PR TITLE
Reset the async handler variables to handle exceptions properly

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -67,7 +67,15 @@ return_type ControllerInterfaceBase::init(
     });
 
   node_->register_on_activate(
-    std::bind(&ControllerInterfaceBase::on_activate, this, std::placeholders::_1));
+    [this](const rclcpp_lifecycle::State & previous_state) -> CallbackReturn
+    {
+      if (is_async() && async_handler_ && async_handler_->is_running())
+      {
+        // This is needed if it is disabled due to a thrown exception in the async callback thread
+        async_handler_->reset_variables();
+      }
+      return on_activate(previous_state);
+    });
 
   node_->register_on_deactivate(
     std::bind(&ControllerInterfaceBase::on_deactivate, this, std::placeholders::_1));


### PR DESCRIPTION
Exception handling is recently added to AsyncFunctionHandler :  https://github.com/ros-controls/realtime_tools/pull/172

Right now, if the exception is thrown and the variables are not reset, activating the controller will continue to throw an exception unless it is properly reset. For this to work properly, the user is forced to reconfigure his controller and then activate it. 