### PR TITLE
Integrate pal_statistics for introspection of controllers, hardware components and more

### DIFF
--- a/controller_interface/include/controller_interface/controller_interface_base.hpp
+++ b/controller_interface/include/controller_interface/controller_interface_base.hpp
@@ -27,6 +27,7 @@
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 
+#include "pal_statistics/pal_statistics_utils.hpp"
 #include "rclcpp/version.h"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 
@@ -313,6 +314,15 @@ public:
   CONTROLLER_INTERFACE_PUBLIC
   void wait_for_trigger_update_to_finish();
 
+  CONTROLLER_INTERFACE_PUBLIC
+  std::string get_name() const;
+
+  /// Enable or disable introspection of the controller.
+  /**
+   * \param[in] enable Enable introspection if true, disable otherwise.
+   */
+  void enable_introspection(bool enable);
+
 protected:
   std::vector<hardware_interface::LoanedCommandInterface> command_interfaces_;
   std::vector<hardware_interface::LoanedStateInterface> state_interfaces_;
@@ -324,6 +334,9 @@ private:
   bool is_async_ = false;
   std::string urdf_ = "";
   ControllerUpdateStats trigger_stats_;
+
+protected:
+  pal_statistics::RegistrationsRAII stats_registrations_;
 };
 
 using ControllerInterfaceBaseSharedPtr = std::shared_ptr<ControllerInterfaceBase>;

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -139,9 +139,6 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
         &ControllerInterfaceBase::update, this, std::placeholders::_1, std::placeholders::_2),
       thread_priority);
     async_handler_->start_thread();
-    REGISTER_DEFAULT_INTROSPECTION(
-      "execution_time",
-      std::function<int()>([this]() { return async_handler_->get_last_execution_time().count(); }));
   }
   REGISTER_DEFAULT_INTROSPECTION("total_triggers", &trigger_stats_.total_triggers);
   REGISTER_DEFAULT_INTROSPECTION("failed_triggers", &trigger_stats_.failed_triggers);

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -69,6 +69,7 @@ return_type ControllerInterfaceBase::init(
   node_->register_on_activate(
     [this](const rclcpp_lifecycle::State & previous_state) -> CallbackReturn
     {
+      enable_introspection(true);
       if (is_async() && async_handler_ && async_handler_->is_running())
       {
         // This is needed if it is disabled due to a thrown exception in the async callback thread
@@ -78,7 +79,11 @@ return_type ControllerInterfaceBase::init(
     });
 
   node_->register_on_deactivate(
-    std::bind(&ControllerInterfaceBase::on_deactivate, this, std::placeholders::_1));
+    [this](const rclcpp_lifecycle::State & previous_state) -> CallbackReturn
+    {
+      enable_introspection(false);
+      return on_deactivate(previous_state);
+    });
 
   node_->register_on_shutdown(
     std::bind(&ControllerInterfaceBase::on_shutdown, this, std::placeholders::_1));
@@ -134,7 +139,12 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
         &ControllerInterfaceBase::update, this, std::placeholders::_1, std::placeholders::_2),
       thread_priority);
     async_handler_->start_thread();
+    REGISTER_DEFAULT_INTROSPECTION(
+      "execution_time",
+      std::function<int()>([this]() { return async_handler_->get_last_execution_time().count(); }));
   }
+  REGISTER_DEFAULT_INTROSPECTION("total_triggers", &trigger_stats_.total_triggers);
+  REGISTER_DEFAULT_INTROSPECTION("failed_triggers", &trigger_stats_.failed_triggers);
   trigger_stats_.reset();
 
   return get_node()->configure();
@@ -213,4 +223,19 @@ void ControllerInterfaceBase::wait_for_trigger_update_to_finish()
     async_handler_->wait_for_trigger_cycle_to_finish();
   }
 }
