### PR TITLE
[Handle] Update `get_value` deprecation notice

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -113,8 +113,8 @@ public:
   const std::string & get_prefix_name() const { return prefix_name_; }
 
   [[deprecated(
-    "Use std::optional<T> get_optional() or bool get_value(double & "
-    "value) instead to retrieve the value.")]]
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]]
   double get_value() const
   {
     std::shared_lock<std::shared_mutex> lock(handle_mutex_, std::try_to_lock);
@@ -166,7 +166,10 @@ public:
    * the value is updated and returns true.
    */
   template <typename T>
-  [[nodiscard]] bool get_value(T & value) const
+  [[deprecated(
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]] [[nodiscard]] bool
+  get_value(T & value) const
   {
     std::shared_lock<std::shared_mutex> lock(handle_mutex_, std::try_to_lock);
     if (!lock.owns_lock())

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -129,8 +129,8 @@ public:
   }
 
   [[deprecated(
-    "Use std::optional<T> get_optional() or bool get_value(double & "
-    "value) instead to retrieve the value.")]]
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]]
   double get_value() const
   {
     double value = std::numeric_limits<double>::quiet_NaN();
@@ -195,7 +195,10 @@ public:
    * true immediately.
    */
   template <typename T>
-  [[nodiscard]] bool get_value(T & value, unsigned int max_tries = 10) const
+  [[deprecated(
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]] [[nodiscard]] bool
+  get_value(T & value, unsigned int max_tries = 10) const
   {
     unsigned int nr_tries = 0;
     ++get_value_statistics_.total_counter;

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -89,8 +89,8 @@ public:
   const std::string & get_prefix_name() const { return state_interface_.get_prefix_name(); }
 
   [[deprecated(
-    "Use std::optional<T> get_optional() or bool get_value(double & "
-    "value) instead to retrieve the value.")]]
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]]
   double get_value() const
   {
     double value = std::numeric_limits<double>::quiet_NaN();
@@ -155,7 +155,10 @@ public:
    * the value and returns true immediately.
    */
   template <typename T>
-  [[nodiscard]] bool get_value(T & value, unsigned int max_tries = 10) const
+  [[deprecated(
+    "Use std::optional<T> get_optional() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]] [[nodiscard]] bool
+  get_value(T & value, unsigned int max_tries = 10) const
   {
     unsigned int nr_tries = 0;
     ++get_value_statistics_.total_counter;


### PR DESCRIPTION
As discussed in yesterday's WG meeting, I've added the deprecation notice to all available `get_value` methods with a deadline of ROS 2 K release