### PR TITLE
Fix wrong CM statistics + add fix for overruns

### DIFF
--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -361,10 +361,6 @@ cpu_affinity (optional; int (or) int_array;)
 thread_priority (optional; int; default: 50)
   Sets the thread priority of the ``controller_manager`` node to the specified value. The value must be between 0 and 99.
 
-overrun_wait_period (optional; double; default: 10% of the control period)
-  Sets the time to wait for the control loop to catch up after an overrun.
-  Overrun is triggered when the control loop takes longer than the control period to execute.
-
 use_sim_time (optional; bool; default: false)
   Enables the use of simulation time in the ``controller_manager`` node.
 

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -361,6 +361,10 @@ cpu_affinity (optional; int (or) int_array;)
 thread_priority (optional; int; default: 50)
   Sets the thread priority of the ``controller_manager`` node to the specified value. The value must be between 0 and 99.
 
+overrun_wait_period (optional; double; default: 10% of the control period)
+  Sets the time to wait for the control loop to catch up after an overrun.
+  Overrun is triggered when the control loop takes longer than the control period to execute.
+
 use_sim_time (optional; bool; default: false)
   Enables the use of simulation time in the ``controller_manager`` node.
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -20,7 +20,6 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "rclcpp/executors.hpp"
-#include "rclcpp/version.h"
 #include "realtime_tools/realtime_helpers.hpp"
 
 using namespace std::chrono_literals;
@@ -54,19 +53,13 @@ int main(int argc, char ** argv)
     node_arguments.push_back(argv[i]);
   }
   cm_node_options.arguments(node_arguments);
-  const bool has_realtime = realtime_tools::has_realtime_kernel();
-  const auto cm_clock_type = has_realtime ? RCL_STEADY_TIME : RCL_ROS_TIME;
-#if RCLCPP_VERSION_MAJOR >= 18
-  cm_node_options.clock_type(cm_clock_type);
-#endif
+
   auto cm = std::make_shared<controller_manager::ControllerManager>(
     executor, manager_node_name, "", cm_node_options);
-  RCLCPP_INFO(
-    cm->get_logger(), "Starting controller manager using %s clock",
-    cm->get_clock()->get_clock_type() == RCL_STEADY_TIME ? "STEADY" : "ROS");
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
 
