### PR TITLE
[Handle] Add support for booleans in the handles

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -41,7 +41,7 @@ struct InterfaceInfo
   /// (Optional) Initial value of the interface.
   std::string initial_value;
   /// (Optional) The datatype of the interface, e.g. "bool", "int".
-  std::string data_type;
+  std::string data_type = "double";
   /// (Optional) If the handle is an array, the size of the array.
   int size;
   /// (Optional) enable or disable the limits for the command interfaces
@@ -131,6 +131,16 @@ struct TransmissionInfo
 };
 
 /**
+ * Hardware handles supported types
+ */
+enum class HandleDataType
+{
+  UNKNOWN,
+  DOUBLE,
+  BOOL
+};
+
+/**
  * This structure stores information about an interface for a specific hardware which should be
  * instantiated internally.
  */
@@ -163,6 +173,22 @@ struct InterfaceDescription
   const std::string & get_interface_name() const { return interface_info.name; }
 
   const std::string & get_name() const { return interface_name; }
+
+  HandleDataType get_data_type() const
+  {
+    if (interface_info.data_type == "double")
+    {
+      return HandleDataType::DOUBLE;
+    }
+    else if (interface_info.data_type == "bool")
+    {
+      return HandleDataType::BOOL;
+    }
+    else
+    {
+      return HandleDataType::UNKNOWN;
+    }
+  }
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -89,6 +89,27 @@ TEST(TestHandle, interface_description_state_interface_name_getters_work)
   EXPECT_EQ(handle.get_prefix_name(), JOINT_NAME_1);
 }
 
+TEST(TestHandle, interface_description_bool_data_type)
+{
+  const std::string collision_interface = "collision";
+  const std::string itf_name = "joint1";
+  InterfaceInfo info;
+  info.name = collision_interface;
+  info.data_type = "bool";
+  InterfaceDescription interface_descr(itf_name, info);
+  StateInterface handle{interface_descr};
+
+  EXPECT_EQ(handle.get_name(), itf_name + "/" + collision_interface);
+  EXPECT_EQ(handle.get_interface_name(), collision_interface);
+  EXPECT_EQ(handle.get_prefix_name(), itf_name);
+  EXPECT_NO_THROW({ handle.get_value<bool>(); });
+  ASSERT_FALSE(handle.get_value<bool>().value()) << "Default value should be false";
+  EXPECT_NO_THROW({ handle.set_value(true); });
+  ASSERT_TRUE(handle.get_value<bool>().value());
+  EXPECT_NO_THROW({ handle.set_value(false); });
+  ASSERT_FALSE(handle.get_value<bool>().value());
+}
+
 TEST(TestHandle, interface_description_command_interface_name_getters_work)
 {
   const std::string POSITION_INTERFACE = "position";


### PR DESCRIPTION
This PR aims to add support for boolean types in the Handle using the internal variant. The data_type is selected using the `InterfaceInfo` information.