### PR TITLE
[CI] 3rd party downstream build: Build the ros2_control packages from source

### DIFF
--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -41,8 +41,7 @@ jobs:
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace:
-        ros2_control.jazzy.repos
+      upstream_workspace: os2_control.jazzy.repos
       # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -41,7 +41,9 @@ jobs:
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace: ros2_control.jazzy.repos
+      upstream_workspace: | # build also the ros2_control packages
+        ros2_control.jazzy.repos
+        ros_controls.jazzy.repos
       # we don't test this repository, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -30,7 +30,7 @@ jobs:
       ros_repo: testing
       ref_for_scheduled_build: master
       upstream_workspace: ros2_control.jazzy.repos
-      # we don't test this repository, we just build it
+      # we don't test target_workspace, we just build it
       not_test_build: true
       # we test the downstream packages, which are part of our organization
       downstream_workspace: ros_controls.jazzy.repos
@@ -41,11 +41,12 @@ jobs:
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace: | # build also the ros2_control packages
+      upstream_workspace:
         ros2_control.jazzy.repos
-        ros_controls.jazzy.repos
-      # we don't test this repository, we just build it
+      # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: downstream.jazzy.repos
+      downstream_workspace: | # build also the ros2_control packages
+        downstream.jazzy.repos
+        ros_controls.jazzy.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -45,7 +45,7 @@ jobs:
       # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: | # build also the ros2_control packages
-        downstream.jazzy.repos
+      downstream_workspace: | # build also the ros_controls packages
         ros_controls.jazzy.repos
+        downstream.jazzy.repos
       not_test_downstream: true

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -41,7 +41,7 @@ jobs:
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace: os2_control.jazzy.repos
+      upstream_workspace: ros2_control.jazzy.repos
       # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -49,8 +49,7 @@ jobs:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace:
-        ros2_control.${{ matrix.ROS_DISTRO }}.repos
+      upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -53,7 +53,7 @@ jobs:
       # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: | # build also the ros2_control packages
+      downstream_workspace: | # build also the ros_controls packages
         ros_controls.${{ matrix.ROS_DISTRO }}.repos
         downstream.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -49,7 +49,9 @@ jobs:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
+      upstream_workspace: | # build also the ros2_control packages
+        ros2_control.${{ matrix.ROS_DISTRO }}.repos
+        ros_controls.${{ matrix.ROS_DISTRO }}.repos
       # we don't test this repository, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -34,7 +34,7 @@ jobs:
       ros_repo: testing
       ref_for_scheduled_build: master
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
-      # we don't test this repository, we just build it
+      # we don't test target_workspace, we just build it
       not_test_build: true
       # we test the downstream packages, which are part of our organization
       downstream_workspace: ros_controls.${{ matrix.ROS_DISTRO }}.repos
@@ -49,11 +49,12 @@ jobs:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       ref_for_scheduled_build: master
-      upstream_workspace: | # build also the ros2_control packages
+      upstream_workspace:
         ros2_control.${{ matrix.ROS_DISTRO }}.repos
-        ros_controls.${{ matrix.ROS_DISTRO }}.repos
-      # we don't test this repository, we just build it
+      # we don't test target_workspace, we just build it
       not_test_build: true
       # we don't test the downstream packages, which are outside of our organization
-      downstream_workspace: downstream.${{ matrix.ROS_DISTRO }}.repos
+      downstream_workspace: | # build also the ros2_control packages
+        ros_controls.${{ matrix.ROS_DISTRO }}.repos
+        downstream.${{ matrix.ROS_DISTRO }}.repos
       not_test_downstream: true

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -1,8 +1,4 @@
 repositories:
-  ros-controls/gazebo_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gazebo_ros2_control.git
-    version: humble
   ros-controls/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -15,3 +15,11 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: humble
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: humble
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: humble

--- a/ros_controls.jazzy.repos
+++ b/ros_controls.jazzy.repos
@@ -11,3 +11,11 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: master
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -11,3 +11,11 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: master
+  ros-controls/control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master
+  ros-controls/kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master


### PR DESCRIPTION
The [3rd party downstream](https://github.com/ros-controls/ros2_control/actions/runs/13399924697/job/37428100196?pr=2050) build here fails now because of a breaking change of ros2_controllers.

it installs JTC from binaries
```
executing command [apt-get install -y -qq ros-jazzy-joint-trajectory-controller]
```
and it installs the diff_drive_controller from debs, and this one pulls the released controller_interface.

```
executing command [apt-get install -y -qq ros-jazzy-diff-drive-controller] 
 Setting up ros-jazzy-filters (2.1.2-2noble.20241228.010450) ... 
 Setting up ros-jazzy-control-msgs (5.3.0-1noble.20241227.222227) ... 
 Setting up ros-jazzy-realtime-tools (3.3.0-1noble.20250131.225008) ... 
 Setting up ros-jazzy-joint-limits (4.26.0-1noble.20250210.085130) ... 
 Setting up ros-jazzy-control-toolbox (4.0.1-1noble.20250213.195111) ... 
 Setting up ros-jazzy-hardware-interface (4.26.0-1noble.20250210.091729) ... 
 Setting up ros-jazzy-controller-interface (4.26.0-1noble.20250210.092423) ... 
 Setting up ros-jazzy-diff-drive-controller (4.20.0-1noble.20250213.195423) ...
```

Let's also build the controllers for this CI job.

Other changes:

- Don't test gazebo classic any more on humble
- Make a full semi-binary downstream build by adding ros-controls dependencies