### PR TITLE
fix: suppress unnecessary warnings in clock received validation

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2367,17 +2367,16 @@ controller_interface::return_type ControllerManager::update(
   update_loop_counter_ %= update_rate_;
 
   // Check for valid time
-  if (
-    !get_clock()->started() &&
-    time == rclcpp::Time(0, 0, this->get_node_clock_interface()->get_clock()->get_clock_type()))
+  if (!get_clock()->started())
   {
-    throw std::runtime_error(
-      "No clock received, and time argument is zero. Check your controller_manager node's "
-      "clock configuration (use_sim_time parameter) and if a valid clock source is "
-      "available. Also pass a proper time argument to the update method.");
-  }
-  else
-  {
+    if (time == rclcpp::Time(0, 0, this->get_node_clock_interface()->get_clock()->get_clock_type()))
+    {
+      throw std::runtime_error(
+        "No clock received, and time argument is zero. Check your controller_manager node's "
+        "clock configuration (use_sim_time parameter) and if a valid clock source is "
+        "available. Also pass a proper time argument to the update method.");
+    }
+
     // this can happen with use_sim_time=true until the /clock is received
     rclcpp::Clock clock = rclcpp::Clock();
     RCLCPP_WARN_THROTTLE(


### PR DESCRIPTION
This PR aims to fix clock received validation to suppress unnecessary warning logs.

Previously, the code was displaying warning logs when checking clock received status regardless of the validation timing. This could lead to excessive warning logs in normal operation scenarios.

Changes:
- Add explicit condition to check `!get_clock()->received()` before displaying warning log
- Keep the same warning message for when an actual clock sync issue occurs

This change helps reduce noise in logs by only reporting warnings when there's a genuine clock synchronization issue.