### PR TITLE
Use previous command to enforce the joint limits on position interfaces

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1951,6 +1951,21 @@ bool ResourceManager::perform_command_mode_switch(
   const bool actuators_result = call_perform_mode_switch(resource_storage_->actuators_);
   const bool systems_result = call_perform_mode_switch(resource_storage_->systems_);
 
+  if (actuators_result && systems_result)
+  {
+    // Reset the internals of the joint limiters
+    for (auto & [hw_name, limiters] : resource_storage_->joint_limiters_interface_)
+    {
+      for (const auto & [joint_name, limiter] : limiters)
+      {
+        limiter->reset_internals();
+        RCLCPP_DEBUG(
+          get_logger(), "Resetting internals of joint limiter for joint '%s' in hardware '%s'",
+          joint_name.c_str(), hw_name.c_str());
+      }
+    }
+  }
+
   return actuators_result && systems_result;
 }
 

--- a/hardware_interface_testing/test/test_components/test_actuator.cpp
+++ b/hardware_interface_testing/test/test_components/test_actuator.cpp
@@ -102,7 +102,7 @@ class TestActuator : public ActuatorInterface
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/) override
   {
-    position_state_ += 1.0;
+    position_state_ += 0.001;
     return hardware_interface::return_type::OK;
   }
 
@@ -110,7 +110,7 @@ class TestActuator : public ActuatorInterface
     const std::vector<std::string> & /*start_interfaces*/,
     const std::vector<std::string> & /*stop_interfaces*/) override
   {
-    position_state_ += 100.0;
+    position_state_ += 0.1;
     return hardware_interface::return_type::OK;
   }
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -2297,8 +2297,8 @@ public:
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
 
-      claimed_itfs[0].set_value(10.0);
-      claimed_itfs[1].set_value(-20.0);
+      claimed_itfs[0].set_value(2.0);
+      claimed_itfs[1].set_value(-4.0);
 
       auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
       EXPECT_TRUE(ok_write);
@@ -2314,8 +2314,8 @@ public:
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
 
-      EXPECT_EQ(state_itfs[0].get_value(), 5.0);
-      EXPECT_EQ(state_itfs[1].get_value(), -10.0);
+      EXPECT_EQ(state_itfs[0].get_value(), 1.0);
+      EXPECT_EQ(state_itfs[1].get_value(), -2.0);
       auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
       EXPECT_TRUE(ok_write);
       EXPECT_TRUE(failed_hardware_names_write.empty());
@@ -2330,9 +2330,11 @@ public:
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
 
-      EXPECT_EQ(state_itfs[0].get_value(), 5.0);
-      EXPECT_EQ(state_itfs[1].get_value(), -10.0);
+      EXPECT_EQ(state_itfs[0].get_value(), 1.0);
+      EXPECT_EQ(state_itfs[1].get_value(), -2.0);
 
+      EXPECT_EQ(claimed_itfs[0].get_value(), 2.0);
+      EXPECT_EQ(claimed_itfs[1].get_value(), -4.0);
       claimed_itfs[0].set_value(0.0);
       claimed_itfs[1].set_value(0.0);
       EXPECT_EQ(claimed_itfs[0].get_value(), 0.0);
@@ -2341,9 +2343,9 @@ public:
       // enforcing limits
       rm->enforce_command_limits(duration);
 
-      ASSERT_NEAR(state_itfs[2].get_value(), 5.05, 0.00001);
-      // it is limited to the M_PI as the actual position is outside the range
-      EXPECT_NEAR(claimed_itfs[0].get_value(), M_PI, 0.00001);
+      ASSERT_NEAR(state_itfs[2].get_value(), 1.05, 0.00001);
+      // It is using the actual velocity 1.05 to limit the claimed_itf
+      EXPECT_NEAR(claimed_itfs[0].get_value(), 1.048, 0.00001);
       EXPECT_EQ(claimed_itfs[1].get_value(), 0.0);
 
       auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
@@ -2356,13 +2358,13 @@ public:
       EXPECT_TRUE(read_ok);
       EXPECT_TRUE(failed_hardware_names_read.empty());
 