+
+std::string ControllerInterfaceBase::get_name() const { return get_node()->get_name(); }
+
+void ControllerInterfaceBase::enable_introspection(bool enable)
+{
+  if (enable)
+  {
+    stats_registrations_.enableAll();
+  }
+  else
+  {
+    stats_registrations_.disableAll();
+  }
+}
+
 }  // namespace controller_interface

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -83,7 +83,7 @@ public:
     const rclcpp::NodeOptions & options = get_cm_node_options());
 
   CONTROLLER_MANAGER_PUBLIC
-  virtual ~ControllerManager() = default;
+  virtual ~ControllerManager();
 
   CONTROLLER_MANAGER_PUBLIC
   void robot_description_callback(const std_msgs::msg::String & msg);

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   tinyxml2_vendor
   joint_limits
   urdf
+  pal_statistics
 )
 
 find_package(ament_cmake REQUIRED)

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -28,6 +28,7 @@
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "pal_statistics/pal_statistics_utils.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
@@ -409,6 +410,22 @@ public:
    */
   const HardwareInfo & get_hardware_info() const { return info_; }
 
+  /// Enable or disable introspection of the hardware.
+  /**
+   * \param[in] enable Enable introspection if true, disable otherwise.
+   */
+  void enable_introspection(bool enable)
+  {
+    if (enable)
+    {
+      stats_registrations_.enableAll();
+    }
+    else
+    {
+      stats_registrations_.disableAll();
+    }
+  }
+
 protected:
   HardwareInfo info_;
   // interface names to InterfaceDescription
@@ -433,6 +450,9 @@ private:
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> actuator_states_;
   std::unordered_map<std::string, CommandInterface::SharedPtr> actuator_commands_;
+
+protected:
+  pal_statistics::RegistrationsRAII stats_registrations_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -24,6 +24,7 @@
 #include <variant>
 
 #include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/introspection.hpp"
 #include "hardware_interface/macros.hpp"
 
 namespace hardware_interface
@@ -207,6 +208,23 @@ public:
   {
   }
 
+  void registerIntrospection() const
+  {
+    if (std::holds_alternative<double>(value_))
+    {
+      std::function<double()> f = [this]() { return *value_ptr_; };
+      REGISTER_ENTITY(DEFAULT_REGISTRY_KEY, "state_interface." + get_name(), f);
+    }
+  }
+
+  void unregisterIntrospection() const
+  {
+    if (std::holds_alternative<double>(value_))
+    {
+      UNREGISTER_ENTITY(DEFAULT_REGISTRY_KEY, "state_interface." + get_name());
+    }
+  }
+
   StateInterface(const StateInterface & other) = default;
 
   StateInterface(StateInterface && other) = default;
@@ -233,6 +251,27 @@ public:
   CommandInterface(const CommandInterface & other) = delete;
 
   CommandInterface(CommandInterface && other) = default;
+
+  void registerIntrospection() const
+  {
+    if (std::holds_alternative<double>(value_))
+    {
+      RCLCPP_INFO_STREAM(
+        rclcpp::get_logger("command_interface"), "Registering handle: " << get_name());
+      std::function<double()> f = [this]() { return *value_ptr_; };
+      REGISTER_ENTITY(DEFAULT_REGISTRY_KEY, "command_interface." + get_name(), f);
+    }
+  }
+
+  void unregisterIntrospection() const
+  {
+    if (std::holds_alternative<double>(value_))
+    {
+      RCLCPP_INFO_STREAM(
+        rclcpp::get_logger("command_interface"), "Unregistering handle: " << get_name());
+      UNREGISTER_ENTITY(DEFAULT_REGISTRY_KEY, "command_interface." + get_name());
+    }
+  }
 
   using Handle::Handle;
 

--- a/hardware_interface/include/hardware_interface/introspection.hpp
+++ b/hardware_interface/include/hardware_interface/introspection.hpp
@@ -1,0 +1,28 @@
+// Copyright 2024 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// \author Sai Kishor Kothakota
+
+#ifndef HARDWARE_INTERFACE__INTROSPECTION_HPP_
+#define HARDWARE_INTERFACE__INTROSPECTION_HPP_
+
+#include <pal_statistics/pal_statistics_macros.hpp>
+
+namespace hardware_interface
+{
+constexpr char DEFAULT_REGISTRY_KEY[] = "ros2_control";
+constexpr char DEFAULT_INTROSPECTION_TOPIC[] = "introspection_data";
+}  // namespace hardware_interface
+
+#endif  // HARDWARE_INTERFACE__INTROSPECTION_HPP_

