### PR TITLE
Use singleton approach to store and reuse the service clients

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -55,6 +55,35 @@ class ServiceNotFoundError(Exception):
     pass
 
 
+class SingletonServiceCaller:
+    """
+    Singleton class to call services of controller manager.
+
+    This class is used to create a service client for a given service name.
+    If the service client already exists, it returns the existing client.
+    It is used to avoid creating multiple service clients for the same service name.
+
+    It needs Node object, service type and fully qualified service name to create a service client.
+
+    """
+
+    _clients = {}
+
+    def __new__(cls, node, service_type, fully_qualified_service_name):
+        if fully_qualified_service_name not in cls._clients:
+            cls._clients[fully_qualified_service_name] = node.create_client(
+                service_type, fully_qualified_service_name
+            )
+            node.get_logger().debug(
+                f"{bcolors.MAGENTA}Creating a new service client : {fully_qualified_service_name}{bcolors.ENDC}"
+            )
+
+        node.get_logger().debug(
+            f"{bcolors.OKBLUE}Returning the existing service client : {fully_qualified_service_name}{bcolors.ENDC}"
+        )
+        return cls._clients[fully_qualified_service_name]
+
+
 def service_caller(
     node,
     service_name,
@@ -92,7 +121,7 @@ def service_caller(
     fully_qualified_service_name = (
         f"{namespace}/{service_name}" if not service_name.startswith("/") else service_name
     )
-    cli = node.create_client(service_type, fully_qualified_service_name)
+    cli = SingletonServiceCaller(node, service_type, fully_qualified_service_name)
 
     while not cli.service_is_ready():
         node.get_logger().info(

--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -70,18 +70,18 @@ class SingletonServiceCaller:
     _clients = {}
 
     def __new__(cls, node, service_type, fully_qualified_service_name):
-        if fully_qualified_service_name not in cls._clients:
-            cls._clients[fully_qualified_service_name] = node.create_client(
+        if (node, fully_qualified_service_name) not in cls._clients:
+            cls._clients[(node, fully_qualified_service_name)] = node.create_client(
                 service_type, fully_qualified_service_name
             )
             node.get_logger().debug(
-                f"{bcolors.MAGENTA}Creating a new service client : {fully_qualified_service_name}{bcolors.ENDC}"
+                f"{bcolors.MAGENTA}Creating a new service client : {fully_qualified_service_name} with node : {node.get_name()}{bcolors.ENDC}"
             )
 
         node.get_logger().debug(
-            f"{bcolors.OKBLUE}Returning the existing service client : {fully_qualified_service_name}{bcolors.ENDC}"
+            f"{bcolors.OKBLUE}Returning the existing service client : {fully_qualified_service_name} for node : {node.get_name()}{bcolors.ENDC}"
         )
-        return cls._clients[fully_qualified_service_name]
+        return cls._clients[(node, fully_qualified_service_name)]
 
 
 def service_caller(

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -342,6 +342,7 @@ def main(args=None):
         node.get_logger().fatal(str(err))
         return 1
     finally:
+        node.destroy_node()
         rclpy.shutdown()
 
 


### PR DESCRIPTION
Fixes: #1934 

the node.destroy_node() at the end does the same thing by destroying clients and every subscribers, publishers etc (https://github.com/ros2/rclpy/blob/8f1f16f16090184062f1993728d063ff2680f958/rclpy/rclpy/node.py#L2017-L2053)