-      ASSERT_NEAR(state_itfs[0].get_value(), M_PI_2, 0.00001);
+      ASSERT_NEAR(state_itfs[0].get_value(), claimed_itfs[0].get_value() / 2.0, 0.00001);
       ASSERT_EQ(state_itfs[1].get_value(), 0.0);
     }
 
     // Reset the position state interface of actuator to zero
     {
-      ASSERT_GT(state_itfs[2].get_value(), 5.05);
+      ASSERT_GT(state_itfs[2].get_value(), 1.05);
       claimed_itfs[0].set_value(test_constants::RESET_STATE_INTERFACES_VALUE);
       auto [read_ok, failed_hardware_names_read] = rm->read(time, duration);
       EXPECT_TRUE(read_ok);
@@ -2370,19 +2372,16 @@ public:
       ASSERT_EQ(state_itfs[2].get_value(), 0.0);
       claimed_itfs[0].set_value(0.0);
       claimed_itfs[1].set_value(0.0);
+      ASSERT_EQ(claimed_itfs[0].get_value(), 0.0);
+      ASSERT_EQ(claimed_itfs[1].get_value(), 0.0);
     }
 
     double new_state_value_1 = state_itfs[0].get_value();
     double new_state_value_2 = state_itfs[1].get_value();
     // Now loop and see that the joint limits are being enforced progressively
-    for (size_t i = 1; i < 2000; i++)
+    for (size_t i = 1; i < 300; i++)
     {
-      // let's amplify the limit enforce period, to test more rapidly. It would work with 0.01s as
-      // well
-      const rclcpp::Duration enforce_period =
-        rclcpp::Duration::from_seconds(duration.seconds() * 10.0);
-
-      auto [ok, failed_hardware_names] = rm->read(time, enforce_period);
+      auto [ok, failed_hardware_names] = rm->read(time, duration);
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
 
@@ -2395,13 +2394,15 @@ public:
       EXPECT_EQ(claimed_itfs[1].get_value(), -20.0);
 
       // enforcing limits
-      rm->enforce_command_limits(enforce_period);
+      rm->enforce_command_limits(duration);
 
       // the joint limits value is same as in the parsed URDF
       const double velocity_joint_1 = 0.2;
+      const double prev_command_val = 1.048;
       ASSERT_NEAR(
         claimed_itfs[0].get_value(),
-        std::min(state_itfs[2].get_value() + (velocity_joint_1 * enforce_period.seconds()), M_PI),
+        prev_command_val +
+          std::min((velocity_joint_1 * (duration.seconds() * static_cast<double>(i))), M_PI),
         1.0e-8)
         << "This should be progressively increasing as it is a position limit for iteration : "
         << i;
@@ -2412,7 +2413,7 @@ public:
       new_state_value_1 = claimed_itfs[0].get_value() / 2.0;
       new_state_value_2 = claimed_itfs[1].get_value() / 2.0;
 
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, enforce_period);
+      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
       EXPECT_TRUE(ok_write);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
@@ -2423,7 +2424,7 @@ public:
       EXPECT_TRUE(ok);
       EXPECT_TRUE(failed_hardware_names.empty());
 
-      EXPECT_NEAR(state_itfs[0].get_value(), M_PI_2, 0.00001);
+      EXPECT_NEAR(state_itfs[0].get_value(), 0.823, 0.00001);
       EXPECT_NEAR(state_itfs[1].get_value(), -0.1, 0.00001);
     }
   }

--- a/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
+++ b/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
@@ -183,46 +183,46 @@ TEST_F(
   // When TestSystemCommandModes is ACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 1.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 1.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.001, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 101.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.101, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 102.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 102.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.102, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 202.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 202.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.202, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 203.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 203.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.203, 1e-7);
   EXPECT_FALSE(rm_->perform_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 303.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.303, 1e-7);
 
   // When TestActuatorHardware is INACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 304.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 304.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.304, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 404.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 404.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.404, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 405.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 405.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.405, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 505.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 505.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 506.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 506.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.506, 1e-7);
   EXPECT_FALSE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 606.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 606.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.606, 1e-7);
 };
 
 // System  : INACTIVE
@@ -237,46 +237,46 @@ TEST_F(
   // When TestSystemCommandModes is INACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 1.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 1.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.001, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 101.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.101, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 102.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 102.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.102, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 202.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 202.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.202, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 203.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 203.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.203, 1e-7);
   EXPECT_FALSE(rm_->perform_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 303.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.303, 1e-7);
 
   // When TestActuatorHardware is ACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 304.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 304.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.304, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 404.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 404.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.404, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 405.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 405.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.405, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 505.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 505.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 506.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 506.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.506, 1e-7);
   EXPECT_FALSE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 606.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 606.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.606, 1e-7);
 };
 
 // System  : UNCONFIGURED
