### PR TITLE
Fix links in docs

### DIFF
--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -78,3 +78,4 @@ References
 
 * `ROS 2 and GDB <https://juraph.com/miscellaneous/ros2_and_gdb/>`_
 * `Using GDB to debug a plugin <https://stackoverflow.com/questions/10919832/how-to-use-gdb-to-debug-a-plugin>`_
+* `GDB CLI Tutorial <https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf>`_

--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -78,4 +78,3 @@ References
 
 * `ROS 2 and GDB <https://juraph.com/miscellaneous/ros2_and_gdb/>`_
 * `Using GDB to debug a plugin <https://stackoverflow.com/questions/10919832/how-to-use-gdb-to-debug-a-plugin>`_
-* `GDB CLI Tutorial <https://www.cs.umd.edu/~srhuang/teaching/cmsc212/gdb-tutorial-handout.pdf>`_

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -69,7 +69,7 @@ controller_manager
         <child link="finger_left"/>
         <limit effort="1000.0" lower="0" upper="0.38" velocity="10"/>
       </joint>
-* The support for the ``description`` parameter for loading the URDF was removed (`#1358 <https://github.com/ros-controls/ros2_control/pull/1358>`_). Use ``robot_description`` topic instead, e.g., you can use the `robot_state_publisher <https://index.ros.org/p/robot_state_publisher/github-ros-robot_state_publisher/#{DISTRO}>`_. For an example, see `this PR <https://github.com/ros-controls/ros2_control_demos/pull/456>`_ where the change was applied to the demo repository.
+* The support for the ``description`` parameter for loading the URDF was removed (`#1358 <https://github.com/ros-controls/ros2_control/pull/1358>`_). Use ``robot_description`` topic instead, e.g., you can use the `robot_state_publisher <https://index.ros.org/p/robot_state_publisher/#{DISTRO}>`_. For an example, see `this PR <https://github.com/ros-controls/ros2_control_demos/pull/456>`_ where the change was applied to the demo repository.
 
 hardware_interface
 ******************


### PR DESCRIPTION
There are [two broken links](https://github.com/ros-controls/control.ros.org/actions/runs/13514690970/job/37761146448)

I haven't found any replacement for the GDB CLI handout, @firesurfer do you have an alternative resource by chance?