### PR TITLE
Cleanup chainable controller exported interfaces to allow reconfiguring 

### DIFF
--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -53,6 +53,9 @@ ChainableControllerInterface::export_state_interfaces()
   state_interfaces_ptrs_vec.reserve(state_interfaces.size());
   ordered_exported_state_interfaces_.reserve(state_interfaces.size());
   exported_state_interface_names_.reserve(state_interfaces.size());
+  exported_state_interfaces_.clear();
+  exported_state_interface_names_.clear();
+  ordered_exported_state_interfaces_.clear();
 
   // check if the names of the controller state interfaces begin with the controller's name
   for (const auto & interface : state_interfaces)
@@ -117,6 +120,9 @@ ChainableControllerInterface::export_reference_interfaces()
   reference_interfaces_ptrs_vec.reserve(reference_interfaces.size());
   exported_reference_interface_names_.reserve(reference_interfaces.size());
   ordered_exported_reference_interfaces_.reserve(reference_interfaces.size());
+  exported_reference_interfaces_.clear();
+  exported_reference_interface_names_.clear();
+  ordered_exported_reference_interfaces_.clear();
 
   // BEGIN (Handle export change): for backward compatibility
   // check if the "reference_interfaces_" variable is resized to number of interfaces

--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -56,7 +56,7 @@ TEST_F(ChainableControllerInterfaceTest, export_state_interfaces)
     exported_state_interfaces[0]->get_value<double>().value(), EXPORTED_STATE_INTERFACE_VALUE);
 
   // calling export_state_interfaces again should return the same interface and shouldn't throw
-  exported_state_interfaces = controller.export_state_interfaces();
+  EXPECT_NO_THROW(exported_state_interfaces = controller.export_state_interfaces());
 
   ASSERT_THAT(exported_state_interfaces, SizeIs(1));
   EXPECT_EQ(exported_state_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);
@@ -83,7 +83,7 @@ TEST_F(ChainableControllerInterfaceTest, export_reference_interfaces)
   EXPECT_EQ(reference_interfaces[0]->get_value<double>().value(), INTERFACE_VALUE);
 
   // calling export_reference_interfaces again should return the same interface and shouldn't throw
-  reference_interfaces = controller.export_reference_interfaces();
+  EXPECT_NO_THROW(reference_interfaces = controller.export_reference_interfaces());
 
   ASSERT_THAT(reference_interfaces, SizeIs(1));
   EXPECT_EQ(reference_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);

--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -54,6 +54,13 @@ TEST_F(ChainableControllerInterfaceTest, export_state_interfaces)
 
   EXPECT_EQ(
     exported_state_interfaces[0]->get_value<double>().value(), EXPORTED_STATE_INTERFACE_VALUE);
+
+  // calling export_state_interfaces again should return the same interface and shouldn't throw
+  exported_state_interfaces = controller.export_state_interfaces();
+
+  ASSERT_THAT(exported_state_interfaces, SizeIs(1));
+  EXPECT_EQ(exported_state_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);
+  EXPECT_EQ(exported_state_interfaces[0]->get_interface_name(), "test_state");
 }
 
 TEST_F(ChainableControllerInterfaceTest, export_reference_interfaces)
@@ -74,6 +81,13 @@ TEST_F(ChainableControllerInterfaceTest, export_reference_interfaces)
   EXPECT_EQ(reference_interfaces[0]->get_interface_name(), "test_itf");
 
   EXPECT_EQ(reference_interfaces[0]->get_value<double>().value(), INTERFACE_VALUE);
+
+  // calling export_reference_interfaces again should return the same interface and shouldn't throw
+  reference_interfaces = controller.export_reference_interfaces();
+
+  ASSERT_THAT(reference_interfaces, SizeIs(1));
+  EXPECT_EQ(reference_interfaces[0]->get_prefix_name(), TEST_CONTROLLER_NAME);
+  EXPECT_EQ(reference_interfaces[0]->get_interface_name(), "test_itf");
 }
 
 TEST_F(ChainableControllerInterfaceTest, interfaces_prefix_is_not_node_name)

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -445,6 +445,13 @@ private:
    */
   rclcpp::NodeOptions determine_controller_node_options(const ControllerSpec & controller) const;
 
+  /**
+   * @brief cleanup_controller_exported_interfaces - A method that cleans up the exported interfaces
+   * of a chainable controller
+   * @param controller - controller info
+   */
+  void cleanup_controller_exported_interfaces(const ControllerSpec & controller);
+
   std::shared_ptr<controller_manager::ParamListener> cm_param_listener_;
   std::shared_ptr<controller_manager::Params> params_;
   diagnostic_updater::Updater diagnostics_updater_;


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/ros2_control/issues/2071

Fixes 2 cases in this PR:
1. Calling `configure_controller` service twice right now throws an exception
2. Unloading a chainable controller and when reloading and configuring it again throws an exception

Both the above cases are fixed. Proper tests are also added  