### PR TITLE
Add missing virtual keywords to SystemInterface methods

### DIFF
--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -178,7 +178,7 @@ public:
    *
    * \return vector of shared pointers to the created and stored StateInterfaces
    */
-  std::vector<StateInterface::ConstSharedPtr> on_export_state_interfaces()
+  virtual std::vector<StateInterface::ConstSharedPtr> on_export_state_interfaces()
   {
     // import the unlisted interfaces
     std::vector<hardware_interface::InterfaceDescription> unlisted_interface_descriptions =
@@ -270,7 +270,7 @@ public:
    *
    * \return vector of shared pointers to the created and stored CommandInterfaces
    */
-  std::vector<CommandInterface::SharedPtr> on_export_command_interfaces()
+  virtual std::vector<CommandInterface::SharedPtr> on_export_command_interfaces()
   {
     // import the unlisted interfaces
     std::vector<hardware_interface::InterfaceDescription> unlisted_interface_descriptions =


### PR DESCRIPTION
This PR fixes an issue where the `on_export_state_interfaces` and `on_export_command_interfaces` functions in the `SystemInterface` class were missing the virtual keyword, even though they should be overrideable according to the [migration.rst : Custom export of Command-/StateInterfaces](https://github.com/ros-controls/ros2_control/blob/41d73939597a9332779ebdab82a72f4d13125328/doc/migration.rst#custom-export-of-command-stateinterfaces).

In contrast, the `ActuatorInterface` and `SensorInterface` classes already have the virtual keyword for these functions, as shown in the following references:

https://github.com/ros-controls/ros2_control/blob/41d73939597a9332779ebdab82a72f4d13125328/hardware_interface/include/hardware_interface/actuator_interface.hpp#L176
https://github.com/ros-controls/ros2_control/blob/41d73939597a9332779ebdab82a72f4d13125328/hardware_interface/include/hardware_interface/actuator_interface.hpp#L253
https://github.com/ros-controls/ros2_control/blob/41d73939597a9332779ebdab82a72f4d13125328/hardware_interface/include/hardware_interface/sensor_interface.hpp#L174
This PR ensures consistency across these interfaces and aligns with the intended design outlined in the documentation.

Let me know if you need additional information or adjustments!