### PR TITLE
Reuse spawner service clients

### DIFF
--- a/controller_manager/controller_manager/__init__.py
+++ b/controller_manager/controller_manager/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .controller_manager_services import (
+    ServiceCallerNode,
     configure_controller,
     list_controller_types,
     list_controllers,
@@ -30,6 +31,7 @@ from .controller_manager_services import (
 )
 
 __all__ = [
+    "ServiceCallerNode",
     "configure_controller",
     "list_controller_types",
     "list_controllers",

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -21,6 +21,7 @@ import time
 import warnings
 
 from controller_manager import (
+    ServiceCallerNode,
     configure_controller,
     list_controllers,
     load_controller,
@@ -32,7 +33,6 @@ from controller_manager import (
 from controller_manager.controller_manager_services import ServiceNotFoundError
 
 import rclpy
-from rclpy.node import Node
 from rclpy.signals import SignalHandlerOptions
 
 
@@ -160,7 +160,7 @@ def main(args=None):
             if not os.path.isfile(param_file):
                 raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
 
-    node = Node("spawner_" + controller_names[0])
+    node = ServiceCallerNode("spawner_" + controller_names[0])
 
     if node.get_namespace() != "/" and args.namespace:
         raise RuntimeError(


### PR DESCRIPTION
This is an attempt to reduce the overhead and DDS discovery issues associated with starting multiple controllers with the spawner. See https://github.com/ros-controls/ros2_control/issues/1934 for some background.

In this PR, we save off the service client in spawner for reuse for subsequent controllers so we're not creating a new service client for each controller. This change improves the performance and reduces the failures when starting multiple controllers at a time.

There may be a better way to do this so please comment.

Also, this PR conflicts with https://github.com/ros-controls/ros2_control/pull/1944 and may not require that PR anymore.