--- a/hardware_interface/include/hardware_interface/introspection.hpp
+++ b/hardware_interface/include/hardware_interface/introspection.hpp
@@ -22,7 +22,7 @@
 namespace hardware_interface
 {
 constexpr char DEFAULT_REGISTRY_KEY[] = "ros2_control";
-constexpr char DEFAULT_INTROSPECTION_TOPIC[] = "introspection_data";
+constexpr char DEFAULT_INTROSPECTION_TOPIC[] = "~/introspection_data";
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__INTROSPECTION_HPP_

--- a/hardware_interface/include/hardware_interface/introspection.hpp
+++ b/hardware_interface/include/hardware_interface/introspection.hpp
@@ -23,6 +23,11 @@ namespace hardware_interface
 {
 constexpr char DEFAULT_REGISTRY_KEY[] = "ros2_control";
 constexpr char DEFAULT_INTROSPECTION_TOPIC[] = "~/introspection_data";
+
+#define REGISTER_DEFAULT_INTROSPECTION(ID, ENTITY)                           \
+  REGISTER_ENTITY(                                                           \
+    hardware_interface::DEFAULT_REGISTRY_KEY, get_name() + "." + ID, ENTITY, \
+    &stats_registrations_, false)
 }  // namespace hardware_interface
 
 #endif  // HARDWARE_INTERFACE__INTROSPECTION_HPP_

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -28,6 +28,7 @@
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "pal_statistics/pal_statistics_utils.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/node_interfaces/node_clock_interface.hpp"
@@ -271,6 +272,22 @@ public:
    */
   const HardwareInfo & get_hardware_info() const { return info_; }
 
+  /// Enable or disable introspection of the sensor hardware.
+  /**
+   * \param[in] enable Enable introspection if true, disable otherwise.
+   */
+  void enable_introspection(bool enable)
+  {
+    if (enable)
+    {
+      stats_registrations_.enableAll();
+    }
+    else
+    {
+      stats_registrations_.disableAll();
+    }
+  }
+
 protected:
   HardwareInfo info_;
   // interface names to InterfaceDescription
@@ -288,6 +305,9 @@ private:
   rclcpp::Logger sensor_logger_;
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> sensor_states_map_;
+
+protected:
+  pal_statistics::RegistrationsRAII stats_registrations_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -29,6 +29,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "pal_statistics/pal_statistics_utils.hpp"
 #include "rclcpp/duration.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
@@ -438,6 +439,22 @@ public:
    */
   const HardwareInfo & get_hardware_info() const { return info_; }
 
+  /// Enable or disable introspection of the hardware.
+  /**
+   * \param[in] enable Enable introspection if true, disable otherwise.
+   */
+  void enable_introspection(bool enable)
+  {
+    if (enable)
+    {
+      stats_registrations_.enableAll();
+    }
+    else
+    {
+      stats_registrations_.disableAll();
+    }
+  }
+
 protected:
   HardwareInfo info_;
   // interface names to InterfaceDescription
@@ -472,6 +489,9 @@ private:
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> system_states_;
   std::unordered_map<std::string, CommandInterface::SharedPtr> system_commands_;
+
+protected:
+  pal_statistics::RegistrationsRAII stats_registrations_;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -19,6 +19,7 @@
   <depend>joint_limits</depend>
   <depend>urdf</depend>
   <depend>sdformat_urdf</depend>
+  <depend>pal_statistics</depend>
 
   <build_depend>rcutils</build_depend>
   <exec_depend>rcutils</exec_depend>

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -94,6 +94,7 @@ const rclcpp_lifecycle::State & Actuator::configure()
 const rclcpp_lifecycle::State & Actuator::cleanup()
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
@@ -115,6 +116,7 @@ const rclcpp_lifecycle::State & Actuator::cleanup()
 const rclcpp_lifecycle::State & Actuator::shutdown()
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
@@ -142,6 +144,7 @@ const rclcpp_lifecycle::State & Actuator::activate()
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
+        impl_->enable_introspection(true);
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_state_names::ACTIVE));
         break;