@@ -292,46 +292,46 @@ TEST_F(
   // When TestSystemCommandModes is UNCONFIGURED expect error
   EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.0, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 100.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.100, 1e-7);
 
   EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 100.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.100, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 200.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.200, 1e-7);
 
   EXPECT_FALSE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 200.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.200, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(empty_keys, legal_keys_system));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 300.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.300, 1e-7);
 
   // When TestActuatorHardware is INACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 301.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.301, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 401.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.401, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 402.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.402, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 502.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.502, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 503.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.503, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 603.0);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.603, 1e-7);
 };
 
 // System  : UNCONFIGURED

--- a/joint_limits/include/joint_limits/joint_limiter_interface.hpp
+++ b/joint_limits/include/joint_limits/joint_limiter_interface.hpp
@@ -208,6 +208,8 @@ public:
     return on_enforce(current_joint_states, desired_joint_states, dt);
   }
 
+  virtual void reset_internals() = 0;
+
 protected:
   /** \brief Method is realized by an implementation.
    *

--- a/joint_limits/include/joint_limits/joint_limits_helpers.hpp
+++ b/joint_limits/include/joint_limits/joint_limits_helpers.hpp
@@ -28,7 +28,9 @@ namespace joint_limits
 namespace internal
 {
 constexpr double POSITION_BOUNDS_TOLERANCE = 0.002;
-}
+// 0.5 degrees (or) approx. 1 cm for the prismatic joint
+constexpr double OUT_OF_BOUNDS_EXCEPTION_TOLERANCE = 0.0087;
+}  // namespace internal
 
 /**
  * @brief Checks if a value is limited by the given limits.

--- a/joint_limits/include/joint_limits/joint_limits_helpers.hpp
+++ b/joint_limits/include/joint_limits/joint_limits_helpers.hpp
@@ -41,15 +41,18 @@ bool is_limited(double value, double min, double max);
 
 /**
  * @brief Computes the position limits based on the velocity and acceleration limits.
+ * @param joint_name The name of the joint.
  * @param limits The joint limits.
  * @param act_vel The actual velocity of the joint.
+ * @param act_pos The actual position of the joint.
  * @param prev_command_pos The previous commanded position of the joint.
  * @param dt The time step.
  * @return The position limits, first is the lower limit and second is the upper limit.
  */
 PositionLimits compute_position_limits(
-  const joint_limits::JointLimits & limits, const std::optional<double> & act_vel,
-  const std::optional<double> & act_pos, const std::optional<double> & prev_command_pos, double dt);
+  const std::string & joint_name, const joint_limits::JointLimits & limits,
+  const std::optional<double> & act_vel, const std::optional<double> & act_pos,
+  const std::optional<double> & prev_command_pos, double dt);
 
 /**
  * @brief Computes the velocity limits based on the position and acceleration limits.

--- a/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
+++ b/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
@@ -70,6 +70,13 @@ public:
     const JointLimitsStateDataType & current_joint_states,
     JointLimitsStateDataType & desired_joint_states, const rclcpp::Duration & dt) override;
 
+  /** \brief Reset internal states of the limiter. */
+  /**
+   * This method is called when the controller is stopped or when the controller is
+   * reconfigured. It should reset all internal states of the limiter.
+   */
+  void reset_internals() override { prev_command_ = JointLimitsStateDataType(); }
+
 protected:
   rclcpp::Clock::SharedPtr clock_;
   JointLimitsStateDataType prev_command_;

--- a/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
+++ b/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
@@ -75,11 +75,16 @@ public:
    * This method is called when the controller is stopped or when the controller is
    * reconfigured. It should reset all internal states of the limiter.
    */
-  void reset_internals() override { prev_command_ = JointLimitsStateDataType(); }
+  void reset_internals() override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    prev_command_ = JointLimitsStateDataType();
+  }
 
 protected:
   rclcpp::Clock::SharedPtr clock_;
   JointLimitsStateDataType prev_command_;
+  std::mutex mutex_;
 };
 
 template <typename JointLimitsStateDataType>

