### PR TITLE
[CM] Extend the list controller and hardware components messages

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2184,6 +2184,8 @@ void ControllerManager::list_controllers_srv_cb(
 
     controller_state.name = controllers[i].info.name;
     controller_state.type = controllers[i].info.type;
+    controller_state.is_async = controllers[i].c->is_async();
+    controller_state.update_rate = static_cast<uint16_t>(controllers[i].c->get_update_rate());
     controller_state.claimed_interfaces = controllers[i].info.claimed_interfaces;
     controller_state.state = controllers[i].c->get_lifecycle_state().label();
     controller_state.is_chainable = controllers[i].c->is_chainable();
@@ -2470,6 +2472,8 @@ void ControllerManager::list_hardware_components_srv_cb(
     auto component = controller_manager_msgs::msg::HardwareComponentState();
     component.name = component_name;
     component.type = component_info.type;
+    component.is_async = component_info.is_async;
+    component.rw_rate = static_cast<uint16_t>(component_info.rw_rate);
     component.plugin_name = component_info.plugin_name;
     component.state.id = component_info.state.id();
     component.state.label = component_info.state.label();

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -92,6 +92,8 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
   ASSERT_EQ(test_controller::TEST_CONTROLLER_NAME, result->controller[0].name);
   ASSERT_EQ(test_controller::TEST_CONTROLLER_CLASS_NAME, result->controller[0].type);
   ASSERT_EQ("unconfigured", result->controller[0].state);
+  ASSERT_FALSE(result->controller[0].is_async);
+  ASSERT_EQ(100u, result->controller[0].update_rate);
   ASSERT_TRUE(result->controller[0].claimed_interfaces.empty());
   ASSERT_TRUE(result->controller[0].required_command_interfaces.empty());
   ASSERT_TRUE(result->controller[0].required_state_interfaces.empty());
@@ -100,6 +102,8 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
   ASSERT_EQ("inactive", result->controller[0].state);
+  ASSERT_FALSE(result->controller[0].is_async);
+  ASSERT_EQ(100u, result->controller[0].update_rate);
   ASSERT_TRUE(result->controller[0].claimed_interfaces.empty());
   ASSERT_THAT(
     result->controller[0].required_command_interfaces,
@@ -114,6 +118,8 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
+  ASSERT_FALSE(result->controller[0].is_async);
+  ASSERT_EQ(100u, result->controller[0].update_rate);
   ASSERT_EQ("active", result->controller[0].state);
   ASSERT_THAT(
     result->controller[0].claimed_interfaces,
@@ -131,6 +137,8 @@ TEST_F(TestControllerManagerSrvs, list_controllers_srv)
 
   result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_EQ(1u, result->controller.size());
+  ASSERT_FALSE(result->controller[0].is_async);
+  ASSERT_EQ(100u, result->controller[0].update_rate);
   ASSERT_EQ("inactive", result->controller[0].state);
   ASSERT_TRUE(result->controller[0].claimed_interfaces.empty());
   ASSERT_THAT(

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -133,6 +133,8 @@ public:
     {
       if (component.name == TEST_ACTUATOR_HARDWARE_NAME)
       {
+        ASSERT_FALSE(component.is_async);
+        ASSERT_EQ(100u, component.rw_rate);
         check_component_fileds(
           component, TEST_ACTUATOR_HARDWARE_NAME, TEST_ACTUATOR_HARDWARE_TYPE,
           TEST_ACTUATOR_HARDWARE_PLUGIN_NAME, hw_state_ids[0], hw_state_labels[0]);
@@ -145,6 +147,8 @@ public:
       }
       if (component.name == TEST_SENSOR_HARDWARE_NAME)
       {
+        ASSERT_FALSE(component.is_async);
+        ASSERT_EQ(100u, component.rw_rate);
         check_component_fileds(
           component, TEST_SENSOR_HARDWARE_NAME, TEST_SENSOR_HARDWARE_TYPE,
           TEST_SENSOR_HARDWARE_PLUGIN_NAME, hw_state_ids[1], hw_state_labels[1]);
@@ -157,6 +161,8 @@ public:
       }
       if (component.name == TEST_SYSTEM_HARDWARE_NAME)
       {
+        ASSERT_FALSE(component.is_async);
+        ASSERT_EQ(100u, component.rw_rate);
         check_component_fileds(
           component, TEST_SYSTEM_HARDWARE_NAME, TEST_SYSTEM_HARDWARE_TYPE,
           TEST_SYSTEM_HARDWARE_PLUGIN_NAME, hw_state_ids[2], hw_state_labels[2]);

--- a/controller_manager_msgs/msg/ControllerState.msg
+++ b/controller_manager_msgs/msg/ControllerState.msg
@@ -1,6 +1,8 @@
 string name        # controller name
 string state        # controller state: unconfigured, inactive, active, or finalized
 string type        # the controller class name, e.g. joint_trajectory_controller/JointTrajectoryController
+bool is_async       # true, if controller runs asynchronously. false, if controller runs synchronously
+uint16 update_rate        # update rate of the controller in Hz
 string[] claimed_interfaces        # command interfaces currently owned by controller
 string[] required_command_interfaces        # command interfaces required by controller
 string[] required_state_interfaces        # state interfaces required by controller

--- a/controller_manager_msgs/msg/HardwareComponentState.msg
+++ b/controller_manager_msgs/msg/HardwareComponentState.msg
@@ -1,7 +1,9 @@
-string name
-string type
+string name # Name of the hardware component
+string type # Type of the hardware component
+bool is_async # If the hardware component is running asynchronously
+uint16 rw_rate # read/write rate of the hardware component in Hz
 string class_type  # DEPRECATED
-string plugin_name
-lifecycle_msgs/State state
-HardwareInterface[] command_interfaces
-HardwareInterface[] state_interfaces
+string plugin_name # The name of the plugin that is used to load the hardware component
+lifecycle_msgs/State state # State of the hardware component
+HardwareInterface[] command_interfaces # Command interfaces of the hardware component
+HardwareInterface[] state_interfaces # State interfaces of the hardware component

--- a/ros2controlcli/ros2controlcli/verb/list_controllers.py
+++ b/ros2controlcli/ros2controlcli/verb/list_controllers.py
@@ -34,6 +34,8 @@ def print_controller_state(c, args, col_width_name, col_width_state, col_width_t
     print(
         f"{state_color}{c.name:<{col_width_name}}{bcolors.ENDC} {c.type:<{col_width_type}}  {state_color}{c.state:<{col_width_state}}{bcolors.ENDC}"
     )
+    print(f"\tupdate_rate: {c.update_rate} Hz")
+    print(f"\tis_async: {c.is_async}")
     if args.claimed_interfaces or args.verbose:
         print("\tclaimed interfaces:")
         for claimed_interface in c.claimed_interfaces:

--- a/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
+++ b/ros2controlcli/ros2controlcli/verb/list_hardware_components.py
@@ -60,6 +60,8 @@ class ListHardwareComponentsVerb(VerbExtension):
                 print(
                     f"\tplugin name: {plugin_name}\n"
                     f"\tstate: id={component.state.id} label={activity_color}{component.state.label}{bcolors.ENDC}\n"
+                    f"\tread/write rate: {component.rw_rate} Hz\n"
+                    f"\tis_async: {component.is_async}\n"
                     f"\tcommand interfaces"
                 )
                 for cmd_interface in component.command_interfaces:


### PR DESCRIPTION
This PR aims to extend the `list_controllers` and `list_hardware_components` messages with some important information like async and also update_rate.

**update_rate: 10 Hz
is_async: False**
are added to both HW component and Controllers

Before:
```
~/ros2_control_limits_ws/src$ ros2 control list_controllers -v
joint_state_broadcaster    joint_state_broadcaster/JointStateBroadcaster  active
	claimed interfaces:
	required command interfaces:
	required state interfaces:
		joint1/position
		joint2/position
	chained to interfaces:
	exported reference interfaces:
	exported state interfaces:
joint2_position_controller passthrough_controller/PassthroughController   active
	claimed interfaces:
		joint2/position
	required command interfaces:
		joint2/position
	required state interfaces:
	chained to interfaces:
	exported reference interfaces:
		joint2/position
	exported state interfaces:
joint1_position_controller passthrough_controller/PassthroughController   active
	claimed interfaces:
		joint1/position
	required command interfaces:
		joint1/position
	required state interfaces:
	chained to interfaces:
	exported reference interfaces:
		joint1/position
	exported state interfaces:
```


With the changes of this PR:
```
$ ros2 control list_controllers -v
joint_state_broadcaster    joint_state_broadcaster/JointStateBroadcaster  active
	update_rate: 10 Hz
	is_async: False
	claimed interfaces:
	required command interfaces:
	required state interfaces:
		joint1/position
		joint2/position
	chained to interfaces:
	exported reference interfaces:
	exported state interfaces:
joint1_position_controller passthrough_controller/PassthroughController   active
	update_rate: 10 Hz
	is_async: False
	claimed interfaces:
		joint1/position
	required command interfaces:
		joint1/position
	required state interfaces:
	chained to interfaces:
	exported reference interfaces:
		joint1/position
	exported state interfaces:
joint2_position_controller passthrough_controller/PassthroughController   active
	update_rate: 10 Hz
	is_async: False
	claimed interfaces:
		joint2/position
	required command interfaces:
		joint2/position
	required state interfaces:
	chained to interfaces:
	exported reference interfaces:
		joint2/position
	exported state interfaces:
```


Before:

```
$ ros2 control list_hardware_components -v
Hardware Component 1
	name: RRBot
	type: system
	plugin name: ros2_control_demo_example_12/RRBotSystemPositionOnlyHardware
	state: id=3 label=active
	command interfaces
		joint2/position [available] [claimed]
		joint1/position [available] [claimed]
	state interfaces
		joint2/position [available]
		joint1/position [available]
```

With the changes of this PR:

```
$ ros2 control list_hardware_components -v
Hardware Component 1
	name: RRBot
	type: system
	plugin name: ros2_control_demo_example_12/RRBotSystemPositionOnlyHardware
	state: id=3 label=active
	read/write rate: 10 Hz
	is_async: False
	command interfaces
		joint2/position [available] [claimed]
		joint1/position [available] [claimed]
	state interfaces
		joint2/position [available]
		joint1/position [available]
```