### PR TITLE
Make all packages use gmock, not gtest

### DIFF
--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -14,8 +14,9 @@
 
 #include "test_chainable_controller_interface.hpp"
 
-#include "gmock/gmock.h"
 #include <memory>
+
+#include "gmock/gmock.h"
 
 using ::testing::IsEmpty;
 using ::testing::SizeIs;

--- a/controller_interface/test/test_chainable_controller_interface.cpp
+++ b/controller_interface/test/test_chainable_controller_interface.cpp
@@ -14,7 +14,7 @@
 
 #include "test_chainable_controller_interface.hpp"
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 
 using ::testing::IsEmpty;

--- a/controller_interface/test/test_chainable_controller_interface.hpp
+++ b/controller_interface/test/test_chainable_controller_interface.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_CHAINABLE_CONTROLLER_INTERFACE_HPP_
 #define TEST_CHAINABLE_CONTROLLER_INTERFACE_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <string>
 #include <vector>

--- a/controller_interface/test/test_chainable_controller_interface.hpp
+++ b/controller_interface/test/test_chainable_controller_interface.hpp
@@ -15,12 +15,11 @@
 #ifndef TEST_CHAINABLE_CONTROLLER_INTERFACE_HPP_
 #define TEST_CHAINABLE_CONTROLLER_INTERFACE_HPP_
 
-#include "gmock/gmock.h"
-
 #include <string>
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"
+#include "gmock/gmock.h"
 #include "hardware_interface/handle.hpp"
 
 constexpr char TEST_CONTROLLER_NAME[] = "testable_chainable_controller";

--- a/controller_interface/test/test_controller_interface.cpp
+++ b/controller_interface/test/test_controller_interface.cpp
@@ -14,7 +14,7 @@
 
 #include "test_controller_interface.hpp"
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_interface/test/test_controller_interface.cpp
+++ b/controller_interface/test/test_controller_interface.cpp
@@ -14,11 +14,11 @@
 
 #include "test_controller_interface.hpp"
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/executor_options.hpp"
 #include "rclcpp/executors/multi_threaded_executor.hpp"

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -14,7 +14,7 @@
 
 #include "test_controller_with_options.hpp"
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <string>
 
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -14,7 +14,7 @@
 
 #include "test_controller_with_options.hpp"
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions

--- a/controller_interface/test/test_controller_with_options.cpp
+++ b/controller_interface/test/test_controller_with_options.cpp
@@ -14,8 +14,9 @@
 
 #include "test_controller_with_options.hpp"
 
-#include "gmock/gmock.h"
 #include <string>
