### PR TITLE
Fix generate_controllers_spawner_launch_description_from_dict

### DIFF
--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -133,7 +133,7 @@ def generate_controllers_spawner_launch_description_from_dict(
                     f"Invalid controller_params_file type parsed in the dict {controller_params_file}"
                 )
     return generate_controllers_spawner_launch_description(
-        controller_names=controller_names,
+        controller_names=list(controller_names),
         controller_params_files=controller_params_files,
         extra_spawner_args=extra_spawner_args,
     )

--- a/controller_manager/controller_manager/launch_utils.py
+++ b/controller_manager/controller_manager/launch_utils.py
@@ -119,7 +119,7 @@ def generate_controllers_spawner_launch_description_from_dict(
     """
     if not type(controller_info_dict) is dict:
         raise ValueError(f"Invalid controller_info_dict type parsed {controller_info_dict}")
-    controller_names = controller_info_dict.keys()
+    controller_names = list(controller_info_dict.keys())
     controller_params_files = []
     for controller_name in controller_names:
         controller_params_file = controller_info_dict[controller_name]
@@ -133,7 +133,7 @@ def generate_controllers_spawner_launch_description_from_dict(
                     f"Invalid controller_params_file type parsed in the dict {controller_params_file}"
                 )
     return generate_controllers_spawner_launch_description(
-        controller_names=list(controller_names),
+        controller_names=controller_names,
         controller_params_files=controller_params_files,
         extra_spawner_args=extra_spawner_args,
     )


### PR DESCRIPTION
Hello team!

I was trying to use the method `generate_controllers_spawner_launch_description_from_dict`,  but I was getting this error:
`AttributeError: 'dict_keys' object has no attribute 'extend'`

The issue arises because the method `generate_controllers_spawner_launch_description` expects a list of strings, not type 'dict_keys'. This PR fixes the issue by ensuring the correct data type is passed.

Let me know if any changes or additional explanations are needed! 
