### PR TITLE
[CM] Supress `robot_description` topic from remapping warnings

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3568,7 +3568,9 @@ rclcpp::NodeOptions ControllerManager::determine_controller_node_options(
 
   for (const std::string & arg : cm_node_options_.arguments())
   {
-    if (arg.find("__ns") != std::string::npos || arg.find("__node") != std::string::npos)
+    if (
+      arg.find("__ns") != std::string::npos || arg.find("__node") != std::string::npos ||
+      arg.find("robot_description") != std::string::npos)
     {
       if (
         node_options_arguments.back() == RCL_REMAP_FLAG ||


### PR DESCRIPTION
Before the fix:

```
[ros2_control_node-1] [INFO] [1740782632.616326129] [controller_manager]: Loading controller : 'joint_state_broadcaster' of type 'joint_state_broadcaster/JointStateBroadcaster'
[ros2_control_node-1] [INFO] [1740782632.616592781] [controller_manager]: Loading controller 'joint_state_broadcaster'
[ros2_control_node-1] [WARN] [1740782632.620554809] [controller_manager]: The use of remapping arguments to the controller_manager node is deprecated. Please use the '--controller-ros-args' argument of the spawner to pass remapping arguments to the controller node.
[ros2_control_node-1] [INFO] [1740782632.620580670] [controller_manager]: Controller 'joint_state_broadcaster' node arguments: --ros-args --params-file /home/user/rolling/ros2_control_denis_ws/install/ros2_control_demo_example_12/share/ros2_control_demo_example_12/config/rrbot_chained_controllers.yaml -r ~/robot_description:=/robot_description 
[spawner-5] [INFO] [1740782632.722115378] [spawner_joint_state_broadcaster]: Loaded joint_state_broadcaster
```

With the proposed fix:

```
[ros2_control_node-1] [INFO] [1740782785.636114375] [controller_manager]: Loading controller : 'joint_state_broadcaster' of type 'joint_state_broadcaster/JointStateBroadcaster'
[ros2_control_node-1] [INFO] [1740782785.636153262] [controller_manager]: Loading controller 'joint_state_broadcaster'
[ros2_control_node-1] [INFO] [1740782785.639488230] [controller_manager]: Controller 'joint_state_broadcaster' node arguments: --ros-args --params-file /home/user/rolling/ros2_control_denis_ws/install/ros2_control_demo_example_12/share/ros2_control_demo_example_12/config/rrbot_chained_controllers.yaml 
[spawner-5] [INFO] [1740782785.681564362] [spawner_joint_state_broadcaster]: Loaded joint_state_broadcaster
```