### PR TITLE
[HW Components] Add fix for async hardware components improper rate

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3235,7 +3235,7 @@ void ControllerManager::controller_activity_diagnostic_callback(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   bool atleast_one_hw_active = false;
-  const auto hw_components_info = resource_manager_->get_components_status();
+  const auto & hw_components_info = resource_manager_->get_components_status();
   for (const auto & [component_name, component_info] : hw_components_info)
   {
     if (component_info.state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
@@ -3390,7 +3390,7 @@ void ControllerManager::hardware_components_diagnostic_callback(
 {
   bool all_active = true;
   bool atleast_one_hw_active = false;
-  const auto hw_components_info = resource_manager_->get_components_status();
+  const auto & hw_components_info = resource_manager_->get_components_status();
   for (const auto & [component_name, component_info] : hw_components_info)
   {
     stat.add(component_name, component_info.state.label());

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -377,7 +377,7 @@ public:
   /**
    * \return map of hardware names and their status.
    */
-  std::unordered_map<std::string, HardwareComponentInfo> get_components_status();
+  const std::unordered_map<std::string, HardwareComponentInfo> & get_components_status();
 
   /// Prepare the hardware components for a new command interface mode
   /**

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -236,28 +236,41 @@ public:
    * \param[in] period The measured time taken by the last control loop iteration
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  return_type trigger_read(const rclcpp::Time & time, const rclcpp::Duration & period)
+  HardwareComponentCycleStatus trigger_read(
+    const rclcpp::Time & time, const rclcpp::Duration & period)
   {
-    return_type result = return_type::ERROR;
+    HardwareComponentCycleStatus status;
+    status.result = return_type::ERROR;
     if (info_.is_async)
     {
-      bool trigger_status = true;
-      std::tie(trigger_status, result) = read_async_handler_->trigger_async_callback(time, period);
-      if (!trigger_status)
+      const auto result = read_async_handler_->trigger_async_callback(time, period);
+      status.successful = result.first;
+      status.result = result.second;
+      const auto execution_time = read_async_handler_->get_last_execution_time();
+      if (execution_time.count() > 0)
+      {
+        status.execution_time = execution_time;
+      }
+      if (!status.successful)
       {
         RCLCPP_WARN(
           get_logger(),
           "Trigger read called while read async handler is still in progress for hardware "
           "interface : '%s'. Failed to trigger read cycle!",
           info_.name.c_str());
-        return return_type::OK;
+        status.result = return_type::OK;
+        return status;
       }
     }
     else
     {
-      result = read(time, period);
+      const auto start_time = std::chrono::steady_clock::now();
+      status.successful = true;
+      status.result = read(time, period);
+      status.execution_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - start_time);
     }
-    return result;
+    return status;
   }
 
   /// Read the current state values from the actuator.

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -125,18 +125,25 @@ public:
       async_handler_->init(
         [this](const rclcpp::Time & time, const rclcpp::Duration & period)
         {
-          if (next_trigger_ == TriggerType::READ)
+          const auto read_start_time = std::chrono::steady_clock::now();
+          const auto ret_read = read(time, period);
+          const auto read_end_time = std::chrono::steady_clock::now();
+          read_return_info_.store(ret_read, std::memory_order_release);
+          read_execution_time_.store(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(read_end_time - read_start_time),
+            std::memory_order_release);
+          if (ret_read != return_type::OK)
           {
-            const auto ret = read(time, period);
-            next_trigger_ = TriggerType::WRITE;
-            return ret;
+            return ret_read;
           }
-          else
-          {
-            const auto ret = write(time, period);
-            next_trigger_ = TriggerType::READ;
-            return ret;
-          }
+          const auto write_start_time = std::chrono::steady_clock::now();
+          const auto ret_write = write(time, period);
+          const auto write_end_time = std::chrono::steady_clock::now();
+          write_return_info_.store(ret_write, std::memory_order_release);
+          write_execution_time_.store(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(write_end_time - write_start_time),
+            std::memory_order_release);
+          return ret_write;
         },
         info_.thread_priority);
       async_handler_->start_thread();
@@ -388,37 +395,41 @@ public:
    * \param[in] period The measured time taken by the last control loop iteration
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  return_type trigger_read(const rclcpp::Time & time, const rclcpp::Duration & period)
+  HardwareComponentCycleStatus trigger_read(
+    const rclcpp::Time & time, const rclcpp::Duration & period)
   {
-    return_type result = return_type::ERROR;
+    HardwareComponentCycleStatus status;
+    status.result = return_type::ERROR;
     if (info_.is_async)
     {
-      bool trigger_status = true;
-      if (next_trigger_ == TriggerType::WRITE)
+      status.result = read_return_info_.load(std::memory_order_acquire);
+      const auto read_exec_time = read_execution_time_.load(std::memory_order_acquire);
+      if (read_exec_time.count() > 0)
       {
-        RCLCPP_WARN(
-          get_logger(),
-          "Trigger read called while write async handler call is still pending for hardware "
-          "interface : '%s'. Skipping read cycle and will wait for a write cycle!",
-          info_.name.c_str());
-        return return_type::OK;
+        status.execution_time = read_exec_time;
       }
-      std::tie(trigger_status, result) = async_handler_->trigger_async_callback(time, period);
-      if (!trigger_status)
+      const auto result = async_handler_->trigger_async_callback(time, period);
+      status.successful = result.first;
+      if (!status.successful)
       {
         RCLCPP_WARN(
           get_logger(),
-          "Trigger read called while write async trigger is still in progress for hardware "
-          "interface : '%s'. Failed to trigger read cycle!",
+          "Trigger read/write called while the previous async trigger is still in progress for "
+          "hardware interface : '%s'. Failed to trigger read/write cycle!",
           info_.name.c_str());
-        return return_type::OK;
+        status.result = return_type::OK;
+        return status;
       }
     }
     else
     {
-      result = read(time, period);
+      const auto start_time = std::chrono::steady_clock::now();
+      status.successful = true;
+      status.result = read(time, period);
+      status.execution_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - start_time);
     }
-    return result;
+    return status;
   }
 
   /// Read the current state values from the actuator.
@@ -443,37 +454,30 @@ public:
    * \param[in] period The measured time taken by the last control loop iteration
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  return_type trigger_write(const rclcpp::Time & time, const rclcpp::Duration & period)
+  HardwareComponentCycleStatus trigger_write(
+    const rclcpp::Time & time, const rclcpp::Duration & period)
   {
-    return_type result = return_type::ERROR;
+    HardwareComponentCycleStatus status;
+    status.result = return_type::ERROR;
     if (info_.is_async)
     {
-      bool trigger_status = true;
-      if (next_trigger_ == TriggerType::READ)
+      status.successful = true;
+      const auto write_exec_time = write_execution_time_.load(std::memory_order_acquire);
+      if (write_exec_time.count() > 0)
       {
-        RCLCPP_WARN(
-          get_logger(),
-          "Trigger write called while read async handler call is still pending for hardware "
-          "interface : '%s'. Skipping write cycle and will wait for a read cycle!",
-          info_.name.c_str());
-        return return_type::OK;
+        status.execution_time = write_exec_time;
       }
-      std::tie(trigger_status, result) = async_handler_->trigger_async_callback(time, period);
-      if (!trigger_status)
-      {
-        RCLCPP_WARN(
-          get_logger(),
-          "Trigger write called while read async trigger is still in progress for hardware "
-          "interface : '%s'. Failed to trigger write cycle!",
-          info_.name.c_str());
-        return return_type::OK;
-      }
+      status.result = write_return_info_.load(std::memory_order_acquire);
     }
     else
     {
-      result = write(time, period);
+      const auto start_time = std::chrono::steady_clock::now();
+      status.successful = true;
+      status.result = write(time, period);
+      status.execution_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - start_time);
     }
-    return result;
+    return status;
   }
 
   /// Write the current command values to the actuator.
@@ -552,6 +556,18 @@ public:
    */
   const HardwareInfo & get_hardware_info() const { return info_; }
 
+  /// Prepare for the activation of the hardware.
+  /**
+   * This method is called before the hardware is activated by the resource manager.
+   */
+  void prepare_for_activation()
+  {
+    read_return_info_.store(return_type::OK, std::memory_order_release);
+    read_execution_time_.store(std::chrono::nanoseconds::zero(), std::memory_order_release);
+    write_return_info_.store(return_type::OK, std::memory_order_release);
+    write_execution_time_.store(std::chrono::nanoseconds::zero(), std::memory_order_release);
+  }
+
   /// Enable or disable introspection of the hardware.
   /**
    * \param[in] enable Enable introspection if true, disable otherwise.
@@ -603,7 +619,10 @@ private:
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> system_states_;
   std::unordered_map<std::string, CommandInterface::SharedPtr> system_commands_;
-  std::atomic<TriggerType> next_trigger_ = TriggerType::READ;
+  std::atomic<return_type> read_return_info_ = return_type::OK;
+  std::atomic<std::chrono::nanoseconds> read_execution_time_ = std::chrono::nanoseconds::zero();
+  std::atomic<return_type> write_return_info_ = return_type::OK;
+  std::atomic<std::chrono::nanoseconds> write_execution_time_ = std::chrono::nanoseconds::zero();
 
 protected:
   pal_statistics::RegistrationsRAII stats_registrations_;

--- a/hardware_interface/include/hardware_interface/types/hardware_interface_return_values.hpp
+++ b/hardware_interface/include/hardware_interface/types/hardware_interface_return_values.hpp
@@ -15,7 +15,9 @@
 #ifndef HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_RETURN_VALUES_HPP_
 #define HARDWARE_INTERFACE__TYPES__HARDWARE_INTERFACE_RETURN_VALUES_HPP_
 
+#include <chrono>
 #include <cstdint>
+#include <optional>
 
 namespace hardware_interface
 {
@@ -24,6 +26,22 @@ enum class return_type : std::uint8_t
   OK = 0,
   ERROR = 1,
   DEACTIVATE = 2,
+};
+
+/**
+ * Struct to store the status of the Hardware read or write methods return state.
+ * The status contains information if the cycle was triggered successfully, the result of the
+ * cycle method and the execution duration of the method. The status is used to provide
+ * feedback to the controller_manager.
+ * @var successful: true if it was triggered successfully, false if not.
+ * @var result: return_type::OK if update is successfully, otherwise return_type::ERROR.
+ * @var execution_time: duration of the execution of the update method.
+ */
+struct HardwareComponentCycleStatus
+{
+  bool successful = true;
+  return_type result = return_type::OK;
+  std::optional<std::chrono::nanoseconds> execution_time = std::nullopt;
 };
 
 }  // namespace hardware_interface

--- a/hardware_interface/src/actuator.cpp
+++ b/hardware_interface/src/actuator.cpp
@@ -41,8 +41,8 @@ Actuator::Actuator(Actuator && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.actuators_mutex_);
   impl_ = std::move(other.impl_);
-  last_read_cycle_time_ = other.last_read_cycle_time_;
-  last_write_cycle_time_ = other.last_write_cycle_time_;
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  last_write_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
 }
 
 const rclcpp_lifecycle::State & Actuator::initialize(
@@ -55,8 +55,6 @@ const rclcpp_lifecycle::State & Actuator::initialize(
     switch (impl_->init(actuator_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
-        last_read_cycle_time_ = clock_interface->get_clock()->now();
-        last_write_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -143,8 +141,11 @@ const rclcpp_lifecycle::State & Actuator::shutdown()
 const rclcpp_lifecycle::State & Actuator::activate()
 {
   std::unique_lock<std::recursive_mutex> lock(actuators_mutex_);
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  last_write_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
+    impl_->prepare_for_activation();
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
@@ -302,19 +303,19 @@ return_type Actuator::read(const rclcpp::Time & time, const rclcpp::Duration & p
     last_read_cycle_time_ = time;
     return return_type::OK;
   }
-  return_type result = return_type::ERROR;
   if (
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
-    result = impl_->trigger_read(time, period);
-    if (result == return_type::ERROR)
+    const auto trigger_result = impl_->trigger_read(time, period);
+    if (trigger_result.result == return_type::ERROR)
     {
       error();
     }
     last_read_cycle_time_ = time;
+    return trigger_result.result;
   }
-  return result;
+  return return_type::OK;
 }
 
 return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & period)
@@ -324,19 +325,19 @@ return_type Actuator::write(const rclcpp::Time & time, const rclcpp::Duration & 
     last_write_cycle_time_ = time;
     return return_type::OK;
   }
-  return_type result = return_type::ERROR;
   if (
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
-    result = impl_->trigger_write(time, period);
-    if (result == return_type::ERROR)
+    const auto trigger_result = impl_->trigger_write(time, period);
+    if (trigger_result.result == return_type::ERROR)
     {
       error();
     }
     last_write_cycle_time_ = time;
+    return trigger_result.result;
   }
-  return result;
+  return return_type::OK;
 }
 
 std::recursive_mutex & Actuator::get_mutex() { return actuators_mutex_; }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1772,7 +1772,6 @@ HardwareReadWriteStatus ResourceManager::read(
         auto & hardware_component_info =
           resource_storage_->hardware_info_map_[component.get_name()];
         const auto current_time = resource_storage_->get_clock()->now();
-        // const rclcpp::Duration actual_period = current_time - component.get_last_read_time();
         if (
           hardware_component_info.rw_rate == 0 ||
           hardware_component_info.rw_rate == resource_storage_->cm_update_rate_)

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1461,7 +1461,8 @@ void ResourceManager::import_component(
 }
 
 // CM API: Called in "callback/slow"-thread
-std::unordered_map<std::string, HardwareComponentInfo> ResourceManager::get_components_status()
+const std::unordered_map<std::string, HardwareComponentInfo> &
+ResourceManager::get_components_status()
 {
   auto loop_and_get_state = [&](auto & container)
   {
@@ -1768,19 +1769,23 @@ HardwareReadWriteStatus ResourceManager::read(
       auto ret_val = return_type::OK;
       try
       {
+        auto & hardware_component_info =
+          resource_storage_->hardware_info_map_[component.get_name()];
+        const auto current_time = resource_storage_->get_clock()->now();
+        // const rclcpp::Duration actual_period = current_time - component.get_last_read_time();
         if (
-          resource_storage_->hardware_info_map_[component.get_name()].rw_rate == 0 ||
-          resource_storage_->hardware_info_map_[component.get_name()].rw_rate ==
-            resource_storage_->cm_update_rate_)
+          hardware_component_info.rw_rate == 0 ||
+          hardware_component_info.rw_rate == resource_storage_->cm_update_rate_)
         {
-          ret_val = component.read(time, period);
+          ret_val = component.read(current_time, period);
         }
         else
         {
-          const double read_rate =
-            resource_storage_->hardware_info_map_[component.get_name()].rw_rate;
-          const auto current_time = resource_storage_->get_clock()->now();
-          const rclcpp::Duration actual_period = current_time - component.get_last_read_time();
+          const double read_rate = hardware_component_info.rw_rate;
+          const rclcpp::Duration actual_period =
+            component.get_last_read_time().get_clock_type() != RCL_CLOCK_UNINITIALIZED
+              ? current_time - component.get_last_read_time()
+              : rclcpp::Duration::from_seconds(1.0 / static_cast<double>(read_rate));
           if (actual_period.seconds() * read_rate >= 0.99)
           {
             ret_val = component.read(current_time, actual_period);
@@ -1854,19 +1859,22 @@ HardwareReadWriteStatus ResourceManager::write(
       auto ret_val = return_type::OK;
       try
       {
+        auto & hardware_component_info =
+          resource_storage_->hardware_info_map_[component.get_name()];
+        const auto current_time = resource_storage_->get_clock()->now();
         if (
-          resource_storage_->hardware_info_map_[component.get_name()].rw_rate == 0 ||
-          resource_storage_->hardware_info_map_[component.get_name()].rw_rate ==
-            resource_storage_->cm_update_rate_)
+          hardware_component_info.rw_rate == 0 ||
+          hardware_component_info.rw_rate == resource_storage_->cm_update_rate_)
         {
-          ret_val = component.write(time, period);
+          ret_val = component.write(current_time, period);
         }
         else
         {
-          const double write_rate =
-            resource_storage_->hardware_info_map_[component.get_name()].rw_rate;
-          const auto current_time = resource_storage_->get_clock()->now();
-          const rclcpp::Duration actual_period = current_time - component.get_last_write_time();
+          const double write_rate = hardware_component_info.rw_rate;
+          const rclcpp::Duration actual_period =
+            component.get_last_write_time().get_clock_type() != RCL_CLOCK_UNINITIALIZED
+              ? current_time - component.get_last_write_time()
+              : rclcpp::Duration::from_seconds(1.0 / static_cast<double>(write_rate));
           if (actual_period.seconds() * write_rate >= 0.99)
           {
             ret_val = component.write(current_time, actual_period);

--- a/hardware_interface/src/sensor.cpp
+++ b/hardware_interface/src/sensor.cpp
@@ -40,7 +40,7 @@ Sensor::Sensor(Sensor && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.sensors_mutex_);
   impl_ = std::move(other.impl_);
-  last_read_cycle_time_ = other.last_read_cycle_time_;
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
 }
 
 const rclcpp_lifecycle::State & Sensor::initialize(
@@ -53,7 +53,6 @@ const rclcpp_lifecycle::State & Sensor::initialize(
     switch (impl_->init(sensor_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
-        last_read_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -140,6 +139,7 @@ const rclcpp_lifecycle::State & Sensor::shutdown()
 const rclcpp_lifecycle::State & Sensor::activate()
 {
   std::unique_lock<std::recursive_mutex> lock(sensors_mutex_);
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
@@ -256,19 +256,19 @@ return_type Sensor::read(const rclcpp::Time & time, const rclcpp::Duration & per
     last_read_cycle_time_ = time;
     return return_type::OK;
   }
-  return_type result = return_type::ERROR;
   if (
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
-    result = impl_->trigger_read(time, period);
-    if (result == return_type::ERROR)
+    const auto trigger_result = impl_->trigger_read(time, period);
+    if (trigger_result.result == return_type::ERROR)
     {
       error();
     }
     last_read_cycle_time_ = time;
+    return trigger_result.result;
   }
-  return result;
+  return return_type::OK;
 }
 
 std::recursive_mutex & Sensor::get_mutex() { return sensors_mutex_; }

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -39,8 +39,8 @@ System::System(System && other) noexcept
 {
   std::lock_guard<std::recursive_mutex> lock(other.system_mutex_);
   impl_ = std::move(other.impl_);
-  last_read_cycle_time_ = other.last_read_cycle_time_;
-  last_write_cycle_time_ = other.last_write_cycle_time_;
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  last_write_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
 }
 
 const rclcpp_lifecycle::State & System::initialize(
@@ -53,8 +53,6 @@ const rclcpp_lifecycle::State & System::initialize(
     switch (impl_->init(system_info, logger, clock_interface))
     {
       case CallbackReturn::SUCCESS:
-        last_read_cycle_time_ = clock_interface->get_clock()->now();
-        last_write_cycle_time_ = clock_interface->get_clock()->now();
         impl_->set_lifecycle_state(rclcpp_lifecycle::State(
           lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
           lifecycle_state_names::UNCONFIGURED));
@@ -141,8 +139,11 @@ const rclcpp_lifecycle::State & System::shutdown()
 const rclcpp_lifecycle::State & System::activate()
 {
   std::unique_lock<std::recursive_mutex> lock(system_mutex_);
+  last_read_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
+  last_write_cycle_time_ = rclcpp::Time(0, 0, RCL_CLOCK_UNINITIALIZED);
   if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
   {
+    impl_->prepare_for_activation();
     switch (impl_->on_activate(impl_->get_lifecycle_state()))
     {
       case CallbackReturn::SUCCESS:
@@ -300,19 +301,19 @@ return_type System::read(const rclcpp::Time & time, const rclcpp::Duration & per
     last_read_cycle_time_ = time;
     return return_type::OK;
   }
-  return_type result = return_type::ERROR;
   if (
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
-    result = impl_->trigger_read(time, period);
-    if (result == return_type::ERROR)
+    const auto trigger_result = impl_->trigger_read(time, period);
+    if (trigger_result.result == return_type::ERROR)
     {
       error();
     }
     last_read_cycle_time_ = time;
+    return trigger_result.result;
   }
-  return result;
+  return return_type::OK;
 }
 
 return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & period)
@@ -322,19 +323,19 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
     last_write_cycle_time_ = time;
     return return_type::OK;
   }
-  return_type result = return_type::ERROR;
   if (
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
     impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
-    result = impl_->trigger_write(time, period);
-    if (result == return_type::ERROR)
+    const auto trigger_result = impl_->trigger_write(time, period);
+    if (trigger_result.result == return_type::ERROR)
     {
       error();
     }
     last_write_cycle_time_ = time;
+    return trigger_result.result;
   }
-  return result;
+  return return_type::OK;
 }
 
 std::recursive_mutex & System::get_mutex() { return system_mutex_; }


### PR DESCRIPTION
This PR addressed the problem of half rate and spam logs of the hardware components running asynchronously.

With the current master, we have the following spam or logs and the update rate is half

```
[ros2_control_node-2] [WARN] [1740648615.839676344] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger write called while read async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping write cycle and will wait for a read cycle!
[ros2_control_node-2] [WARN] [1740648615.839702115] [rt_device_manager_ethercat]: Overrun, time since last cycle: 2.00068 msecs
[ros2_control_node-2] [WARN] [1740648615.840620668] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger read called while write async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping read cycle and will wait for a write cycle!
[ros2_control_node-2] [WARN] [1740648615.841685048] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger write called while read async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping write cycle and will wait for a read cycle!
[ros2_control_node-2] [WARN] [1740648615.841708566] [rt_device_manager_ethercat]: Overrun, time since last cycle: 2.00112 msecs
[ros2_control_node-2] [WARN] [1740648615.842621799] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger read called while write async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping read cycle and will wait for a write cycle!
[ros2_control_node-2] [WARN] [1740648615.843674634] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger write called while read async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping write cycle and will wait for a read cycle!
[ros2_control_node-2] [WARN] [1740648615.843704074] [rt_device_manager_ethercat]: Overrun, time since last cycle: 1.99762 msecs
[ros2_control_node-2] [WARN] [1740648615.844618273] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger read called while write async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping read cycle and will wait for a write cycle!
[ros2_control_node-2] [WARN] [1740648615.845672721] [controller_manager.resource_manager.hardware_component.system.ros2_control_triago_system_ethercat]: Trigger write called while read async handler call is still pending for hardware interface : 'ros2_control_triago_system_ethercat'. Skipping write cycle and will wait for a read cycle!
```

With this PR, it is as expected no spam of logs and works as expected