### PR TITLE
Make get_name() return a const reference

### DIFF
--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -81,12 +81,12 @@ public:
     }
   }
 
-  const std::string get_name() const { return command_interface_.get_name(); }
+  const std::string & get_name() const { return command_interface_.get_name(); }
 
   const std::string & get_interface_name() const { return command_interface_.get_interface_name(); }
 
   [[deprecated(
-    "Replaced by get_name method, which is semantically more correct")]] const std::string
+    "Replaced by get_name method, which is semantically more correct")]] const std::string &
   get_full_name() const
   {
     return command_interface_.get_name();

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -86,7 +86,7 @@ public:
   const std::string & get_interface_name() const { return command_interface_.get_interface_name(); }
 
   [[deprecated(
-    "Replaced by get_name method, which is semantically more correct")]] const std::string &
+    "Replaced by get_name method, which is semantically more correct")]] const std::string
   get_full_name() const
   {
     return command_interface_.get_name();

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -75,12 +75,12 @@ public:
     }
   }
 
-  const std::string get_name() const { return state_interface_.get_name(); }
+  const std::string & get_name() const { return state_interface_.get_name(); }
 
   const std::string & get_interface_name() const { return state_interface_.get_interface_name(); }
 
   [[deprecated(
-    "Replaced by get_name method, which is semantically more correct")]] const std::string
+    "Replaced by get_name method, which is semantically more correct")]] const std::string &
   get_full_name() const
   {
     return state_interface_.get_name();

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -80,7 +80,7 @@ public:
   const std::string & get_interface_name() const { return state_interface_.get_interface_name(); }
 
   [[deprecated(
-    "Replaced by get_name method, which is semantically more correct")]] const std::string &
+    "Replaced by get_name method, which is semantically more correct")]] const std::string
   get_full_name() const
   {
     return state_interface_.get_name();


### PR DESCRIPTION
This PR provides a simple update: get_name() now returns const std::string& instead of std::string. This avoids unnecessary copies and improves efficiency.