### PR TITLE
Fix case with wildcard AND explicit controller in the same file

### DIFF
--- a/controller_manager/controller_manager/controller_manager_services.py
+++ b/controller_manager/controller_manager/controller_manager_services.py
@@ -343,10 +343,9 @@ def get_params_files_with_controller_parameters(
                         )
                         break
                     controller_parameter_files.append(parameter_file)
-
-                if WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:
+                elif WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:
                     controller_parameter_files.append(parameter_file)
-                if WILDCARD_KEY in parameters and ROS_PARAMS_KEY in parameters[WILDCARD_KEY]:
+                elif WILDCARD_KEY in parameters and ROS_PARAMS_KEY in parameters[WILDCARD_KEY]:
                     controller_parameter_files.append(parameter_file)
     return controller_parameter_files
 
@@ -378,9 +377,9 @@ def get_parameter_from_param_files(
                         break
                     controller_param_dict = parameters[key]
 
-                if WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:
+                elif WILDCARD_KEY in parameters and key in parameters[WILDCARD_KEY]:
                     controller_param_dict = parameters[WILDCARD_KEY][key]
-                if WILDCARD_KEY in parameters and ROS_PARAMS_KEY in parameters[WILDCARD_KEY]:
+                elif WILDCARD_KEY in parameters and ROS_PARAMS_KEY in parameters[WILDCARD_KEY]:
                     controller_param_dict = parameters[WILDCARD_KEY]
 
                 if controller_param_dict and (

--- a/controller_manager/test/test_controller_spawner_wildcard_entries_global.yaml
+++ b/controller_manager/test/test_controller_spawner_wildcard_entries_global.yaml
@@ -1,0 +1,10 @@
+/**:
+  ros__parameters:
+    joint_names: ["joint1"]
+    param1: 1.0
+    param2: 2.0
+
+wildcard_ctrl:
+  ros__parameters:
+    type: "controller_manager/test_controller"
+    param3: 3.0


### PR DESCRIPTION
I had a parameter file of the form

```yaml
/**:
  ros__parameters:
    joint_names: ["joint1"]
    param1: 1.0
    param2: 2.0

wildcard_ctrl:
  ros__parameters:
    type: "controller_manager/test_controller"
    param3: 3.0
```

and had the issue that 

- the parameter file gets added twice
- and that the wildcard section wins over the second one and no type will be found to spawn:
`1: [ERROR] [1740775475.315343500] [test_controller_manager]: The 'type' param was not defined for 'wildcard_ctrl'.`

