### PR TITLE
Fix: on_shutdown callback of controllers never get executed #1987

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -318,6 +318,13 @@ private:
   void initialize_parameters();
 
   /**
+   * Call shutdown and move given controller to the finalized state.
+   *
+   * \param[in] controller controller to be shutdown.
+   */
+  void shutdown_controller(controller_manager::ControllerSpec & controller) const;
+
+  /**
    * Clear request lists used when switching controllers. The lists are shared between "callback"
    * and "control loop" threads.
    */

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -695,7 +695,7 @@ controller_interface::return_type ControllerManager::unload_controller(
     return controller_interface::return_type::ERROR;
   }
 
-  RCLCPP_DEBUG(get_logger(), "Cleanup controller");
+  RCLCPP_DEBUG(get_logger(), "Shutdown controller");
   controller_chain_spec_cleanup(controller_chain_spec_, controller_name);
   // TODO(destogl): remove reference interface if chainable; i.e., add a separate method for
   // cleaning-up controllers?
@@ -705,29 +705,7 @@ controller_interface::return_type ControllerManager::unload_controller(
       get_logger(), "Controller '%s' is cleaned-up before unloading!", controller_name.c_str());
     // TODO(destogl): remove reference interface if chainable; i.e., add a separate method for
     // cleaning-up controllers?
-    try
-    {
-      const auto new_state = controller.c->get_node()->cleanup();
-      if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
-      {
-        RCLCPP_WARN(
-          get_logger(), "Failed to clean-up the controller '%s' before unloading!",
-          controller_name.c_str());
-      }
-    }
-    catch (const std::exception & e)
-    {
-      RCLCPP_ERROR(
-        get_logger(),
-        "Caught exception of type : %s while cleaning up the controller '%s' before unloading: %s",
-        typeid(e).name(), controller_name.c_str(), e.what());
-    }
-    catch (...)
-    {
-      RCLCPP_ERROR(
-        get_logger(), "Failed to clean-up the controller '%s' before unloading",
-        controller_name.c_str());
-    }
+    shutdown_controller(controller);
   }
   executor_->remove_node(controller.c->get_node()->get_node_base_interface());
   to.erase(found_it);
@@ -743,6 +721,31 @@ controller_interface::return_type ControllerManager::unload_controller(
   RCLCPP_DEBUG(get_logger(), "Successfully unloaded controller '%s'", controller_name.c_str());
 
   return controller_interface::return_type::OK;
+}
+
+void ControllerManager::shutdown_controller(controller_manager::ControllerSpec & controller) const
+try
+{
+  const auto new_state = controller.c->get_node()->shutdown();
+  if (new_state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
+  {
+    RCLCPP_WARN(
+      get_logger(), "Failed to shut-down the controller '%s' before unloading!",
+      controller.info.name.c_str());
+  }
+}
+catch (const std::exception & e)
+{
+  RCLCPP_ERROR(
+    get_logger(),
+    "Caught exception of type : %s while shut down the controller '%s' before unloading: %s",
+    typeid(e).name(), controller.info.name.c_str(), e.what());
+}
+catch (...)
+{
+  RCLCPP_ERROR(
+    get_logger(), "Failed to shut-down the controller '%s' before unloading",
+    controller.info.name.c_str());
 }
 
 std::vector<ControllerSpec> ControllerManager::get_loaded_controllers() const


### PR DESCRIPTION
As discussed with @christophfroehlich, I added a shutdown call instead of calling cleanup.