+
+#include "gmock/gmock.h"
 
 class FriendControllerWithOptions : public controller_with_options::ControllerWithOptions
 {

--- a/controller_interface/test/test_force_torque_sensor.hpp
+++ b/controller_interface/test/test_force_torque_sensor.hpp
@@ -19,7 +19,7 @@
 #ifndef TEST_FORCE_TORQUE_SENSOR_HPP_
 #define TEST_FORCE_TORQUE_SENSOR_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/controller_interface/test/test_force_torque_sensor.hpp
+++ b/controller_interface/test/test_force_torque_sensor.hpp
@@ -19,12 +19,11 @@
 #ifndef TEST_FORCE_TORQUE_SENSOR_HPP_
 #define TEST_FORCE_TORQUE_SENSOR_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "semantic_components/force_torque_sensor.hpp"
 
 // implementing and friending so we can access member variables

--- a/controller_interface/test/test_gps_sensor.cpp
+++ b/controller_interface/test/test_gps_sensor.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
 #include <string>

--- a/controller_interface/test/test_gps_sensor.cpp
+++ b/controller_interface/test/test_gps_sensor.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <algorithm>
 #include <array>
 #include <string>

--- a/controller_interface/test/test_gps_sensor.cpp
+++ b/controller_interface/test/test_gps_sensor.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <algorithm>
 #include <array>
 #include <string>
 #include <vector>
+
+#include "gmock/gmock.h"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "semantic_components/gps_sensor.hpp"

--- a/controller_interface/test/test_imu_sensor.hpp
+++ b/controller_interface/test/test_imu_sensor.hpp
@@ -19,12 +19,11 @@
 #ifndef TEST_IMU_SENSOR_HPP_
 #define TEST_IMU_SENSOR_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "semantic_components/imu_sensor.hpp"
 
 // implementing and friending so we can access member variables

--- a/controller_interface/test/test_imu_sensor.hpp
+++ b/controller_interface/test/test_imu_sensor.hpp
@@ -19,7 +19,7 @@
 #ifndef TEST_IMU_SENSOR_HPP_
 #define TEST_IMU_SENSOR_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/controller_interface/test/test_led_rgb_device.hpp
+++ b/controller_interface/test/test_led_rgb_device.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_LED_RGB_DEVICE_HPP_
 #define TEST_LED_RGB_DEVICE_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <array>
 #include <limits>

--- a/controller_interface/test/test_led_rgb_device.hpp
+++ b/controller_interface/test/test_led_rgb_device.hpp
@@ -15,14 +15,13 @@
 #ifndef TEST_LED_RGB_DEVICE_HPP_
 #define TEST_LED_RGB_DEVICE_HPP_
 
-#include "gmock/gmock.h"
-
 #include <array>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "semantic_components/led_rgb_device.hpp"
 
 class TestableLedDevice : public semantic_components::LedRgbDevice

--- a/controller_interface/test/test_pose_sensor.hpp
+++ b/controller_interface/test/test_pose_sensor.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_POSE_SENSOR_HPP_
 #define TEST_POSE_SENSOR_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <array>
 #include <memory>

--- a/controller_interface/test/test_pose_sensor.hpp
+++ b/controller_interface/test/test_pose_sensor.hpp
@@ -15,13 +15,12 @@
 #ifndef TEST_POSE_SENSOR_HPP_
 #define TEST_POSE_SENSOR_HPP_
 
-#include "gmock/gmock.h"
-
 #include <array>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "semantic_components/pose_sensor.hpp"
 
 class TestablePoseSensor : public semantic_components::PoseSensor

--- a/controller_interface/test/test_semantic_component_command_interface.hpp
+++ b/controller_interface/test/test_semantic_component_command_interface.hpp
@@ -18,12 +18,11 @@
 #ifndef TEST_SEMANTIC_COMPONENT_COMMAND_INTERFACE_HPP_
 #define TEST_SEMANTIC_COMPONENT_COMMAND_INTERFACE_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 
 #include "geometry_msgs/msg/pose.hpp"
+#include "gmock/gmock.h"
 #include "semantic_components/semantic_component_command_interface.hpp"
 
 // implementing and friending so we can access member variables

--- a/controller_interface/test/test_semantic_component_command_interface.hpp
+++ b/controller_interface/test/test_semantic_component_command_interface.hpp
@@ -18,7 +18,7 @@
 #ifndef TEST_SEMANTIC_COMPONENT_COMMAND_INTERFACE_HPP_
 #define TEST_SEMANTIC_COMPONENT_COMMAND_INTERFACE_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/controller_interface/test/test_semantic_component_interface.hpp
+++ b/controller_interface/test/test_semantic_component_interface.hpp
@@ -19,7 +19,7 @@
 #ifndef TEST_SEMANTIC_COMPONENT_INTERFACE_HPP_
 #define TEST_SEMANTIC_COMPONENT_INTERFACE_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/controller_interface/test/test_semantic_component_interface.hpp
+++ b/controller_interface/test/test_semantic_component_interface.hpp
@@ -19,12 +19,11 @@
 #ifndef TEST_SEMANTIC_COMPONENT_INTERFACE_HPP_
 #define TEST_SEMANTIC_COMPONENT_INTERFACE_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 
 #include "geometry_msgs/msg/wrench.hpp"
+#include "gmock/gmock.h"
 #include "semantic_components/semantic_component_interface.hpp"
 
 // implementing and friending so we can access member variables

--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -16,7 +16,6 @@
 #define CONTROLLER_MANAGER_TEST_COMMON_HPP_
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <chrono>
 #include <memory>

--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -15,7 +15,7 @@
 #ifndef CONTROLLER_MANAGER_TEST_COMMON_HPP_
 #define CONTROLLER_MANAGER_TEST_COMMON_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <chrono>
 #include <memory>

--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -15,8 +15,6 @@
 #ifndef CONTROLLER_MANAGER_TEST_COMMON_HPP_
 #define CONTROLLER_MANAGER_TEST_COMMON_HPP_
 
-#include "gmock/gmock.h"
-
 #include <chrono>
 #include <memory>
 #include <string>
@@ -24,16 +22,13 @@
 #include <vector>
 
 #include "controller_interface/controller_interface.hpp"
-
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
-
+#include "gmock/gmock.h"
 #include "rclcpp/executors.hpp"
 #include "rclcpp/utilities.hpp"
-
-#include "std_msgs/msg/string.hpp"
-
 #include "ros2_control_test_assets/descriptions.hpp"
+#include "std_msgs/msg/string.hpp"
 
 namespace
 {

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -20,6 +18,7 @@
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/msg/controller_manager_activity.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/executor.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
+++ b/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <utility>

--- a/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
+++ b/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <utility>
@@ -20,6 +19,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "ros2_control_test_assets/test_hardware_interface_constants.hpp"

--- a/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
+++ b/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 #include <utility>

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <random>
 #include <string>
 #include <vector>
 
 #include "controller_manager_test_common.hpp"
-
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager_msgs/srv/list_controller_types.hpp"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/list_hardware_interfaces.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"
 #include "test_controller/test_controller.hpp"

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -17,12 +17,12 @@
 #include <string>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_interface/controller_interface.hpp"
 #include "controller_manager_msgs/srv/list_controller_types.hpp"
 #include "controller_manager_msgs/srv/list_controllers.hpp"
 #include "controller_manager_msgs/srv/list_hardware_interfaces.hpp"
 #include "controller_manager_msgs/srv/switch_controller.hpp"
+#include "controller_manager_test_common.hpp"
 #include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <memory>
 #include <random>
 #include <string>

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <random>
 #include <string>

--- a/controller_manager/test/test_controller_manager_urdf_passing.cpp
+++ b/controller_manager/test/test_controller_manager_urdf_passing.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <utility>

--- a/controller_manager/test/test_controller_manager_urdf_passing.cpp
+++ b/controller_manager/test/test_controller_manager_urdf_passing.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <utility>
@@ -20,6 +19,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "ros2_control_test_assets/descriptions.hpp"
 #include "test_controller/test_controller.hpp"
 

--- a/controller_manager/test/test_controller_manager_urdf_passing.cpp
+++ b/controller_manager/test/test_controller_manager_urdf_passing.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 #include <utility>

--- a/controller_manager/test/test_controller_manager_with_namespace.cpp
+++ b/controller_manager/test/test_controller_manager_with_namespace.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_manager/test/test_controller_manager_with_namespace.cpp
+++ b/controller_manager/test/test_controller_manager_with_namespace.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "test_controller/test_controller.hpp"
 
 using ::testing::_;

--- a/controller_manager/test/test_controller_manager_with_namespace.cpp
+++ b/controller_manager/test/test_controller_manager_with_namespace.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
+++ b/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
+++ b/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -21,6 +20,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"
 #include "test_controller/test_controller.hpp"

--- a/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
+++ b/controller_manager/test/test_controllers_chaining_with_controller_manager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -15,10 +15,10 @@
 #include <string>
 #include <vector>
 
-#include "controller_manager_test_common.hpp"
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/msg/hardware_component_state.hpp"
 #include "controller_manager_msgs/srv/set_hardware_component_state.hpp"
+#include "controller_manager_test_common.hpp"
 #include "gmock/gmock.h"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -11,17 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "controller_manager_test_common.hpp"
-
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_msgs/msg/hardware_component_state.hpp"
 #include "controller_manager_msgs/srv/set_hardware_component_state.hpp"
+#include "gmock/gmock.h"
 #include "hardware_interface/types/lifecycle_state_names.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/parameter.hpp"

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_manager/test/test_hardware_management_srvs.cpp
+++ b/controller_manager/test/test_hardware_management_srvs.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/controller_manager/test/test_hardware_spawner.cpp
+++ b/controller_manager/test/test_hardware_spawner.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <cstdlib>
 #include <memory>

--- a/controller_manager/test/test_hardware_spawner.cpp
+++ b/controller_manager/test/test_hardware_spawner.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <cstdlib>
 #include <memory>

--- a/controller_manager/test/test_hardware_spawner.cpp
+++ b/controller_manager/test/test_hardware_spawner.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -21,6 +19,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"
 #include "test_controller/test_controller.hpp"

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <tuple>

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "gmock/gmock.h"
 #include <memory>
 #include <string>
 #include <tuple>
@@ -20,6 +18,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_controller/test_controller.hpp"
 #include "test_controller_failed_init/test_controller_failed_init.hpp"

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/controller_manager/test/test_release_interfaces.cpp
+++ b/controller_manager/test/test_release_interfaces.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include <string>
 #include <vector>
 

--- a/controller_manager/test/test_release_interfaces.cpp
+++ b/controller_manager/test/test_release_interfaces.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 

--- a/controller_manager/test/test_release_interfaces.cpp
+++ b/controller_manager/test/test_release_interfaces.cpp
@@ -11,13 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_controller/test_controller.hpp"
 #include "test_controller_with_interfaces/test_controller_with_interfaces.hpp"

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <cstdlib>
 #include <memory>

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <cstdlib>
 #include <memory>

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -21,6 +19,7 @@
 
 #include "controller_manager/controller_manager.hpp"
 #include "controller_manager_test_common.hpp"
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "test_chainable_controller/test_chainable_controller.hpp"
 #include "test_controller/test_controller.hpp"

--- a/hardware_interface/test/mock_components/test_generic_system.cpp
+++ b/hardware_interface/test/mock_components/test_generic_system.cpp
@@ -14,7 +14,7 @@
 //
 // Author: Denis Stogl
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <cmath>
 #include <string>

--- a/hardware_interface/test/mock_components/test_generic_system.cpp
+++ b/hardware_interface/test/mock_components/test_generic_system.cpp
@@ -14,13 +14,12 @@
 //
 // Author: Denis Stogl
 
-#include "gmock/gmock.h"
-
 #include <cmath>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/loaned_command_interface.hpp"
 #include "hardware_interface/loaned_state_interface.hpp"
 #include "hardware_interface/resource_manager.hpp"

--- a/hardware_interface/test/mock_components/test_generic_system.cpp
+++ b/hardware_interface/test/mock_components/test_generic_system.cpp
@@ -2210,6 +2210,6 @@ TEST_F(TestGenericSystem, prepare_command_mode_switch_works_with_all_example_tag
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -2161,6 +2161,6 @@ TEST(TestComponentInterfaces, dummy_system_default_write_error_behavior)
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-
 #include <array>
 #include <limits>
 #include <memory>
@@ -22,6 +20,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/hardware_info.hpp"

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <array>
 #include <limits>

--- a/hardware_interface/test/test_component_interfaces_custom_export.cpp
+++ b/hardware_interface/test/test_component_interfaces_custom_export.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-
 #include <array>
 #include <limits>
 #include <memory>
@@ -21,6 +19,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/handle.hpp"

--- a/hardware_interface/test/test_component_interfaces_custom_export.cpp
+++ b/hardware_interface/test/test_component_interfaces_custom_export.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <array>
 #include <limits>

--- a/hardware_interface/test/test_component_interfaces_custom_export.cpp
+++ b/hardware_interface/test/test_component_interfaces_custom_export.cpp
@@ -374,6 +374,6 @@ TEST(TestComponentInterfaces, dummy_system_default_custom_export)
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -11,10 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include "gmock/gmock.h"
 #include <string>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "ros2_control_test_assets/components_urdfs.hpp"

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 
 #include "hardware_interface/component_parser.hpp"

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include "hardware_interface/handle.hpp"
 #include "hardware_interface/hardware_info.hpp"
 

--- a/hardware_interface/test/test_inst_hardwares.cpp
+++ b/hardware_interface/test/test_inst_hardwares.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/sensor.hpp"

--- a/hardware_interface/test/test_inst_hardwares.cpp
+++ b/hardware_interface/test/test_inst_hardwares.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "gmock/gmock.h"
-
 #include "hardware_interface/actuator.hpp"
 #include "hardware_interface/sensor.hpp"
 #include "hardware_interface/system.hpp"

--- a/hardware_interface/test/test_macros.cpp
+++ b/hardware_interface/test/test_macros.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
-
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/macros.hpp"
 
 class TestMacros : public ::testing::Test

--- a/hardware_interface/test/test_macros.cpp
+++ b/hardware_interface/test/test_macros.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <vector>
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -2221,6 +2221,6 @@ TEST_F(ResourceManagerTestAsyncReadWrite, test_components_with_async_components_
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/hardware_interface_testing/test/test_resource_manager.hpp
+++ b/hardware_interface_testing/test/test_resource_manager.hpp
@@ -17,7 +17,7 @@
 #ifndef TEST_RESOURCE_MANAGER_HPP_
 #define TEST_RESOURCE_MANAGER_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <string>
 #include <vector>

--- a/hardware_interface_testing/test/test_resource_manager.hpp
+++ b/hardware_interface_testing/test/test_resource_manager.hpp
@@ -17,15 +17,13 @@
 #ifndef TEST_RESOURCE_MANAGER_HPP_
 #define TEST_RESOURCE_MANAGER_HPP_
 
-#include "gmock/gmock.h"
-
 #include <string>
 #include <vector>
 
-#include <rclcpp/node.hpp>
-
+#include "gmock/gmock.h"
 #include "hardware_interface/resource_manager.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/node.hpp"
 
 class ResourceManagerTest : public ::testing::Test
 {

--- a/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
+++ b/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
@@ -392,6 +392,6 @@ TEST_F(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -66,17 +66,16 @@ ament_target_dependencies(joint_saturation_limiter PUBLIC ${THIS_PACKAGE_INCLUDE
 pluginlib_export_plugin_description_file(joint_limits joint_limiters.xml)
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)
   find_package(generate_parameter_library REQUIRED)
   find_package(launch_testing_ament_cmake REQUIRED)
   find_package(pluginlib REQUIRED)
   find_package(rclcpp REQUIRED)
 
-  ament_add_gtest_executable(joint_limits_rosparam_test test/joint_limits_rosparam_test.cpp)
+  ament_add_gmock_executable(joint_limits_rosparam_test test/joint_limits_rosparam_test.cpp)
   target_link_libraries(joint_limits_rosparam_test joint_limits)
 
-  ament_add_gtest(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
+  ament_add_gmock(joint_limits_urdf_test test/joint_limits_urdf_test.cpp)
   target_link_libraries(joint_limits_urdf_test joint_limits)
 
   add_launch_test(test/joint_limits_rosparam.launch.py)

--- a/joint_limits/package.xml
+++ b/joint_limits/package.xml
@@ -27,7 +27,6 @@
   <depend>urdf</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>generate_parameter_library</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/joint_limits/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits/test/joint_limits_rosparam_test.cpp
@@ -14,7 +14,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include "joint_limits/joint_limits_rosparam.hpp"
 #include "lifecycle_msgs/msg/state.hpp"

--- a/joint_limits/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits/test/joint_limits_rosparam_test.cpp
@@ -14,7 +14,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "joint_limits/joint_limits_rosparam.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
@@ -441,7 +441,7 @@ TEST_F(
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   int ret = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return ret;

--- a/joint_limits/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits/test/joint_limits_rosparam_test.cpp
@@ -15,7 +15,6 @@
 /// \author Adolfo Rodriguez Tsouroukdissian
 
 #include "gmock/gmock.h"
-
 #include "joint_limits/joint_limits_rosparam.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/joint_limits/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits/test/joint_limits_rosparam_test.cpp
@@ -14,8 +14,9 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include "gmock/gmock.h"
 #include "joint_limits/joint_limits_rosparam.hpp"
+
+#include "gmock/gmock.h"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 

--- a/joint_limits/test/joint_limits_urdf_test.cpp
+++ b/joint_limits/test/joint_limits_urdf_test.cpp
@@ -14,8 +14,9 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include "gmock/gmock.h"
 #include "joint_limits/joint_limits_urdf.hpp"
+
+#include "gmock/gmock.h"
 
 using std::string;
 

--- a/joint_limits/test/joint_limits_urdf_test.cpp
+++ b/joint_limits/test/joint_limits_urdf_test.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// \author Adolfo Rodriguez Tsouroukdissian
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include "joint_limits/joint_limits_urdf.hpp"
 

--- a/joint_limits/test/joint_limits_urdf_test.cpp
+++ b/joint_limits/test/joint_limits_urdf_test.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 /// \author Adolfo Rodriguez Tsouroukdissian
-#include "gmock/gmock.h"
 
+#include "gmock/gmock.h"
 #include "joint_limits/joint_limits_urdf.hpp"
 
 using std::string;

--- a/joint_limits/test/joint_limits_urdf_test.cpp
+++ b/joint_limits/test/joint_limits_urdf_test.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// \author Adolfo Rodriguez Tsouroukdissian
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "joint_limits/joint_limits_urdf.hpp"
 
@@ -170,6 +170,6 @@ TEST_F(JointLimitsUrdfTest, GetSoftJointLimits)
 
 int main(int argc, char ** argv)
 {
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/joint_limits/test/test_joint_limiter.hpp
+++ b/joint_limits/test/test_joint_limiter.hpp
@@ -15,11 +15,11 @@
 #ifndef TEST_JOINT_LIMITER_HPP_
 #define TEST_JOINT_LIMITER_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "gmock/gmock.h"
 #include "joint_limits/data_structures.hpp"
 #include "joint_limits/joint_limiter_interface.hpp"
 #include "joint_limits/joint_limits.hpp"

--- a/joint_limits/test/test_joint_limiter.hpp
+++ b/joint_limits/test/test_joint_limiter.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_JOINT_LIMITER_HPP_
 #define TEST_JOINT_LIMITER_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/joint_limits/test/test_joint_limiter.hpp
+++ b/joint_limits/test/test_joint_limiter.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_JOINT_LIMITER_HPP_
 #define TEST_JOINT_LIMITER_HPP_
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <memory>
 #include <string>

--- a/joint_limits/test/test_joint_range_limiter.cpp
+++ b/joint_limits/test/test_joint_range_limiter.cpp
@@ -716,7 +716,7 @@ TEST_F(JointSaturationLimiterTest, check_all_desired_references_limiting)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/joint_limits/test/test_joint_saturation_limiter.cpp
+++ b/joint_limits/test/test_joint_saturation_limiter.cpp
@@ -519,7 +519,7 @@ TEST_F(JointSaturationLimiterTest, when_deceleration_exceeded_with_no_maxdec_exp
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/joint_limits/test/test_joint_saturation_limiter.hpp
+++ b/joint_limits/test/test_joint_saturation_limiter.hpp
@@ -15,7 +15,7 @@
 #ifndef TEST_JOINT_SATURATION_LIMITER_HPP_
 #define TEST_JOINT_SATURATION_LIMITER_HPP_
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include <memory>
 #include <string>

--- a/joint_limits/test/test_joint_saturation_limiter.hpp
+++ b/joint_limits/test/test_joint_saturation_limiter.hpp
@@ -15,11 +15,11 @@
 #ifndef TEST_JOINT_SATURATION_LIMITER_HPP_
 #define TEST_JOINT_SATURATION_LIMITER_HPP_
 
-#include "gmock/gmock.h"
-
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "gmock/gmock.h"
 #include "joint_limits/joint_limiter_interface.hpp"
 #include "joint_limits/joint_limits.hpp"
 #include "pluginlib/class_loader.hpp"

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -1065,7 +1065,7 @@ TEST_F(JointSoftLimiterTest, check_all_desired_references_limiting)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>

--- a/transmission_interface/test/differential_transmission_loader_test.cpp
+++ b/transmission_interface/test/differential_transmission_loader_test.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "pluginlib/class_loader.hpp"

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "random_generator_utils.hpp"
 #include "transmission_interface/differential_transmission.hpp"

--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>

--- a/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_loader_test.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "pluginlib/class_loader.hpp"

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -14,10 +14,10 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "random_generator_utils.hpp"
 #include "transmission_interface/four_bar_linkage_transmission.hpp"

--- a/transmission_interface/test/four_bar_linkage_transmission_test.cpp
+++ b/transmission_interface/test/four_bar_linkage_transmission_test.cpp
@@ -14,7 +14,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>

--- a/transmission_interface/test/simple_transmission_loader_test.cpp
+++ b/transmission_interface/test/simple_transmission_loader_test.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gmock/gmock.h"
 #include <exception>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/component_parser.hpp"
 #include "hardware_interface/hardware_info.hpp"
 #include "pluginlib/class_loader.hpp"

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -11,10 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "gmock/gmock.h"
 #include <string>
 #include <vector>
 
+#include "gmock/gmock.h"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "transmission_interface/simple_transmission.hpp"
 

--- a/transmission_interface/test/utils_test.cpp
+++ b/transmission_interface/test/utils_test.cpp
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 #include "gmock/gmock.h"
-
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
-
 #include "transmission_interface/accessor.hpp"
 #include "transmission_interface/handle.hpp"
 

--- a/transmission_interface/test/utils_test.cpp
+++ b/transmission_interface/test/utils_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 


### PR DESCRIPTION
## Brief
In this PR
- Moved all Test Packages to `gmock` instead of `gtest and/or gmock` (refer 7895b47273c161be225ddc8ef7274ecf88afa5ad)
    - Fixes #93 
    - used reference from https://github.com/ros-controls/control_toolbox/pull/300
- Fixed order of includes as suggested in above PR to match with [this](https://google.github.io/styleguide/cppguide.html#Names_and_Order_of_Includes) (refer 91c3aa9 and ab62583)

## How was this tested?
```bash
colcon build --symlink-install
source install/setup.bash
colcon test --packages-select controller_interface controller_manager controller_manager_msgs hardware_interface hardware_interface_testing joint_limits ros2_control ros2_control_test_assets ros2controlcli rqt_controller_manager transmission_interface --event-handlers console_direct+ 
```

Note: Do let me know if there is a better way to have tested this! just did what came first to my mind