### PR TITLE
fix introspection for handles with variable references

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -206,17 +206,17 @@ public:
 
   void registerIntrospection() const
   {
-    if (std::holds_alternative<double>(value_))
+    if (value_ptr_ || std::holds_alternative<double>(value_))
     {
       std::function<double()> f = [this]()
-      { return value_ptr_ ? *value_ptr_ : std::numeric_limits<double>::quiet_NaN(); };
+      { return value_ptr_ ? *value_ptr_ : std::get<double>(value_); };
       DEFAULT_REGISTER_ROS2_CONTROL_INTROSPECTION("state_interface." + get_name(), f);
     }
   }
 
   void unregisterIntrospection() const
   {
-    if (std::holds_alternative<double>(value_))
+    if (value_ptr_ || std::holds_alternative<double>(value_))
     {
       DEFAULT_UNREGISTER_ROS2_CONTROL_INTROSPECTION("state_interface." + get_name());
     }
@@ -251,17 +251,17 @@ public:
 
   void registerIntrospection() const
   {
-    if (std::holds_alternative<double>(value_))
+    if (value_ptr_ || std::holds_alternative<double>(value_))
     {
       std::function<double()> f = [this]()
-      { return value_ptr_ ? *value_ptr_ : std::numeric_limits<double>::quiet_NaN(); };
+      { return value_ptr_ ? *value_ptr_ : std::get<double>(value_); };
       DEFAULT_REGISTER_ROS2_CONTROL_INTROSPECTION("command_interface." + get_name(), f);
     }
   }
 
   void unregisterIntrospection() const
   {
-    if (std::holds_alternative<double>(value_))
+    if (value_ptr_ || std::holds_alternative<double>(value_))
     {
       DEFAULT_UNREGISTER_ROS2_CONTROL_INTROSPECTION("command_interface." + get_name());
     }


### PR DESCRIPTION
While testing the new master on our robots, I realized that if we use old hardware interface handles, when it holds a variable reference, the introspection is not working properly as the condition is not properly done. This PR aims to fix this issue.

Tested on the robot and I confirm it is working :)