### PR TITLE
Log an error if update() call returns `ERROR`

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2122,7 +2122,7 @@ controller_interface::return_type ControllerManager::update(
 
         if (controller_ret != controller_interface::return_type::OK)
         {
-          RCLCPP_ERROR_ONCE(
+          RCLCPP_ERROR(
             get_logger(), "The update call of the following controller returned an error: '%s'",
             loaded_controller.info.name.c_str());
           ret = controller_ret;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2122,6 +2122,9 @@ controller_interface::return_type ControllerManager::update(
 
         if (controller_ret != controller_interface::return_type::OK)
         {
+          RCLCPP_ERROR_ONCE(
+            get_logger(), "The update call of the following controller returned an error: '%s'",
+            loaded_controller.info.name.c_str());
           ret = controller_ret;
         }
       }


### PR DESCRIPTION
As we discussed in #1873: On humble we do not take any action if the update call of a controller returns ERROR. As we don't want to break the behavior on humble, I suggest adding at least a log output. 

I'm just not sure if we should just print it once, throttled, or on every call.

Closes #1873 