### PR TITLE
Remove ControllerMock #1948

### DIFF
--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -226,10 +226,4 @@ public:
   ControllerManagerFixture<CtrlMgr> * cmf_;
 };
 
-class ControllerMock : public controller_interface::ControllerInterface
-{
-public:
-  MOCK_METHOD0(update, controller_interface::return_type(void));
-};
-
 #endif  // CONTROLLER_MANAGER_TEST_COMMON_HPP_


### PR DESCRIPTION
I was looking at the #1948, and indeed this is an overload and not a overrided method. There is no update method that takes zero arguments. Nevertheless, I've checked and this code is not used in ros2_control nor in any other ros2_control repo. I think this might be deleted.