--- a/joint_limits/src/joint_limits_helpers.cpp
+++ b/joint_limits/src/joint_limits_helpers.cpp
@@ -42,8 +42,8 @@ void verify_actual_position_within_limits(
   {
     const double actual_pos = actual_position.value();
     if (
-      actual_pos > (limits.max_position + internal::POSITION_BOUNDS_TOLERANCE) ||
-      actual_pos < (limits.min_position - internal::POSITION_BOUNDS_TOLERANCE))
+      actual_pos > (limits.max_position + internal::OUT_OF_BOUNDS_EXCEPTION_TOLERANCE) ||
+      actual_pos < (limits.min_position - internal::OUT_OF_BOUNDS_EXCEPTION_TOLERANCE))
     {
       const std::string error_message =
         "Joint position is out of bounds for the joint : '" + joint_name +

--- a/joint_limits/src/joint_limits_helpers.cpp
+++ b/joint_limits/src/joint_limits_helpers.cpp
@@ -77,8 +77,7 @@ PositionLimits compute_position_limits(
                                : limits.max_velocity;
     const double max_vel = std::min(limits.max_velocity, delta_vel);
     const double delta_pos = max_vel * dt;
-    const double position_reference =
-      act_pos.has_value() ? act_pos.value() : prev_command_pos.value();
+    const double position_reference = prev_command_pos.value();
     pos_limits.lower_limit = std::max(
       std::min(position_reference - delta_pos, pos_limits.upper_limit), pos_limits.lower_limit);
     pos_limits.upper_limit = std::min(

--- a/joint_limits/src/joint_limits_helpers.cpp
+++ b/joint_limits/src/joint_limits_helpers.cpp
@@ -34,6 +34,14 @@ void check_and_swap_limits(double & lower_limit, double & upper_limit)
   }
 }
 
+/**
+ * @brief Verify if the actual position is within the limits and if not, log an error and throw an
+ * exception.
+ * @param joint_name The name of the joint.
+ * @param actual_position The actual position of the joint.
+ * @param limits The joint limits.
+ * @throws std::runtime_error if the actual position is out of bounds.
+ */
 void verify_actual_position_within_limits(
   const std::string & joint_name, const std::optional<double> & actual_position,
   const joint_limits::JointLimits & limits)
@@ -77,6 +85,11 @@ PositionLimits compute_position_limits(
                                : limits.max_velocity;
     const double max_vel = std::min(limits.max_velocity, delta_vel);
     const double delta_pos = max_vel * dt;
+    /// @note: We use the previous command position to compute the limits here because using the
+    /// actual position would be too conservative, usually there is a couple of cycles of delay
+    /// between the command sent to the robot and the robot actually showing that in the state. That
+    /// effectively limits the velocity with which the joint can be moved which is much lower than
+    /// the actual velocity limit.
     const double position_reference = prev_command_pos.value();
     pos_limits.lower_limit = std::max(
       std::min(position_reference - delta_pos, pos_limits.upper_limit), pos_limits.lower_limit);

--- a/joint_limits/src/joint_range_limiter.cpp
+++ b/joint_limits/src/joint_range_limiter.cpp
@@ -113,7 +113,8 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
   if (desired.has_position())
   {
     const auto limits = compute_position_limits(
-      joint_limits, actual.velocity, actual.position, prev_command_.position, dt_seconds);
+      joint_name, joint_limits, actual.velocity, actual.position, prev_command_.position,
+      dt_seconds);
     limits_enforced = is_limited(desired.position.value(), limits.lower_limit, limits.upper_limit);
     desired.position = std::clamp(desired.position.value(), limits.lower_limit, limits.upper_limit);
   }

--- a/joint_limits/src/joint_range_limiter.cpp
+++ b/joint_limits/src/joint_range_limiter.cpp
@@ -46,6 +46,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
   const JointControlInterfacesData & actual, JointControlInterfacesData & desired,
   const rclcpp::Duration & dt)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   bool limits_enforced = false;
 
   const auto dt_seconds = dt.seconds();

--- a/joint_limits/src/joint_saturation_limiter.cpp
+++ b/joint_limits/src/joint_saturation_limiter.cpp
@@ -30,6 +30,7 @@ bool JointSaturationLimiter<trajectory_msgs::msg::JointTrajectoryPoint>::on_enfo
   const trajectory_msgs::msg::JointTrajectoryPoint & current_joint_states,
   trajectory_msgs::msg::JointTrajectoryPoint & desired_joint_states, const rclcpp::Duration & dt)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   bool limits_enforced = false;
 
   const auto dt_seconds = dt.seconds();

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -23,6 +23,7 @@ bool JointSoftLimiter::on_enforce(
   const JointControlInterfacesData & actual, JointControlInterfacesData & desired,
   const rclcpp::Duration & dt)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   bool limits_enforced = false;
 
   const auto dt_seconds = dt.seconds();

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -95,16 +95,25 @@ bool JointSoftLimiter::on_enforce(
 
   double soft_min_vel = -std::numeric_limits<double>::infinity();
   double soft_max_vel = std::numeric_limits<double>::infinity();
-  const double act_position =
-    actual.has_position()
-      ? actual.position.value()
-      : ((prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
-           ? prev_command_.position.value()
-           : std::numeric_limits<double>::infinity());
-  const double prev_command_position =
-    (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
-      ? prev_command_.position.value()
-      : (actual.has_position() ? actual.position.value() : std::numeric_limits<double>::infinity());
+  double act_position = std::numeric_limits<double>::infinity();
+  double prev_command_position = std::numeric_limits<double>::infinity();
+
+  if (actual.position.has_value())
+  {
+    act_position = actual.position.value();
+  }
+  else if (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+  {
+    act_position = prev_command_.position.value();
+  }
+  if (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+  {
+    prev_command_position = prev_command_.position.value();
+  }
+  else if (actual.position.has_value())
+  {
+    prev_command_position = actual.position.value();
+  }
 
   if (hard_limits.has_velocity_limits)
   {

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -95,25 +95,16 @@ bool JointSoftLimiter::on_enforce(
 
   double soft_min_vel = -std::numeric_limits<double>::infinity();
   double soft_max_vel = std::numeric_limits<double>::infinity();
-  double act_position = std::numeric_limits<double>::infinity();
-  double prev_command_position = std::numeric_limits<double>::infinity();
-
-  if (actual.position.has_value())
-  {
-    act_position = actual.position.value();
-  }
-  else if (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
-  {
-    act_position = prev_command_.position.value();
-  }
-  if (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
-  {
-    prev_command_position = prev_command_.position.value();
-  }
-  else if (actual.position.has_value())
-  {
-    prev_command_position = actual.position.value();
-  }
+  const double act_position =
+    actual.has_position()
+      ? actual.position.value()
+      : ((prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+           ? prev_command_.position.value()
+           : std::numeric_limits<double>::infinity());
+  const double prev_command_position =
+    (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+      ? prev_command_.position.value()
+      : (actual.has_position() ? actual.position.value() : std::numeric_limits<double>::infinity());
 
   if (hard_limits.has_velocity_limits)
   {

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -143,7 +143,8 @@ bool JointSoftLimiter::on_enforce(
   if (desired.has_position())
   {
     const auto position_limits = compute_position_limits(
-      hard_limits, actual.velocity, actual.position, prev_command_.position, dt_seconds);
+      joint_name, hard_limits, actual.velocity, actual.position, prev_command_.position,
+      dt_seconds);
 
     double pos_low = -std::numeric_limits<double>::infinity();
     double pos_high = std::numeric_limits<double>::infinity();

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -120,6 +120,11 @@ bool JointSoftLimiter::on_enforce(
     soft_min_vel = -hard_limits.max_velocity;
     soft_max_vel = hard_limits.max_velocity;
 
+    /// @note: We use the previous command position to compute the velocity limits here because
+    /// using the actual position would be too conservative, usually there is a couple of cycles of
+    /// delay between the command sent to the robot and the robot actually showing that in the
+    /// state. That effectively limits the velocity with which the joint can be moved which is much
+    /// lower than the actual velocity limit.
     if (
       hard_limits.has_position_limits && has_soft_limits(soft_joint_limits) &&
       std::isfinite(prev_command_position))

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -95,16 +95,18 @@ bool JointSoftLimiter::on_enforce(
 
   double soft_min_vel = -std::numeric_limits<double>::infinity();
   double soft_max_vel = std::numeric_limits<double>::infinity();
-  double position = std::numeric_limits<double>::infinity();
-
-  if (actual.has_position())
-  {
-    position = actual.position.value();
-  }
-  else if (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
-  {
-    position = prev_command_.position.value();
-  }
+  const double act_position =
+    (actual.has_position() && std::isfinite(actual.position.value()))
+      ? actual.position.value()
+      : ((prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+           ? prev_command_.position.value()
+           : std::numeric_limits<double>::infinity());
+  const double prev_command_position =
+    (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
+      ? prev_command_.position.value()
+      : ((actual.has_position() && std::isfinite(actual.position.value()))
+           ? actual.position.value()
+           : std::numeric_limits<double>::infinity());
 
   if (hard_limits.has_velocity_limits)
   {
@@ -113,25 +115,27 @@ bool JointSoftLimiter::on_enforce(
 
     if (
       hard_limits.has_position_limits && has_soft_limits(soft_joint_limits) &&
-      std::isfinite(position))
+      std::isfinite(prev_command_position))
     {
       soft_min_vel = std::clamp(
-        -soft_joint_limits.k_position * (position - soft_joint_limits.min_position),
+        -soft_joint_limits.k_position * (prev_command_position - soft_joint_limits.min_position),
         -hard_limits.max_velocity, hard_limits.max_velocity);
 
       soft_max_vel = std::clamp(
-        -soft_joint_limits.k_position * (position - soft_joint_limits.max_position),
+        -soft_joint_limits.k_position * (prev_command_position - soft_joint_limits.max_position),
         -hard_limits.max_velocity, hard_limits.max_velocity);
 
       if (
-        (position < (hard_limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)) ||
-        (position > (hard_limits.max_position + internal::POSITION_BOUNDS_TOLERANCE)))
+        std::isfinite(act_position) &&
+          (act_position < (hard_limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)) ||
+        (act_position > (hard_limits.max_position + internal::POSITION_BOUNDS_TOLERANCE)))
       {
         soft_min_vel = 0.0;
         soft_max_vel = 0.0;
       }
       else if (
-        (position < soft_joint_limits.min_position) || (position > soft_joint_limits.max_position))
+        (act_position < soft_joint_limits.min_position) ||
+        (act_position > soft_joint_limits.max_position))
       {
         const double soft_limit_reach_velocity = 1.0 * (M_PI / 180.0);
         soft_min_vel = std::copysign(soft_limit_reach_velocity, soft_min_vel);
@@ -157,8 +161,8 @@ bool JointSoftLimiter::on_enforce(
 
     if (hard_limits.has_velocity_limits)
     {
-      pos_low = std::clamp(position + soft_min_vel * dt_seconds, pos_low, pos_high);
-      pos_high = std::clamp(position + soft_max_vel * dt_seconds, pos_low, pos_high);
+      pos_low = std::clamp(prev_command_position + soft_min_vel * dt_seconds, pos_low, pos_high);
+      pos_high = std::clamp(prev_command_position + soft_max_vel * dt_seconds, pos_low, pos_high);
     }
     pos_low = std::max(pos_low, position_limits.lower_limit);
     pos_high = std::min(pos_high, position_limits.upper_limit);

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -96,7 +96,7 @@ bool JointSoftLimiter::on_enforce(
   double soft_min_vel = -std::numeric_limits<double>::infinity();
   double soft_max_vel = std::numeric_limits<double>::infinity();
   const double act_position =
-    (actual.has_position() && std::isfinite(actual.position.value()))
+    actual.has_position()
       ? actual.position.value()
       : ((prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
            ? prev_command_.position.value()
@@ -104,9 +104,7 @@ bool JointSoftLimiter::on_enforce(
   const double prev_command_position =
     (prev_command_.has_position() && std::isfinite(prev_command_.position.value()))
       ? prev_command_.position.value()
-      : ((actual.has_position() && std::isfinite(actual.position.value()))
-           ? actual.position.value()
-           : std::numeric_limits<double>::infinity());
+      : (actual.has_position() ? actual.position.value() : std::numeric_limits<double>::infinity());
 
   if (hard_limits.has_velocity_limits)
   {
@@ -127,8 +125,8 @@ bool JointSoftLimiter::on_enforce(
 
       if (
         std::isfinite(act_position) &&
-          (act_position < (hard_limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)) ||
-        (act_position > (hard_limits.max_position + internal::POSITION_BOUNDS_TOLERANCE)))
+        ((act_position < (hard_limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)) ||
+         (act_position > (hard_limits.max_position + internal::POSITION_BOUNDS_TOLERANCE))))
       {
         soft_min_vel = 0.0;
         soft_max_vel = 0.0;

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -16,6 +16,7 @@
 
 #include <cmath>
 #include <limits>
+#include "joint_limits/joint_limits_helpers.hpp"
 #include "test_joint_limiter.hpp"
 
 TEST_F(JointSoftLimiterTest, when_loading_limiter_plugin_expect_loaded)
@@ -288,32 +289,6 @@ TEST_F(JointSoftLimiterTest, check_desired_position_only_cases)
     actual_state_.position = expected_pos;
   }
 
-  // More generic test case to mock a slow system
-  soft_limits.k_position = 0.5;
-  soft_limits.max_position = 2.0;
-  soft_limits.min_position = -2.0;
-  ASSERT_TRUE(Init(limits, soft_limits));
-  desired_state_.position = 2.0;
-  ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
-  EXPECT_NEAR(desired_state_.position.value(), 1.0, COMMON_THRESHOLD);
-  actual_state_.position = -0.1;
-  for (auto i = 0; i < 10000; i++)
-  {
-    SCOPED_TRACE(
-      "Testing for iteration: " + std::to_string(i) +
-      " for desired position: " + std::to_string(desired_state_.position.value()) +
-      " and actual position : " + std::to_string(actual_state_.position.value()) +
-      " for the joint limits : " + limits.to_string());
-    desired_state_.position = 4.0;
-    const double delta_pos = std::min(
-      (soft_limits.max_position - actual_state_.position.value()) * soft_limits.k_position,
-      limits.max_velocity * period.seconds());
-    const double expected_pos = actual_state_.position.value() + delta_pos;
-    ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
-    EXPECT_NEAR(desired_state_.position.value(), expected_pos, COMMON_THRESHOLD);
-    actual_state_.position = expected_pos / 1.27;
-  }
-
   // Now test when there are no position limits and soft limits, then the desired position is not
   // saturated
   limits = joint_limits::JointLimits();
@@ -392,6 +367,7 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
     EXPECT_FALSE(desired_state_.has_jerk());
   };
 
+  const double outside_limits_pos = 5.0 + (2.0 * joint_limits::internal::POSITION_BOUNDS_TOLERANCE);
   auto test_generic_cases = [&](const joint_limits::SoftJointLimits & soft_joint_limits)
   {
     ASSERT_TRUE(Init(limits, soft_joint_limits));
@@ -417,8 +393,8 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
     test_limit_enforcing(4.5, 0.5, 0.5, false);
     test_limit_enforcing(5.0, 0.9, 0.0, true);
     // When the position is out of the limits, then the velocity is saturated to zero
-    test_limit_enforcing(6.0, 2.0, 0.0, true);
-    test_limit_enforcing(6.0, -2.0, 0.0, true);
+    test_limit_enforcing(outside_limits_pos, 2.0, 0.0, true);
+    test_limit_enforcing(outside_limits_pos, -2.0, 0.0, true);
     test_limit_enforcing(4.0, 0.5, 0.5, false);
     test_limit_enforcing(-4.8, -6.0, -0.2, true);
     test_limit_enforcing(4.3, 5.0, 0.7, true);
@@ -429,9 +405,9 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
     test_limit_enforcing(-5.0, -3.0, 0.0, true);
     test_limit_enforcing(-5.0, -1.0, 0.0, true);
     // When the position is out of the limits, then the velocity is saturated to zero
-    test_limit_enforcing(-6.0, -1.0, 0.0, true);
-    test_limit_enforcing(-6.0, -2.0, 0.0, true);
-    test_limit_enforcing(-6.0, 1.0, 0.0, true);
+    test_limit_enforcing(-1.0 * outside_limits_pos, -1.0, 0.0, true);
+    test_limit_enforcing(-1.0 * outside_limits_pos, -2.0, 0.0, true);
+    test_limit_enforcing(-1.0 * outside_limits_pos, 1.0, 0.0, true);
   };
 
   test_generic_cases(soft_limits);
@@ -483,10 +459,10 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
   test_limit_enforcing(-4.5, 0.2, M_PI / 180., true);
   test_limit_enforcing(-3.0, 5.0, M_PI / 180., true);
 
-  test_limit_enforcing(6.0, 2.0, 0.0, true);
-  test_limit_enforcing(6.0, -2.0, 0.0, true);
-  test_limit_enforcing(-6.0, -2.0, 0.0, true);
-  test_limit_enforcing(-6.0, 2.0, 0.0, true);
+  test_limit_enforcing(outside_limits_pos, 2.0, 0.0, true);
+  test_limit_enforcing(outside_limits_pos, -2.0, 0.0, true);
+  test_limit_enforcing(-1.0 * outside_limits_pos, -2.0, 0.0, true);
+  test_limit_enforcing(-1.0 * outside_limits_pos, 2.0, 0.0, true);
 
   test_limit_enforcing(-5.0, -3.0, M_PI / 180., true);
   test_limit_enforcing(-5.0, -1.0, M_PI / 180., true);
@@ -551,10 +527,10 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
   test_limit_enforcing(-4.3, -1.0, -0.7, true);
   test_limit_enforcing(-4.3, 0.0, -0.2, true);
   test_limit_enforcing(-4.3, 0.0, 0.0, false);
-  test_limit_enforcing(-6.0, 1.0, 0.0, true);
-  test_limit_enforcing(-6.0, -1.0, 0.0, true);
-  test_limit_enforcing(6.0, 1.0, 0.0, true);
-  test_limit_enforcing(6.0, -1.0, 0.0, true);
+  test_limit_enforcing(-1.0 * outside_limits_pos, 1.0, 0.0, true);
+  test_limit_enforcing(-1.0 * outside_limits_pos, -1.0, 0.0, true);
+  test_limit_enforcing(outside_limits_pos, 1.0, 0.0, true);
+  test_limit_enforcing(outside_limits_pos, -1.0, 0.0, true);
 }
 
 TEST_F(JointSoftLimiterTest, check_desired_effort_only_cases)
@@ -1049,13 +1025,9 @@ TEST_F(JointSoftLimiterTest, check_all_desired_references_limiting)
   // Desired position and velocity affected due to the acceleration limits
   test_limit_enforcing(0.5, 0.0, 6.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, true);
   test_limit_enforcing(1.0, 0.0, 6.0, 0.0, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0, true);
-  // If the actual position doesn't change, the desired position should not change
-  test_limit_enforcing(1.0, 0.0, 6.0, 0.0, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0, true);
-  test_limit_enforcing(1.0, 0.0, 6.0, 0.0, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0, true);
-  test_limit_enforcing(1.2, 0.0, 6.0, 0.0, 0.0, 0.0, 1.7, 0.0, 0.0, 0.0, true);
-  test_limit_enforcing(1.5, 0.0, 6.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, true);
-  test_limit_enforcing(1.5, 0.0, -6.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, true);
-  test_limit_enforcing(2.0, 0.0, 6.0, 2.0, 1.0, 0.5, 2.5, 0.5, 0.5, 0.5, true);
+  test_limit_enforcing(1.0, 0.0, 6.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, true);
+  test_limit_enforcing(1.0, 0.0, -6.0, 0.0, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0, true);
+  test_limit_enforcing(2.0, 0.0, 6.0, 2.0, 1.0, 0.5, 2.0, 0.5, 0.5, 0.5, true);
   test_limit_enforcing(2.0, 0.5, 6.0, 2.0, 1.0, 0.5, 3.0, 1.0, 0.5, 0.5, true);
   test_limit_enforcing(3.0, 0.5, 6.0, 2.0, 1.0, 0.5, 4.0, 1.0, 0.5, 0.5, true);
   test_limit_enforcing(4.0, 0.5, 6.0, 2.0, 1.0, 0.5, 5.0, 1.0, 0.5, 0.5, true);

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -219,8 +219,9 @@ TEST_F(JointSoftLimiterTest, check_desired_position_only_cases)
   EXPECT_NEAR(desired_state_.position.value(), 1.0, COMMON_THRESHOLD);
   actual_state_.position = 0.95;
   desired_state_.position = 2.0;
-  ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
-  EXPECT_NEAR(desired_state_.position.value(), 1.95, COMMON_THRESHOLD);
+  ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period))
+    << "Shouldn't change as internally it is using previous command";
+  EXPECT_NEAR(desired_state_.position.value(), 2.0, COMMON_THRESHOLD);
   actual_state_.position = 1.5;
   desired_state_.position = 2.0;
   ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
@@ -239,7 +240,7 @@ TEST_F(JointSoftLimiterTest, check_desired_position_only_cases)
   actual_state_.position = 0.45;
   desired_state_.position = 2.0;
   ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
-  EXPECT_NEAR(desired_state_.position.value(), 1.45, COMMON_THRESHOLD);
+  EXPECT_NEAR(desired_state_.position.value(), 1.5, COMMON_THRESHOLD);
   actual_state_.position = 0.95;
   desired_state_.position = 2.0;
   ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
@@ -277,13 +278,12 @@ TEST_F(JointSoftLimiterTest, check_desired_position_only_cases)
   desired_state_.position = 2.0;
   ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
   EXPECT_NEAR(desired_state_.position.value(), 1.0, COMMON_THRESHOLD);
-  actual_state_.position = 0.2;
+  double prev_command = 1.0;
   while (actual_state_.position.value() < (desired_state_.position.value() - COMMON_THRESHOLD))
   {
     desired_state_.position = 2.0;
     double expected_pos =
-      actual_state_.position.value() +
-      (soft_limits.max_position - actual_state_.position.value()) * soft_limits.k_position;
+      prev_command + (soft_limits.max_position - prev_command) * soft_limits.k_position;
     ASSERT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
     EXPECT_NEAR(desired_state_.position.value(), expected_pos, COMMON_THRESHOLD);
     actual_state_.position = expected_pos;


### PR DESCRIPTION
This PR partially reverts the changes proposed in the PR : https://github.com/ros-controls/ros2_control/pull/1988 and the corresponding changes introduced into the JointLimits integration PR : https://github.com/ros-controls/ros2_control/pull/2047/commits/7846f6ad0a74a37e12f56454bb6f087ff95f8c91

Additionally, if the actual position is outside the joint limits completely, then it will throw an exception to avoid controlling the joint and probably causing self collision