### PR TITLE
[Docs] Update determinism section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ros2_control
 
-[![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![codecov](https://codecov.io/gh/ros-controls/ros2_control/graph/badge.svg?token=idvm1zJXOf)](https://codecov.io/gh/ros-controls/ros2_control)
 
 This package is a part of the ros2_control framework.

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -16,7 +16,7 @@ Independent of the kernel installed, the main thread of Controller Manager attem
 configure ``SCHED_FIFO`` with a priority of ``50``. Read more about the scheduling policies
 `for example here <https://blogs.oracle.com/linux/post/task-priority>`__.
 
-For real time tasks a priority range of 0 to 99 is used. In this case a higher number indicates higher priority. By default, the user does not have permission to set such a high priority.
+For real-time tasks, a priority range of 0 to 99 is expected, with higher numbers indicating higher priority. By default, users do not have permission to set such high priorities.
 To give the user such permissions, add a group named realtime and add the user controlling your robot to this group:
 
 .. code-block:: console
@@ -52,7 +52,7 @@ For more information, see the Docker engine documentation about `resource_constr
 The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
 Alternatives to the standard kernel include
 
-- `Real-time Ubuntu <https://ubuntu.com/real-time>`_ on Ubuntu 24.04 (also for RaspberryPi)
+- `Real-time Ubuntu <https://ubuntu.com/real-time>`_ on Ubuntu (also for RaspberryPi)
 - `linux-image-rt-amd64 <https://packages.debian.org/bookworm/linux-image-rt-amd64>`_ on Debian Bookworm for 64-bit PCs
 - `lowlatency kernel <https://ubuntu.com/blog/industrial-embedded-systems>`__ (``sudo apt install linux-lowlatency``) on any Ubuntu
 
@@ -72,6 +72,8 @@ Subscribers
 
 robot_description [std_msgs::msg::String]
   String with the URDF xml, e.g., from ``robot_state_publisher``.
+  Reloading of the URDF is not supported yet.
+  All joints defined in the ``<ros2_control>``-tag have to be present in the URDF.
 
 
 Parameters

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -37,7 +37,7 @@ Afterwards, add the following limits to the realtime group in ``/etc/security/li
 
 The limits will be applied after you log out and in again.
 
-You can run ros2_control with real-time requirements also from a docker container. Pass the following capability options to allow the container to set the thread priority and lock memory, e.g., for the ``ros2_control_demos`` container:
+You can run ros2_control with real-time requirements also from a docker container. Pass the following capability options to allow the container to set the thread priority and lock memory, e.g.,
 
 .. code-block:: console
 
@@ -45,7 +45,7 @@ You can run ros2_control with real-time requirements also from a docker containe
         --cap-add=sys_nice \
         --ulimit rtprio=99 \
         --ulimit memlock=-1 \
-        --rm --net host ros2_control_demos
+        --rm --net host <IMAGE>
 
 For more information, see the Docker engine documentation about `resource_constraints <https://docs.docker.com/engine/containers/resource_constraints/#configure-the-real-time-scheduler>`__ and `linux capabilities <https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities>`__.
 

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -53,7 +53,7 @@ The normal linux kernel is optimized for computational throughput and therefore 
 Alternatives to the standard kernel include
 
 - `Real-time Ubuntu <https://ubuntu.com/real-time>`_ on Ubuntu (also for RaspberryPi)
-- `linux-image-rt-amd64 <https://packages.debian.org/bookworm/linux-image-rt-amd64>`_ on Debian Bookworm for 64-bit PCs
+- `linux-image-rt-amd64 <https://packages.debian.org/search?searchon=names&keywords=linux-image-rt-amd64>`__ or `linux-image-rt-arm64 <https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=linux-image-rt-arm64>`__ on Debian for 64-bit PCs
 - `lowlatency kernel <https://ubuntu.com/blog/industrial-embedded-systems>`__ (``sudo apt install linux-lowlatency``) on any Ubuntu
 
 Though installing a realtime-kernel will definitely get the best results when it comes to low

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -37,6 +37,18 @@ Afterwards, add the following limits to the realtime group in ``/etc/security/li
 
 The limits will be applied after you log out and in again.
 
+You can run ros2_control with real-time requirements also from a docker container. Pass the following capability options to allow the container to set the thread priority and lock memory, e.g., for the ``ros2_control_demos`` container:
+
+.. code-block:: console
+
+    $ docker run -it \
+        --cap-add=sys_nice \
+        --ulimit rtprio=99 \
+        --ulimit memlock=-1 \
+        --rm --name ros2_control_demos --net host ros2_control_demos
+
+For more information, see the Docker engine documentation about `resource_constraints <https://docs.docker.com/engine/containers/resource_constraints/#configure-the-real-time-scheduler>`__ and `linux capabilities <https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities>`__.
+
 The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
 Alternatives to the standard kernel include
 

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -45,7 +45,7 @@ You can run ros2_control with real-time requirements also from a docker containe
         --cap-add=sys_nice \
         --ulimit rtprio=99 \
         --ulimit memlock=-1 \
-        --rm --name ros2_control_demos --net host ros2_control_demos
+        --rm --net host ros2_control_demos
 
 For more information, see the Docker engine documentation about `resource_constraints <https://docs.docker.com/engine/containers/resource_constraints/#configure-the-real-time-scheduler>`__ and `linux capabilities <https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities>`__.
 

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -13,8 +13,10 @@ Determinism
 For best performance when controlling hardware you want the controller manager to have as little jitter as possible in the main control loop.
 
 Independent of the kernel installed, the main thread of Controller Manager attempts to
-configure ``SCHED_FIFO`` with a priority of ``50``.
-By default, the user does not have permission to set such a high priority.
+configure ``SCHED_FIFO`` with a priority of ``50``. Read more about the scheduling policies
+`for example here <https://blogs.oracle.com/linux/post/task-priority>`__.
+
+For real time tasks a priority range of 0 to 99 is used. In this case a higher number indicates higher priority. By default, the user does not have permission to set such a high priority.
 To give the user such permissions, add a group named realtime and add the user controlling your robot to this group:
 
 .. code-block:: console
@@ -38,9 +40,9 @@ The limits will be applied after you log out and in again.
 The normal linux kernel is optimized for computational throughput and therefore is not well suited for hardware control.
 Alternatives to the standard kernel include
 
-- `Real-time Ubuntu 22.04 LTS Beta <https://ubuntu.com/blog/real-time-ubuntu-released>`_ on Ubuntu 22.04
-- `linux-image-rt-amd64 <https://packages.debian.org/bullseye/linux-image-rt-amd64>`_ on Debian Bullseye
-- lowlatency kernel (``sudo apt install linux-lowlatency``) on any ubuntu
+- `Real-time Ubuntu <https://ubuntu.com/real-time>`_ on Ubuntu 24.04 (also for RaspberryPi)
+- `linux-image-rt-amd64 <https://packages.debian.org/bookworm/linux-image-rt-amd64>`_ on Debian Bookworm for 64-bit PCs
+- `lowlatency kernel <https://ubuntu.com/blog/industrial-embedded-systems>`__ (``sudo apt install linux-lowlatency``) on any Ubuntu
 
 Though installing a realtime-kernel will definitely get the best results when it comes to low
 jitter, using a lowlatency kernel can improve things a lot with being really easy to install.
@@ -58,8 +60,6 @@ Subscribers
 
 robot_description [std_msgs::msg::String]
   String with the URDF xml, e.g., from ``robot_state_publisher``.
-  Reloading of the URDF is not supported yet.
-  All joints defined in the ``<ros2_control>``-tag have to be present in the URDF.
 
 
 Parameters


### PR DESCRIPTION
I tested different configurations with a Raspi5 and updated the docs a bit

## some tests
what I compared

1. stock Ubuntu Server 24.04 LTS, PREEMPT_DYNAMIC (default)
2. with Ubuntu Real-Time:
```
$ cat /proc/version
Linux version 6.8.0-2019-raspi-realtime (buildd@bos03-arm64-026) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #20-Ubuntu SMP PREEMPT_RT Thu Feb 27 14:16:18 UTC 2025
```
3. Ubuntu Real-time with ros2_control launched inside a docker
4. Raspberry Pi OS Lite
`Linux version 6.6.51+rpt-rpi-2712 (serge@raspberrypi.com) (gcc-12 (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT Debian 1:6.6.51-1+rpt3 (2024-10-08)`
5. Raspberry Pi OS Lite + Docker

I was not able to install the lowlatency-kernel on Ubuntu, there seems to be a bug with kernel 6.8 on the arm platform.


I launched ros2_control_demo_example_1 and had only a look 

- on the console output if the memory lock and the thread priority was set successfully
- the cm periodicity from the /diagnostics topic

While being in idle, there was not a big difference. But with something like

`stress --cpu 3 --io 4 --vm 4 --vm-bytes 1024M --timeout 10s`

the standard deviation increased a lot with the stock kernel (periodicity min/max 9.5-10.5), while there was almost no change in periodicty with the realtime kernel. 
When running ros2_control inside the docker with the appropriate flags, I had almost the same result like with running natively and RT-kernel.

## rendered docs
![image](https://github.com/user-attachments/assets/cb462fc0-3f90-464b-866c-2c216436abf6)
