### PR TITLE
[RM] Add error handling for missing `plugin` tags in URDF parsing

### DIFF
--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -555,7 +555,7 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
 
   if (!type_it)
   {
-    throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
+    throw std::runtime_error("Missing <plugin> tag of <transmission> element in your URDF.");
   }
 
   transmission.type = get_text_for_element(type_it, kPluginNameTag);
@@ -669,7 +669,7 @@ HardwareInfo parse_resource_from_xml(
 
       if (!type_it)
       {
-        throw std::runtime_error("Missing <plugin> tag in <hardware> element in your URDF.");
+        throw std::runtime_error("Missing <plugin> tag of <hardware> element in your URDF.");
       }
 
       hardware.hardware_plugin_name =

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -551,10 +551,9 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
 
   // Find name, type and class of a transmission
   transmission.name = get_attribute_value(transmission_it, kNameAttribute, transmission_it->Name());
-  const auto * type_it = nullptr;
+  const auto * type_it = transmission_it->FirstChildElement(kPluginNameTag);
   try
   {
-    type_it = transmission_it->FirstChildElement(kPluginNameTag);
     if (!type_it)
     {
       throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
@@ -672,10 +671,9 @@ HardwareInfo parse_resource_from_xml(
   {
     if (std::string(kHardwareTag) == ros2_control_child_it->Name())
     {
-      const auto * type_it = nullptr;
+      const auto * type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
       try
       {
-        type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
         if (!type_it)
         {
           throw std::runtime_error("Missing <plugin> tag in <hardware> element in your urdf.");
@@ -686,6 +684,7 @@ HardwareInfo parse_resource_from_xml(
         std::cerr << "Error: " << e.what() << std::endl;
         throw;
       }
+
       hardware.hardware_plugin_name =
         get_text_for_element(type_it, std::string("hardware ") + kPluginNameTag);
       const auto * group_it = ros2_control_child_it->FirstChildElement(kGroupTag);

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -552,12 +552,10 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
   // Find name, type and class of a transmission
   transmission.name = get_attribute_value(transmission_it, kNameAttribute, transmission_it->Name());
   const auto * type_it = transmission_it->FirstChildElement(kPluginNameTag);
-
   if (!type_it)
   {
     throw std::runtime_error("Missing <plugin> tag of <transmission> element in your URDF.");
   }
-
   transmission.type = get_text_for_element(type_it, kPluginNameTag);
 
   // Parse joints
@@ -666,12 +664,10 @@ HardwareInfo parse_resource_from_xml(
     if (std::string(kHardwareTag) == ros2_control_child_it->Name())
     {
       const auto * type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
-
       if (!type_it)
       {
         throw std::runtime_error("Missing <plugin> tag of <hardware> element in your URDF.");
       }
-
       hardware.hardware_plugin_name =
         get_text_for_element(type_it, std::string("hardware ") + kPluginNameTag);
       const auto * group_it = ros2_control_child_it->FirstChildElement(kGroupTag);

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -551,7 +551,20 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
 
   // Find name, type and class of a transmission
   transmission.name = get_attribute_value(transmission_it, kNameAttribute, transmission_it->Name());
-  const auto * type_it = transmission_it->FirstChildElement(kPluginNameTag);
+  const auto * type_it = nullptr;
+  try
+  {
+    type_it = transmission_it->FirstChildElement(kPluginNameTag);
+    if (!type_it)
+    {
+      throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
+    }
+  }
+  catch (const std::runtime_error & e)
+  {
+    std::cerr << "Error: " << e.what() << std::endl;
+    throw;
+  }
   transmission.type = get_text_for_element(type_it, kPluginNameTag);
 
   // Parse joints
@@ -659,7 +672,20 @@ HardwareInfo parse_resource_from_xml(
   {
     if (std::string(kHardwareTag) == ros2_control_child_it->Name())
     {
-      const auto * type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
+      const auto * type_it = nullptr;
+      try
+      {
+        type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
+        if (!type_it)
+        {
+          throw std::runtime_error("Missing <plugin> tag in <hardware> element in your urdf.");
+        }
+      }
+      catch (const std::runtime_error & e)
+      {
+        std::cerr << "Error: " << e.what() << std::endl;
+        throw;
+      }
       hardware.hardware_plugin_name =
         get_text_for_element(type_it, std::string("hardware ") + kPluginNameTag);
       const auto * group_it = ros2_control_child_it->FirstChildElement(kGroupTag);

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -552,18 +552,13 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
   // Find name, type and class of a transmission
   transmission.name = get_attribute_value(transmission_it, kNameAttribute, transmission_it->Name());
   const auto * type_it = transmission_it->FirstChildElement(kPluginNameTag);
-  try
+
+  if (!type_it)
   {
-    if (!type_it)
-    {
-      throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
-    }
+    std::cerr << "Error: Missing <plugin> tag in <transmission> element in your URDF." << std::endl;
+    throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
   }
-  catch (const std::runtime_error & e)
-  {
-    std::cerr << "Error: " << e.what() << std::endl;
-    throw;
-  }
+
   transmission.type = get_text_for_element(type_it, kPluginNameTag);
 
   // Parse joints
@@ -672,17 +667,11 @@ HardwareInfo parse_resource_from_xml(
     if (std::string(kHardwareTag) == ros2_control_child_it->Name())
     {
       const auto * type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
-      try
+
+      if (!type_it)
       {
-        if (!type_it)
-        {
-          throw std::runtime_error("Missing <plugin> tag in <hardware> element in your urdf.");
-        }
-      }
-      catch (const std::runtime_error & e)
-      {
-        std::cerr << "Error: " << e.what() << std::endl;
-        throw;
+        std::cerr << "Error: Missing <plugin> tag in <hardware> element in your URDF." << std::endl;
+        throw std::runtime_error("Missing <plugin> tag in <hardware> element in your urdf.");
       }
 
       hardware.hardware_plugin_name =

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -555,7 +555,6 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
 
   if (!type_it)
   {
-    std::cerr << "Error: Missing <plugin> tag in <transmission> element in your URDF." << std::endl;
     throw std::runtime_error("Missing <plugin> tag in <transmission> element in your URDF.");
   }
 
@@ -670,8 +669,7 @@ HardwareInfo parse_resource_from_xml(
 
       if (!type_it)
       {
-        std::cerr << "Error: Missing <plugin> tag in <hardware> element in your URDF." << std::endl;
-        throw std::runtime_error("Missing <plugin> tag in <hardware> element in your urdf.");
+        throw std::runtime_error("Missing <plugin> tag in <hardware> element in your URDF.");
       }
 
       hardware.hardware_plugin_name =


### PR DESCRIPTION
Added a try-catch block statement to check the validity of type_it in hardware interface parser. It returns an error signifying the missing plugin in either hardware or transmission element