@@ -160,6 +163,7 @@ const rclcpp_lifecycle::State & Actuator::activate()
 const rclcpp_lifecycle::State & Actuator::deactivate()
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
     switch (impl_->on_deactivate(impl_->get_lifecycle_state()))
@@ -183,6 +187,7 @@ const rclcpp_lifecycle::State & Actuator::deactivate()
 const rclcpp_lifecycle::State & Actuator::error()
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -632,6 +632,7 @@ public:
         command_interface->get_name() + "]");
       throw std::runtime_error(msg);
     }
+    command_interface->registerIntrospection();
   }
 
   // BEGIN (Handle export change): for backward compatibility, can be removed if
@@ -689,6 +690,7 @@ public:
         interface->get_name() + "]");
       throw std::runtime_error(msg);
     }
+    interface->registerIntrospection();
     return interface_name;
   }
   /// Adds exported state interfaces into internal storage.
@@ -736,6 +738,7 @@ public:
   {
     for (const auto & interface : interface_names)
     {
+      state_interface_map_[interface]->unregisterIntrospection();
       state_interface_map_.erase(interface);
     }
   }
@@ -796,6 +799,7 @@ public:
   {
     for (const auto & interface : interface_names)
     {
+      command_interface_map_[interface]->unregisterIntrospection();
       command_interface_map_.erase(interface);
       claimed_command_interface_map_.erase(interface);
     }

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -93,6 +93,7 @@ const rclcpp_lifecycle::State & Sensor::configure()
 const rclcpp_lifecycle::State & Sensor::cleanup()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
@@ -114,6 +115,7 @@ const rclcpp_lifecycle::State & Sensor::cleanup()
 const rclcpp_lifecycle::State & Sensor::shutdown()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
@@ -141,6 +143,7 @@ const rclcpp_lifecycle::State & Sensor::activate()
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
+        impl_->enable_introspection(true);
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_state_names::ACTIVE));
         break;
@@ -159,6 +162,7 @@ const rclcpp_lifecycle::State & Sensor::activate()
 const rclcpp_lifecycle::State & Sensor::deactivate()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
     switch (impl_->on_deactivate(impl_->get_lifecycle_state()))
@@ -182,6 +186,7 @@ const rclcpp_lifecycle::State & Sensor::deactivate()
 const rclcpp_lifecycle::State & Sensor::error()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -92,6 +92,7 @@ const rclcpp_lifecycle::State & System::configure()
 const rclcpp_lifecycle::State & System::cleanup()
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     switch (impl_->on_cleanup(impl_->get_lifecycle_state()))
@@ -113,6 +114,7 @@ const rclcpp_lifecycle::State & System::cleanup()
 const rclcpp_lifecycle::State & System::shutdown()
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
@@ -140,6 +142,7 @@ const rclcpp_lifecycle::State & System::activate()
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
+        impl_->enable_introspection(true);
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, lifecycle_state_names::ACTIVE));
         break;
@@ -158,6 +161,7 @@ const rclcpp_lifecycle::State & System::activate()
 const rclcpp_lifecycle::State & System::deactivate()
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
+  impl_->enable_introspection(false);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
     switch (impl_->on_deactivate(impl_->get_lifecycle_state()))
@@ -181,6 +185,7 @@ const rclcpp_lifecycle::State & System::deactivate()
 const rclcpp_lifecycle::State & System::error()
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
+  impl_->enable_introspection(false);
   if (
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN &&
     impl_->get_lifecycle_state().id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)


### PR DESCRIPTION
Added integration of pal_statistics into the ros2_control infrastructure 

You can find more examples in https://github.com/ros-controls/ros2_control/pull/1897