+  const bool has_realtime = realtime_tools::has_realtime_kernel();
   const bool lock_memory = cm->get_parameter_or<bool>("lock_memory", has_realtime);
   if (lock_memory)
   {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -152,11 +152,11 @@ int main(int argc, char ** argv)
         }
         else
         {
-          const std::chrono::system_clock::time_point time_now{
-            std::chrono::nanoseconds(cm->now().nanoseconds())};
-          if (next_iteration_time < time_now)
+          const auto time_now = cm->now().nanoseconds();
+          if (next_iteration_time.time_since_epoch().count() < time_now)
           {
-            const double time_diff = static_cast<double>((time_now - next_iteration_time).count());
+            const double time_diff =
+              static_cast<double>((time_now - next_iteration_time.time_since_epoch().count()));
             const double cm_period = 1.0 / static_cast<double>(cm->get_update_rate());
             const int overrun_count = static_cast<int>(std::ceil(time_diff / cm_period));
             RCLCPP_WARN(

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -130,7 +130,7 @@ int main(int argc, char ** argv)
       std::this_thread::sleep_for(period);
 
       auto const cm_now = std::chrono::nanoseconds(cm->now().nanoseconds());
-      std::chrono::steady_clock::time_point next_iteration_time{cm_now};
+      std::chrono::system_clock::time_point next_iteration_time{cm_now};
 
       while (rclcpp::ok())
       {
@@ -152,7 +152,7 @@ int main(int argc, char ** argv)
         }
         else
         {
-          const std::chrono::steady_clock::time_point time_now{
+          const std::chrono::system_clock::time_point time_now{
             std::chrono::nanoseconds(cm->now().nanoseconds())};
           if (next_iteration_time < time_now)
           {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
     executor, manager_node_name, "", cm_node_options);
   RCLCPP_INFO(
     cm->get_logger(), "Starting controller manager using %s clock",
-    has_realtime ? "STEADY" : "ROS");
+    cm->get_clock()->get_clock_type() == RCL_STEADY_TIME ? "STEADY" : "ROS");
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
 

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -156,16 +156,14 @@ int main(int argc, char ** argv)
             std::chrono::nanoseconds(cm->now().nanoseconds())};
           if (next_iteration_time < time_now)
           {
-            const int overrun_count = static_cast<int>(std::ceil(
-              static_cast<double>(time_now.time_since_epoch().count()) /
-              static_cast<double>(next_iteration_time.time_since_epoch().count())));
+            const double time_diff = static_cast<double>((time_now - next_iteration_time).count());
+            const double cm_period = 1.0 / static_cast<double>(cm->get_update_rate());
+            const int overrun_count = static_cast<int>(std::ceil(time_diff / cm_period));
             RCLCPP_WARN(
               cm->get_logger(),
               "Overrun detected! The controller manager missed its desired rate of %d Hz. The loop "
               "took %f ms (missed cycles : %d).",
-              cm->get_update_rate(),
-              static_cast<double>((time_now - next_iteration_time).count() + period.count()) / 1e6,
-              overrun_count + 1);
+              cm->get_update_rate(), time_diff + cm_period, overrun_count + 1);
             next_iteration_time += (overrun_count * period);
           }
           std::this_thread::sleep_until(next_iteration_time);

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -124,12 +124,14 @@ int main(int argc, char ** argv)
 
       // for calculating sleep time
       auto const period = std::chrono::nanoseconds(1'000'000'000 / cm->get_update_rate());
-      auto const cm_now = std::chrono::nanoseconds(cm->now().nanoseconds());
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
-        next_iteration_time{cm_now - period};
 
       // for calculating the measured period of the loop
-      rclcpp::Time previous_time = cm->now() - period;
+      rclcpp::Time previous_time = cm->now();
+      std::this_thread::sleep_for(period);
+
+      auto const cm_now = std::chrono::nanoseconds(cm->now().nanoseconds());
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>
+        next_iteration_time{cm_now};
 
       while (rclcpp::ok())
       {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -61,11 +61,9 @@ int main(int argc, char ** argv)
 #endif
   auto cm = std::make_shared<controller_manager::ControllerManager>(
     executor, manager_node_name, "", cm_node_options);
-  const auto cm_clock =
-    (RCLCPP_VERSION_MAJOR >= 18) ? cm->get_clock() : std::make_shared<rclcpp::Clock>(cm_clock_type);
   RCLCPP_INFO(
     cm->get_logger(), "Starting controller manager using %s clock",
-    cm_clock->get_clock_type() == RCL_STEADY_TIME ? "STEADY" : "ROS");
+    cm->get_clock()->get_clock_type() == RCL_STEADY_TIME ? "STEADY" : "ROS");
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
 
@@ -103,8 +101,8 @@ int main(int argc, char ** argv)
   }
 
   // wait for the clock to be available
-  cm_clock->wait_until_started();
-  cm_clock->sleep_for(rclcpp::Duration::from_seconds(1.0 / cm->get_update_rate()));
+  cm->get_clock()->wait_until_started();
+  cm->get_clock()->sleep_for(rclcpp::Duration::from_seconds(1.0 / cm->get_update_rate()));
 
   RCLCPP_INFO(cm->get_logger(), "update rate is %d Hz", cm->get_update_rate());
   const int thread_priority = cm->get_parameter_or<int>("thread_priority", kSchedPriority);
@@ -113,7 +111,7 @@ int main(int argc, char ** argv)
     thread_priority);
 
   std::thread cm_thread(
-    [cm, cm_clock, thread_priority, use_sim_time]()
+    [cm, thread_priority, use_sim_time]()
     {
       if (!realtime_tools::configure_sched_fifo(thread_priority))
       {
@@ -135,7 +133,7 @@ int main(int argc, char ** argv)
       auto const period = std::chrono::nanoseconds(1'000'000'000 / cm->get_update_rate());
 
       // for calculating the measured period of the loop
-      rclcpp::Time previous_time = cm_clock->now();
+      rclcpp::Time previous_time = cm->now();
       std::this_thread::sleep_for(period);
 
       std::chrono::steady_clock::time_point next_iteration_time{std::chrono::steady_clock::now()};
@@ -143,19 +141,19 @@ int main(int argc, char ** argv)
       while (rclcpp::ok())
       {
         // calculate measured period
-        auto const current_time = cm_clock->now();
+        auto const current_time = cm->now();
         auto const measured_period = current_time - previous_time;
         previous_time = current_time;
 
         // execute update loop
-        cm->read(cm_clock->now(), measured_period);
-        cm->update(cm_clock->now(), measured_period);
-        cm->write(cm_clock->now(), measured_period);
+        cm->read(cm->now(), measured_period);
+        cm->update(cm->now(), measured_period);
+        cm->write(cm->now(), measured_period);
 
         // wait until we hit the end of the period
         if (use_sim_time)
         {
-          cm_clock->sleep_until(current_time + period);
+          cm->get_clock()->sleep_until(current_time + period);
         }
         else
         {

--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -156,8 +156,8 @@ int main(int argc, char ** argv)
           if (next_iteration_time.time_since_epoch().count() < time_now)
           {
             const double time_diff =
-              static_cast<double>((time_now - next_iteration_time.time_since_epoch().count()));
-            const double cm_period = 1.0 / static_cast<double>(cm->get_update_rate());
+              static_cast<double>((time_now - next_iteration_time.time_since_epoch().count())) / 1.e6;
+            const double cm_period = 1.e3 / static_cast<double>(cm->get_update_rate());
             const int overrun_count = static_cast<int>(std::ceil(time_diff / cm_period));
             RCLCPP_WARN(
               cm->get_logger(),


### PR DESCRIPTION
There is a bug in the CM statistics in the first loop, but then apart from that, when there is a controller that takes longer in the loop, this causes an overrun in the system. In order to fix it, I've added an overrun check and adjust the time properly to trigger the loops. 

Earlier, the triggered overruns are the cause for such fast loops, resulting in high periodicity reports

Tested on real hardware TIAGo  at 1kHz 

![image](https://github.com/user-attachments/assets/d7fad7b1-eb51-4ec2-a090-674448f9e270)
