### PR TITLE
Remove the dangling param flag for robot_description with parameter

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3828,7 +3828,9 @@ rclcpp::NodeOptions ControllerManager::determine_controller_node_options(
     {
       if (
         node_options_arguments.back() == RCL_REMAP_FLAG ||
-        node_options_arguments.back() == RCL_SHORT_REMAP_FLAG)
+        node_options_arguments.back() == RCL_SHORT_REMAP_FLAG ||
+        node_options_arguments.back() == RCL_PARAM_FLAG ||
+        node_options_arguments.back() == RCL_SHORT_PARAM_FLAG)
       {
         node_options_arguments.pop_back();
       }


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/pull/2082#issuecomment-2735941028

Initially, when we suppressed the warning we only handled the case of the robot_description parsed using topics but not the parameter.

@lukicdarkoo Can you check this change and let us know :)