### PR TITLE
Add fix to strip the single quotes while using `--controller-ros-args`

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -216,7 +216,7 @@ def main(args=None):
                         controller_manager_name,
                         controller_name,
                         "node_options_args",
-                        controller_ros_args.split(),
+                        controller_ros_args.strip("'").split(),
                     ):
                         return 1
                 if param_files:


### PR DESCRIPTION
With the changes introduced in  #1713. When updating the demos, if we encapsulate the args into single quotes, then it seems not to work. 

We cannot leave single quotes in the launch description, as it complains for pre-commit. The proposed changes should handle both the cases