### PR TITLE
[CM] Fix `switch_controller` behaviour with unknown controller switch request

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1191,6 +1191,7 @@ controller_interface::return_type ControllerManager::switch_controller(
   {
     // lock controllers
     std::lock_guard<std::recursive_mutex> guard(rt_controllers_wrapper_.controllers_lock_);
+    auto result = controller_interface::return_type::OK;
 
     // list all controllers to (de)activate
     for (const auto & controller : controller_list)
@@ -1207,6 +1208,10 @@ controller_interface::return_type ControllerManager::switch_controller(
           get_logger(),
           "Could not '%s' controller with name '%s' because no controller with this name exists",
           action.c_str(), controller.c_str());
+        // For the BEST_EFFORT switch, if there are more controllers that are in the list, this is
+        // not a critical error
+        result = request_list.empty() ? controller_interface::return_type::ERROR
+                                      : controller_interface::return_type::OK;
         if (strictness == controller_manager_msgs::srv::SwitchController::Request::STRICT)
         {
           RCLCPP_ERROR(get_logger(), "Aborting, no controller is switched! ('STRICT' switch)");
@@ -1215,6 +1220,7 @@ controller_interface::return_type ControllerManager::switch_controller(
       }
       else
       {
+        result = controller_interface::return_type::OK;
         RCLCPP_DEBUG(
           get_logger(), "Found controller '%s' that needs to be %sed in list of controllers",
           controller.c_str(), action.c_str());
@@ -1224,7 +1230,7 @@ controller_interface::return_type ControllerManager::switch_controller(
     RCLCPP_DEBUG(
       get_logger(), "'%s' request vector has size %i", action.c_str(), (int)request_list.size());
 
-    return controller_interface::return_type::OK;
+    return result;
   };
 
   // list all controllers to deactivate (check if all controllers exist)

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -1966,3 +1966,97 @@ TEST_F(TestControllerManagerSrvs, activate_chained_controllers_all_at_once)
 
   RCLCPP_ERROR(srv_node->get_logger(), "Check successful!");
 }
+
+TEST_F(TestControllerManagerSrvs, switch_controller_failure_cases)
+{
+  rclcpp::executors::SingleThreadedExecutor srv_executor;
+  rclcpp::Node::SharedPtr srv_node = std::make_shared<rclcpp::Node>("srv_client");
+  srv_executor.add_node(srv_node);
+  rclcpp::Client<ListControllers>::SharedPtr client =
+    srv_node->create_client<ListControllers>("test_controller_manager/list_controllers");
+  auto request = std::make_shared<ListControllers::Request>();
+
+  auto result = call_service_and_wait(*client, request, srv_executor);
+  ASSERT_EQ(0u, result->controller.size());
+
+  auto test_controller = std::make_shared<TestController>();
+  controller_interface::InterfaceConfiguration cmd_cfg = {
+    controller_interface::interface_configuration_type::INDIVIDUAL,
+    {"joint1/position", "joint2/velocity"}};
+  controller_interface::InterfaceConfiguration state_cfg = {
+    controller_interface::interface_configuration_type::INDIVIDUAL,
+    {"joint1/position", "joint1/velocity", "joint2/position"}};
+  test_controller->set_command_interface_configuration(cmd_cfg);
+  test_controller->set_state_interface_configuration(state_cfg);
+  auto abstract_test_controller = cm_->add_controller(
+    test_controller, test_controller::TEST_CONTROLLER_NAME,
+    test_controller::TEST_CONTROLLER_CLASS_NAME);
+  ASSERT_EQ(1u, cm_->get_loaded_controllers().size());
+  result = call_service_and_wait(*client, request, srv_executor);
+  ASSERT_EQ(1u, result->controller.size());
+  ASSERT_EQ(test_controller::TEST_CONTROLLER_NAME, result->controller[0].name);
+  ASSERT_EQ(test_controller::TEST_CONTROLLER_CLASS_NAME, result->controller[0].type);
+  ASSERT_EQ("unconfigured", result->controller[0].state);
+  ASSERT_TRUE(result->controller[0].claimed_interfaces.empty());
+  ASSERT_TRUE(result->controller[0].required_command_interfaces.empty());
+  ASSERT_TRUE(result->controller[0].required_state_interfaces.empty());
+
+  cm_->configure_controller(test_controller::TEST_CONTROLLER_NAME);
+  result = call_service_and_wait(*client, request, srv_executor);
+  ASSERT_EQ(1u, result->controller.size());
+  ASSERT_EQ("inactive", result->controller[0].state);
+  ASSERT_TRUE(result->controller[0].claimed_interfaces.empty());
+  ASSERT_THAT(
+    result->controller[0].required_command_interfaces,
+    UnorderedElementsAre("joint1/position", "joint2/velocity"));
+  ASSERT_THAT(
+    result->controller[0].required_state_interfaces,
+    UnorderedElementsAre("joint1/position", "joint1/velocity", "joint2/position"));
+
+  // Switch to an unknown controller and see if it is working
+  // It should fail if the controller doesn't exist at all
+  for (const auto & strictness :
+       {controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT,
+        controller_manager_msgs::srv::SwitchController::Request::STRICT})
+  {
+    SCOPED_TRACE("Switching to unknown controller with strictness: " + std::to_string(strictness));
+    ASSERT_EQ(
+      cm_->switch_controller({"unknown_controller"}, {}, strictness, true, rclcpp::Duration(0, 0)),
+      controller_interface::return_type::ERROR);
+    ASSERT_EQ(
+      cm_->switch_controller({}, {"unknown_controller"}, strictness, true, rclcpp::Duration(0, 0)),
+      controller_interface::return_type::ERROR);
+  }
+
+  // now test with strict along with our known controller. It should fail as the unknown controller
+  // is not known
+  ASSERT_EQ(
+    cm_->switch_controller(
+      {test_controller::TEST_CONTROLLER_NAME, "unknown_controller"}, {},
+      controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
+      rclcpp::Duration(0, 0)),
+    controller_interface::return_type::ERROR);
+  ASSERT_EQ(
+    cm_->switch_controller(
+      {}, {test_controller::TEST_CONTROLLER_NAME, "unknown_controller"},
+      controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
+      rclcpp::Duration(0, 0)),
+    controller_interface::return_type::ERROR);
+
+  cm_->switch_controller(
+    {test_controller::TEST_CONTROLLER_NAME}, {},
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, true, rclcpp::Duration(0, 0));
+
+  result = call_service_and_wait(*client, request, srv_executor);
+  ASSERT_EQ(1u, result->controller.size());
+  ASSERT_EQ("active", result->controller[0].state);
+  ASSERT_THAT(
+    result->controller[0].claimed_interfaces,
+    UnorderedElementsAre("joint1/position", "joint2/velocity"));
+  ASSERT_THAT(
+    result->controller[0].required_command_interfaces,
+    UnorderedElementsAre("joint1/position", "joint2/velocity"));
+  ASSERT_THAT(
+    result->controller[0].required_state_interfaces,
+    UnorderedElementsAre("joint1/position", "joint1/velocity", "joint2/position"));
+}

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -327,53 +327,54 @@ INSTANTIATE_TEST_SUITE_P(
       "Switch with no controllers specified and strictness BEST_EFFORT didn't return OK"),
     // combination of empty and non-existent controller
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
-      "Switch with nonexistent start controller specified and strictness UNSPECIFIED didn't return "
-      "OK"),
+      controller_interface::return_type::ERROR, UNSPECIFIED, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified and strictness UNSPECIFIED should return "
+      "ERROR"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
       "Switch with nonexistent start controller specified and strictness STRICT didn't return "
       "ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
-      "Switch with nonexistent start controller specified and strictness BEST_EFFORT didn't return "
-      "OK"),
+      controller_interface::return_type::ERROR, BEST_EFFORT, NONEXISTENT_CONTROLLER, EMPTY_STR_VEC,
+      "Switch with nonexistent start controller specified and strictness BEST_EFFORT should return "
+      "ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
-      "Switch with nonexistent stop controller specified and strictness UNSPECIFIED didn't return "
-      "OK"),
+      controller_interface::return_type::ERROR, UNSPECIFIED, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified and strictness UNSPECIFIED should return "
+      "ERROR"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
       "Switch with nonexistent stop controller specified and strictness STRICT didn't return "
       "ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
