### PR TITLE
Release interfaces upon destruction of the controller

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -37,6 +37,7 @@ ControllerInterfaceBase::~ControllerInterfaceBase()
       get_node()->get_name());
     node_->shutdown();
   }
+  release_interfaces();
 }
 
 return_type ControllerInterfaceBase::init(


### PR DESCRIPTION
This PR addresses the issue mostly in the tests, when the controllers are not properly cleanup, there might be a dangling reference left in the Loaned Interfaces, and by releasing interfaces upon controller destruction might prevent this issue. 

Most likely fixes https://github.com/ros-controls/ros2_controllers/issues/1588