### PR TITLE
Use Clock instead of Rate for backward compatibility of rolling

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -58,7 +58,6 @@ int main(int argc, char ** argv)
     executor, manager_node_name, "", cm_node_options);
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
-  rclcpp::Rate rate(cm->get_update_rate(), cm->get_clock());
 
   const bool lock_memory = cm->get_parameter_or<bool>("lock_memory", true);
   std::string message;
@@ -85,7 +84,7 @@ int main(int argc, char ** argv)
     thread_priority);
 
   std::thread cm_thread(
-    [cm, thread_priority, use_sim_time, &rate]()
+    [cm, thread_priority, use_sim_time]()
     {
       if (!realtime_tools::configure_sched_fifo(thread_priority))
       {
@@ -128,7 +127,7 @@ int main(int argc, char ** argv)
         next_iteration_time += period;
         if (use_sim_time)
         {
-          rate.sleep();
+          cm->get_clock()->sleep_until(current_time + period);
         }
         else
         {


### PR DESCRIPTION
The recently merged : https://github.com/ros-controls/ros2_control/pull/1810 breaks the backward compatibility of rolling in Humble, as the Humble rclcpp doesn't have the implementation of the Rate using Clock -> https://github.com/ros2/rclcpp/blob/humble/rclcpp/include/rclcpp/rate.hpp#L115

This PR proposes a fix by using the Clock's `sleep_until` method which is backward compatible and works the same 