-      "Switch with nonexistent stop controller specified and strictness BEST_EFFORT didn't return "
-      "OK"),
+      controller_interface::return_type::ERROR, BEST_EFFORT, EMPTY_STR_VEC, NONEXISTENT_CONTROLLER,
+      "Switch with nonexistent stop controller specified and strictness BEST_EFFORT should return "
+      "ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, UNSPECIFIED, NONEXISTENT_CONTROLLER,
+      controller_interface::return_type::ERROR, UNSPECIFIED, NONEXISTENT_CONTROLLER,
       NONEXISTENT_CONTROLLER,
       "Switch with nonexistent start and stop controllers specified, and strictness UNSPECIFIED, "
-      "didn't return OK"),
+      "should return ERROR"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER,
       NONEXISTENT_CONTROLLER,
       "Switch with nonexistent start and stop controllers specified, and strictness STRICT, didn't "
       "return ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER,
+      controller_interface::return_type::ERROR, BEST_EFFORT, NONEXISTENT_CONTROLLER,
       NONEXISTENT_CONTROLLER,
       "Switch with nonexistent start and stop controllers specified, and strictness BEST_EFFORT, "
-      "didn't return OK"),
+      "should return ERROR"),
     // valid controller used
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
       "Switch with valid stopped controller and nonexistent start controller specified, and "
       "strictness STRICT, didn't return ERROR"),
     std::make_tuple(
-      controller_interface::return_type::OK, BEST_EFFORT, NONEXISTENT_CONTROLLER, VALID_CONTROLLER,
+      controller_interface::return_type::ERROR, BEST_EFFORT, NONEXISTENT_CONTROLLER,
+      VALID_CONTROLLER,
       "Switch with valid stopped controller specified, nonexistent start controller and strictness "
-      "BEST_EFFORT didn't return OK"),
+      "BEST_EFFORT should return ERROR"),
     std::make_tuple(
       controller_interface::return_type::ERROR, STRICT, VALID_PLUS_NONEXISTENT_CONTROLLERS,
       EMPTY_STR_VEC,


### PR DESCRIPTION
When there is an unknown controller which is the only one to activate or deactivate the BEST_EFFORT still says successful. I believe it should fail, if there is only one controller in the request and it is also found in the controller list. 

The BEST_EFFORT being successful makes sense when there are more than one controller in the request and one of them doesn't exist and then it can proceed with further checks

Before
```
$ ros2 control switch_controllers --deactivate unkown_controller
Successfully switched controllers
```

Now
```
$ ros2 control switch_controllers --deactivate unkown_controller
Error switching controllers, check controller_manager logs

$ ros2 control switch_controllers --activate unkown_controller
Error switching controllers, check controller_manager logs

$ ros2 control switch_controllers --deactivate unkown_controller --activate ctrl_1
Error switching controllers, check controller_manager logs

$ ros2 control switch_controllers --activate unkown_controller --deactivate ctrl_1
Error switching controllers, check controller_manager logs

$ ros2 control switch_controllers --deactivate unkown_controller  ctrl_1
Successfully switched controllers

$ ros2 control switch_controllers --activate unkown_controller  ctrl_1
Successfully switched controllers

$ ros2 control switch_controllers --activate unkown_controller ctrl_2 --deactivate ctrl_1
Successfully switched controllers
```