### PR TITLE
[CLI] print update_rate and is_async on verbose

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/list_controllers.py
+++ b/ros2controlcli/ros2controlcli/verb/list_controllers.py
@@ -34,8 +34,9 @@ def print_controller_state(c, args, col_width_name, col_width_state, col_width_t
     print(
         f"{state_color}{c.name:<{col_width_name}}{bcolors.ENDC} {c.type:<{col_width_type}}  {state_color}{c.state:<{col_width_state}}{bcolors.ENDC}"
     )
-    print(f"\tupdate_rate: {c.update_rate} Hz")
-    print(f"\tis_async: {c.is_async}")
+    if args.verbose:
+        print(f"\tupdate_rate: {c.update_rate} Hz")
+        print(f"\tis_async: {c.is_async}")
     if args.claimed_interfaces or args.verbose:
         print("\tclaimed interfaces:")
         for claimed_interface in c.claimed_interfaces:


### PR DESCRIPTION
This was introduced by error in my previous PR: https://github.com/ros-controls/ros2_control/pull/2102

With `master`

```
$ ros2 control list_controllers 
forward_position_controller forward_command_controller/ForwardCommandController  active
	update_rate: 10 Hz
	is_async: False
position_controller         passthrough_controller/PassthroughController         active
	update_rate: 10 Hz
	is_async: False
joint2_position_controller  passthrough_controller/PassthroughController         active
	update_rate: 10 Hz
	is_async: False
joint1_position_controller  passthrough_controller/PassthroughController         active
	update_rate: 10 Hz
	is_async: False
joint_state_broadcaster     joint_state_broadcaster/JointStateBroadcaster        active
	update_rate: 10 Hz
	is_async: False
```

With fix proposed in this PR:

```
$ ros2 control list_controllers 
forward_position_controller forward_command_controller/ForwardCommandController  active
position_controller         passthrough_controller/PassthroughController         active
joint2_position_controller  passthrough_controller/PassthroughController         active
joint1_position_controller  passthrough_controller/PassthroughController         active
joint_state_broadcaster     joint_state_broadcaster/JointStateBroadcaster        active
```

