### PR TITLE
Fix memory leak in the ros2_control

### DIFF
--- a/hardware_interface/include/hardware_interface/actuator.hpp
+++ b/hardware_interface/include/hardware_interface/actuator.hpp
@@ -72,9 +72,9 @@ public:
     const std::vector<std::string> & start_interfaces,
     const std::vector<std::string> & stop_interfaces);
 
-  std::string get_name() const;
+  const std::string & get_name() const;
 
-  std::string get_group_name() const;
+  const std::string & get_group_name() const;
 
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -461,13 +461,13 @@ public:
   /**
    * \return name.
    */
-  virtual std::string get_name() const { return info_.name; }
+  const std::string & get_name() const { return info_.name; }
 
   /// Get name of the actuator hardware group to which it belongs to.
   /**
    * \return group name.
    */
-  virtual std::string get_group_name() const { return info_.group; }
+  const std::string & get_group_name() const { return info_.group; }
 
   /// Get life-cycle state of the actuator hardware.
   /**

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -158,11 +158,11 @@ struct InterfaceDescription
    */
   std::string interface_name;
 
-  std::string get_prefix_name() const { return prefix_name; }
+  const std::string & get_prefix_name() const { return prefix_name; }
 
-  std::string get_interface_name() const { return interface_info.name; }
+  const std::string & get_interface_name() const { return interface_info.name; }
 
-  std::string get_name() const { return interface_name; }
+  const std::string & get_name() const { return interface_name; }
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.

--- a/hardware_interface/include/hardware_interface/sensor.hpp
+++ b/hardware_interface/include/hardware_interface/sensor.hpp
@@ -62,9 +62,9 @@ public:
 
   std::vector<StateInterface::ConstSharedPtr> export_state_interfaces();
 
-  std::string get_name() const;
+  const std::string & get_name() const;
 
-  std::string get_group_name() const;
+  const std::string & get_group_name() const;
 
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -275,13 +275,13 @@ public:
   /**
    * \return name.
    */
-  virtual std::string get_name() const { return info_.name; }
+  const std::string & get_name() const { return info_.name; }
 
   /// Get name of the actuator hardware group to which it belongs to.
   /**
    * \return group name.
    */
-  virtual std::string get_group_name() const { return info_.group; }
+  const std::string & get_group_name() const { return info_.group; }
 
   /// Get life-cycle state of the actuator hardware.
   /**

--- a/hardware_interface/include/hardware_interface/system.hpp
+++ b/hardware_interface/include/hardware_interface/system.hpp
@@ -72,9 +72,9 @@ public:
     const std::vector<std::string> & start_interfaces,
     const std::vector<std::string> & stop_interfaces);
 
-  std::string get_name() const;
+  const std::string & get_name() const;
 
-  std::string get_group_name() const;
+  const std::string & get_group_name() const;
 
   const rclcpp_lifecycle::State & get_lifecycle_state() const;
 

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -490,13 +490,13 @@ public:
   /**
    * \return name.
    */
-  virtual std::string get_name() const { return info_.name; }
+  const std::string & get_name() const { return info_.name; }
 
   /// Get name of the actuator hardware group to which it belongs to.
   /**
    * \return group name.
    */
