### PR TITLE
Using urdf/model.hpp for rolling

### DIFF
--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -20,7 +20,12 @@
 #include <unordered_map>
 #include <vector>
 
-#include "urdf/model.h"
+#include "rclcpp/version.h"
+#if RCLCPP_VERSION_GTE(29, 0, 0)
+#include "urdf/model.hpp"  
+#else
+#include "urdf/model.h"  
+#endif
 
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/hardware_info.hpp"

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -22,9 +22,9 @@
 
 #include "rclcpp/version.h"
 #if RCLCPP_VERSION_GTE(29, 0, 0)
-#include "urdf/model.hpp"  
+#include "urdf/model.hpp"
 #else
-#include "urdf/model.h"  
+#include "urdf/model.h"
 #endif
 
 #include "hardware_interface/component_parser.hpp"


### PR DESCRIPTION
### **Description**

**This pull request addresses the use of the deprecated `urdf/model.h` header in component_parser.cpp to ensure compatibility with Rolling, Jazzy, and Humble distributions of ROS 2.**

**Since `urdf/model.h` was replaced by `urdf/model.hpp` in newer ROS 2 distributions starting from Rolling, this PR introduces a version-conditional include to maintain backward compatibility with older distributions.**

Fixes #1977 