### PR TITLE
Destroy service clients explicitely

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -117,7 +117,9 @@ def service_caller(
                 f"{call_timeout}. (Attempt {attempt+1} of {max_attempts}.)"
             )
         else:
+            node.destroy_client(cli)
             return future.result()
+    node.destroy_client(cli)
     raise RuntimeError(
         f"Could not successfully call service {fully_qualified_service_name} after {max_attempts} attempts."
     )


### PR DESCRIPTION
While trying to fix https://github.com/ros-controls/ros2_control_demos/pull/666 I found out that the cm `service_caller` adds a client for every call, but never [destroys](https://github.com/ros2/rclpy/blob/23e9c570db7cb276e880b0672c6d43bf4deeb2a0/rclpy/rclpy/node.py#L1943) it.
If the spawner is used with a list of controllers, it will create identical service clients in the same node -> might cause issues.


