### PR TITLE
Execute command switch for async hardware components

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1649,9 +1649,11 @@ bool ResourceManager::prepare_command_mode_switch(
   };
 
   const bool actuators_result = call_prepare_mode_switch(resource_storage_->actuators_);
+  const bool async_actuators_result = call_prepare_mode_switch(resource_storage_->async_actuators_);
   const bool systems_result = call_prepare_mode_switch(resource_storage_->systems_);
+  const bool async_systems_result = call_prepare_mode_switch(resource_storage_->async_systems_);
 
-  return actuators_result && systems_result;
+  return actuators_result && async_actuators_result && systems_result && async_systems_result;
 }
 
 // CM API: Called in "update"-thread
@@ -1714,9 +1716,11 @@ bool ResourceManager::perform_command_mode_switch(
   };
 
   const bool actuators_result = call_perform_mode_switch(resource_storage_->actuators_);
+  const bool async_actuators_result = call_perform_mode_switch(resource_storage_->async_actuators_);
   const bool systems_result = call_perform_mode_switch(resource_storage_->systems_);
-
-  return actuators_result && systems_result;
+  const bool async_systems_result = call_perform_mode_switch(resource_storage_->async_systems_);
+  
+  return actuators_result && async_actuators_result && systems_result && async_systems_result;
 }
 
 // CM API: Called in "callback/slow"-thread


### PR DESCRIPTION
Call `prepare_command_mode_switch` and `perform_command_mode_switch` also on async hardware components. Currently this is not the case as they are stored separately in the resource storage.
