### PR TITLE
Add some logging for `--unload-on-kill` keyboard interrupt

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -319,8 +319,9 @@ def main(args=None):
             while True:
                 time.sleep(1)
         except KeyboardInterrupt:
+            node.get_logger().info("KeyboardInterrupt successfully captured!")
             if not args.inactive:
-                node.get_logger().info("Interrupt captured, deactivating and unloading controller")
+                node.get_logger().info("Deactivating and unloading controllers...")
                 # TODO(saikishor) we might have an issue in future, if any of these controllers is in chained mode
                 ret = switch_controllers(
                     node,
@@ -365,6 +366,7 @@ def main(args=None):
                 return 1
         return 0
     except KeyboardInterrupt:
+        node.get_logger().info("KeyboardInterrupt received! Exiting....")
         pass
     except ServiceNotFoundError as err:
         node.get_logger().fatal(str(err))


### PR DESCRIPTION
Add some meaningful information for the `--unload-on-kill` options. 

This might be interesting to have to introspect https://github.com/ros-controls/ros2_control/issues/2063, I'm not able to reproduce this locally even after 300+ runs