### PR TITLE
Reject duplicate state/command interfaces after configuring the controller 

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -324,11 +324,19 @@ private:
   void initialize_parameters();
 
   /**
+   * Call cleanup to change the given controller lifecycle node to the unconfigured state.
+   *
+   * \param[in] controller controller to be shutdown.
+   */
+  controller_interface::return_type cleanup_controller(
+    const controller_manager::ControllerSpec & controller);
+
+  /**
    * Call shutdown to change the given controller lifecycle node to the finalized state.
    *
    * \param[in] controller controller to be shutdown.
    */
-  void shutdown_controller(controller_manager::ControllerSpec & controller) const;
+  void shutdown_controller(const controller_manager::ControllerSpec & controller) const;
 
   /**
    * Clear request lists used when switching controllers. The lists are shared between "callback"

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -254,7 +254,7 @@ void get_controller_list_command_interfaces(
   }
 }
 template <typename Collection>
-[[nodiscard]] auto is_unique(Collection collection)
+[[nodiscard]] bool is_unique(Collection collection)
 {
   std::sort(collection.begin(), collection.end());
   return std::adjacent_find(collection.cbegin(), collection.cend()) == collection.cend();

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -592,6 +592,9 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   auto test_chainable_controller = std::make_shared<TestChainableController>();
   controller_interface::InterfaceConfiguration chained_cmd_cfg = {
     controller_interface::interface_configuration_type::INDIVIDUAL, {"joint1/position"}};
+  controller_interface::InterfaceConfiguration duplicated_chained_cmd_cfg = {
+    controller_interface::interface_configuration_type::INDIVIDUAL,
+    {"joint1/position", "joint1/position"}};
   controller_interface::InterfaceConfiguration chained_state_cfg = {
     controller_interface::interface_configuration_type::INDIVIDUAL,
     {"joint1/position", "joint1/velocity"}};
@@ -624,6 +627,53 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   result = call_service_and_wait(*client, request, srv_executor, true);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
+  EXPECT_EQ(
+    test_chainable_controller::TEST_CONTROLLER_NAME,
+    cm_->get_loaded_controllers()[0].c->get_name());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    test_chainable_controller->get_lifecycle_state().id());
+
+  // Now try to configure the chainable controller with duplicated command interfaces
+  test_chainable_controller->set_command_interface_configuration(duplicated_chained_cmd_cfg);
+  result = call_service_and_wait(*client, request, srv_executor, true);
+  ASSERT_FALSE(result->ok) << "Controller not configured: " << request->name;
+  EXPECT_EQ(
+    test_chainable_controller::TEST_CONTROLLER_NAME,
+    cm_->get_loaded_controllers()[0].c->get_name());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    test_chainable_controller->get_lifecycle_state().id());
+
+  // Now duplicate state interfaces
+  controller_interface::InterfaceConfiguration duplicated_chained_state_cfg = {
+    controller_interface::interface_configuration_type::INDIVIDUAL,
+    {"joint1/position", "joint1/position", "joint1/velocity"}};
+  test_chainable_controller->set_command_interface_configuration(chained_cmd_cfg);
+  test_chainable_controller->set_state_interface_configuration(duplicated_chained_state_cfg);
+  result = call_service_and_wait(*client, request, srv_executor, true);
+  ASSERT_FALSE(result->ok) << "Controller not configured: " << request->name;
+  EXPECT_EQ(
+    test_chainable_controller::TEST_CONTROLLER_NAME,
+    cm_->get_loaded_controllers()[0].c->get_name());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
+    test_chainable_controller->get_lifecycle_state().id());
+
+  // Now try to configure the chainable controller again with unique state and command interfaces
+  test_chainable_controller->set_command_interface_configuration(chained_cmd_cfg);
+  test_chainable_controller->set_state_interface_configuration(chained_state_cfg);
+  result = call_service_and_wait(*client, request, srv_executor, true);
+  ASSERT_TRUE(result->ok);
   EXPECT_EQ(
     test_chainable_controller::TEST_CONTROLLER_NAME,
     cm_->get_loaded_controllers()[0].c->get_name());


### PR DESCRIPTION
We've found a situation where the controller upon reconfiguring says that the controller interfaces are claimed already, even though they are not. Upon verifying, I've seen that when we reconfigure the controller and the controller required interfaces are not performed an internal cleanup, it might end up with duplicated interfaces and will cause this behaviour.

I've observed that with the `forward_command_controller`, every time you run a reconfigure, it adds the same info again to the `command_interface_types_`; it is missing a clear before that.

https://github.com/ros-controls/ros2_controllers/blob/0fb4fc68df5b4ef05b01aba9984fb22940f0a76d/forward_command_controller/src/forward_command_controller.cpp#L47-L51