### PR TITLE
Define _USE_MATH_DEFINES in joint_soft_limiter.cpp to ensure that M_PI is defined

### DIFF
--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 /// \author Adrià Roig Moreno
+#define _USE_MATH_DEFINES
 #include "joint_limits/joint_soft_limiter.hpp"
 
 namespace joint_limits


### PR DESCRIPTION
`joint_soft_limiter.cpp` uses `M_PI`, that on Windows is defined by `cmath` only if the `_USE_MATH_DEFINES` macro is defined prior to the first inclusion of cmath.

fyi @GilmarCorreia

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
