### PR TITLE
Fix the missing `bcolors.ENDC` in hardware_spawner log prints

### DIFF
--- a/controller_manager/controller_manager/hardware_spawner.py
+++ b/controller_manager/controller_manager/hardware_spawner.py
@@ -67,18 +67,15 @@ def handle_set_component_state_service_call(
     response = set_hardware_component_state(node, controller_manager_name, component, target_state)
     if response.ok and response.state == target_state:
         node.get_logger().info(
-            bcolors.OKGREEN
-            + f"{action} component '{component}'. Hardware now in state: {response.state}."
+            f"{bcolors.OKGREEN}{action} component '{component}'. Hardware now in state: {response.state}.{bcolors.ENDC}"
         )
     elif response.ok and not response.state == target_state:
         node.get_logger().warn(
-            bcolors.WARNING
-            + f"Could not {action} component '{component}'. Service call returned ok=True, but state: {response.state} is not equal to target state '{target_state}'."
+            f"{bcolors.WARNING}Could not {action} component '{component}'. Service call returned ok=True, but state: {response.state} is not equal to target state '{target_state}'.{bcolors.ENDC}"
         )
     else:
         node.get_logger().warn(
-            bcolors.WARNING
-            + f"Could not {action} component '{component}'. Service call failed. Wrong component name?"
+            f"{bcolors.WARNING}Could not {action} component '{component}'. Service call failed. Wrong component name?{bcolors.ENDC}"
         )
 
 
@@ -160,9 +157,7 @@ def main(args=None):
                 node, controller_manager_name, hardware_component, controller_manager_timeout
             ):
                 node.get_logger().warn(
-                    bcolors.WARNING
-                    + "Hardware Component is not loaded - state can not be changed."
-                    + bcolors.ENDC
+                    f"{bcolors.WARNING}Hardware Component is not loaded - state can not be changed.{bcolors.ENDC}"
                 )
             elif activate:
                 activate_component(node, controller_manager_name, hardware_component)
@@ -170,14 +165,14 @@ def main(args=None):
                 configure_component(node, controller_manager_name, hardware_component)
             else:
                 node.get_logger().error(
-                    'You need to either specify if the hardware component should be activated with the "--activate" flag or configured with the "--configure" flag'
+                    f'{bcolors.FAIL}You need to either specify if the hardware component should be activated with the "--activate" flag or configured with the "--configure" flag{bcolors.ENDC}'
                 )
                 parser.print_help()
                 return 0
     except KeyboardInterrupt:
         pass
     except ServiceNotFoundError as err:
-        node.get_logger().fatal(str(err))
+        node.get_logger().fatal(f"{bcolors.FAIL}{str(err)}{bcolors.ENDC}")
         return 1
     finally:
         rclpy.shutdown()


### PR DESCRIPTION
While running some tests, I realized that the `bcolors.ENDC` is missing in couple of logging statements in hardware spawner and this is causing the logs to continue to stay in that color. 

**Previously:**
![image](https://github.com/user-attachments/assets/4cd705bd-1933-4a87-a6c5-6dddd642bb2e)

**With the fix proposed in this PR:**
![image](https://github.com/user-attachments/assets/508186cd-015e-46ea-89a1-6db809cd1223)
