### PR TITLE
Add a method to perform the hardware command mode changes

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -376,6 +376,22 @@ private:
   void clear_requests();
 
   /**
+   * Perform hardware command mode change for the given list of controllers to activate and
+   * deactivate.
+   * \param[in] rt_controller_list list of controllers in the real-time list.
+   * \param[in] activate_controllers_list list of controllers to activate.
+   * \param[in] deactivate_controllers_list list of controllers to deactivate.
+   * \param[in] rt_cycle_name name of the real-time cycle.
+   * \note This method is meant to be used only in the real-time control loops (`read`, `update` and
+   * `write`).
+   */
+  void perform_hardware_command_mode_change(
+    const std::vector<ControllerSpec> & rt_controller_list,
+    const std::vector<std::string> & activate_controllers_list,
+    const std::vector<std::string> & deactivate_controllers_list,
+    const std::string & rt_cycle_name);
+
+  /**
    * If a controller is deactivated all following controllers (if any exist) should be switched
    * 'from' the chained mode.
    *


### PR DESCRIPTION
Right now, we perform and prepare command mode switches when the controllers fail in the `update` loop, but not when the `read` and `write` methods are calling deactivate. This PR addresses this by proposing a common method to handle this kind of scenario.