-  virtual std::string get_group_name() const { return info_.group; }
+  const std::string & get_group_name() const { return info_.group; }
 
   /// Get life-cycle state of the actuator hardware.
   /**

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -277,9 +277,9 @@ return_type Actuator::perform_command_mode_switch(
   return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
 }
 
-std::string Actuator::get_name() const { return impl_->get_name(); }
+const std::string & Actuator::get_name() const { return impl_->get_name(); }
 
-std::string Actuator::get_group_name() const { return impl_->get_group_name(); }
+const std::string & Actuator::get_group_name() const { return impl_->get_group_name(); }
 
 const rclcpp_lifecycle::State & Actuator::get_lifecycle_state() const
 {

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -233,9 +233,9 @@ std::vector<StateInterface::ConstSharedPtr> Sensor::export_state_interfaces()
   // END: for backward compatibility
 }
 
-std::string Sensor::get_name() const { return impl_->get_name(); }
+const std::string & Sensor::get_name() const { return impl_->get_name(); }
 
-std::string Sensor::get_group_name() const { return impl_->get_group_name(); }
+const std::string & Sensor::get_group_name() const { return impl_->get_group_name(); }
 
 const rclcpp_lifecycle::State & Sensor::get_lifecycle_state() const
 {

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -275,9 +275,9 @@ return_type System::perform_command_mode_switch(
   return impl_->perform_command_mode_switch(start_interfaces, stop_interfaces);
 }
 
-std::string System::get_name() const { return impl_->get_name(); }
+const std::string & System::get_name() const { return impl_->get_name(); }
 
-std::string System::get_group_name() const { return impl_->get_group_name(); }
+const std::string & System::get_group_name() const { return impl_->get_group_name(); }
 
 const rclcpp_lifecycle::State & System::get_lifecycle_state() const
 {

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -101,8 +101,6 @@ class DummyActuator : public hardware_interface::ActuatorInterface
     return command_interfaces;
   }
 
-  std::string get_name() const override { return "DummyActuator"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
@@ -193,8 +191,6 @@ class DummyActuatorDefault : public hardware_interface::ActuatorInterface
     return CallbackReturn::SUCCESS;
   }
 
-  std::string get_name() const override { return "DummyActuatorDefault"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
@@ -276,8 +272,6 @@ class DummySensor : public hardware_interface::SensorInterface
     return state_interfaces;
   }
 
-  std::string get_name() const override { return "DummySensor"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
@@ -337,8 +331,6 @@ class DummySensorDefault : public hardware_interface::SensorInterface
     return CallbackReturn::SUCCESS;
   }
 
-  std::string get_name() const override { return "DummySensorDefault"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
@@ -396,8 +388,6 @@ class DummySensorJointDefault : public hardware_interface::SensorInterface
     read_calls_ = 0;
     return CallbackReturn::SUCCESS;
   }
-
-  std::string get_name() const override { return "DummySensorJointDefault"; }
 
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
@@ -501,8 +491,6 @@ class DummySystem : public hardware_interface::SystemInterface
 
     return command_interfaces;
   }
-
-  std::string get_name() const override { return "DummySystem"; }
 
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
@@ -608,8 +596,6 @@ class DummySystemDefault : public hardware_interface::SystemInterface
     return CallbackReturn::SUCCESS;
   }
 
-  std::string get_name() const override { return "DummySystemDefault"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {
@@ -686,8 +672,6 @@ class DummySystemPreparePerform : public hardware_interface::SystemInterface
     // We hardcode the info
     return CallbackReturn::SUCCESS;
   }
-
-  std::string get_name() const override { return "DummySystemPreparePerform"; }
 
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override

--- a/hardware_interface/test/test_component_interfaces_custom_export.cpp
+++ b/hardware_interface/test/test_component_interfaces_custom_export.cpp
@@ -54,8 +54,6 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 
 class DummyActuatorDefault : public hardware_interface::ActuatorInterface
 {
-  std::string get_name() const override { return "DummyActuatorDefault"; }
-
   std::vector<hardware_interface::InterfaceDescription>
   export_unlisted_state_interface_descriptions() override
   {
@@ -95,8 +93,6 @@ class DummyActuatorDefault : public hardware_interface::ActuatorInterface
 
 class DummySensorDefault : public hardware_interface::SensorInterface
 {
-  std::string get_name() const override { return "DummySensorDefault"; }
-
   std::vector<hardware_interface::InterfaceDescription>
   export_unlisted_state_interface_descriptions() override
   {
@@ -118,8 +114,6 @@ class DummySensorDefault : public hardware_interface::SensorInterface
 
 class DummySystemDefault : public hardware_interface::SystemInterface
 {
-  std::string get_name() const override { return "DummySystemDefault"; }
-
   std::vector<hardware_interface::InterfaceDescription>
   export_unlisted_state_interface_descriptions() override
   {

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -371,8 +371,6 @@ class ExternalComponent : public hardware_interface::ActuatorInterface
     return command_interfaces;
   }
 
-  std::string get_name() const override { return "ExternalComponent"; }
-
   hardware_interface::return_type read(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) override
   {


### PR DESCRIPTION
For some reason, the `get_name` method that is returning by copy is creating various mallocs in the RT loop and this is causing slight memory leaks.

gdb with breakpoint on `malloc`, brings me to these logs, so it would be nice to have this sorted to not have allocations in the RT loop

````#1  0x00007f7185c0a98c in operator new(unsigned long) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#2  0x00007f71817f5cdd in ?? () from //lib/librobot_control.so
#3  0x00007f718580eb29 in hardware_interface::System::get_name[abi:cxx11]() const () from lib/libhardware_interface.so
#4  0x00007f71857ebc62 in ?? () from lib/libhardware_interface.so
#5  0x00007f71857edd20 in hardware_interface::ResourceManager::read(rclcpp::Time const&, rclcpp::Duration const&) () from lib/libhardware_interface.so
#6  0x00007f718608b5de in controller_manager::ControllerManager::read(rclcpp::Time const&, rclcpp::Duration const&) () from lib/libcontroller_manager.so
#7  0x000055dd43023c26 in ?? ()
#8  0x00007f7185c38253 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007f71859a7ac3 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#10 0x00007f7185a39850 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```