### PR TITLE
Modernize CMakeLists.txt to remove deprecated ament_target_dependencies (Fixes #2210)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.sourceDirectory": "C:/Users/naray/ros2_control/controller_interface"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "C:/Users/naray/ros2_control/controller_interface"
+}

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -84,7 +84,7 @@ if(BUILD_TESTING)
     hardware_interface::hardware_interface
   )
   target_link_libraries(test_pose_sensor
-  geometry_msgs::geometry_msgs
+    ${geometry_msgs_TARGETS}
   )
   ament_add_gmock(test_gps_sensor test/test_gps_sensor.cpp)
   target_link_libraries(test_gps_sensor

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -27,7 +27,11 @@ target_include_directories(controller_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/controller_interface>
 )
-ament_target_dependencies(controller_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(controller_interface PUBLIC
+  hardware_interface::hardware_interface
+  rclcpp_lifecycle::rclcpp_lifecycle
+  realtime_tools::realtime_tools
+)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
@@ -70,8 +74,8 @@ if(BUILD_TESTING)
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_imu_sensor
-    sensor_msgs
+  target_link_libraries(test_imu_sensor
+  sensor_msgs::sensor_msgs
   )
 
   ament_add_gmock(test_pose_sensor test/test_pose_sensor.cpp)
@@ -79,8 +83,8 @@ if(BUILD_TESTING)
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_pose_sensor
-    geometry_msgs
+  target_link_libraries(test_pose_sensor
+  geometry_msgs::geometry_msgs
   )
   ament_add_gmock(test_gps_sensor test/test_gps_sensor.cpp)
   target_link_libraries(test_gps_sensor
@@ -105,6 +109,8 @@ if(BUILD_TESTING)
   )
   ament_target_dependencies(test_led_rgb_device
     std_msgs
+  )target_link_libraries(test_led_rgb_device
+  std_msgs::std_msgs
   )
 endif()
 

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -107,10 +107,8 @@ if(BUILD_TESTING)
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_led_rgb_device
-    std_msgs
-  )target_link_libraries(test_led_rgb_device
-  std_msgs::std_msgs
+target_link_libraries(test_led_rgb_device
+    ${std_msgs_TARGETS}
   )
 endif()
 

--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -75,7 +75,7 @@ if(BUILD_TESTING)
     hardware_interface::hardware_interface
   )
   target_link_libraries(test_imu_sensor
-  sensor_msgs::sensor_msgs
+    ${sensor_msgs_TARGETS}
   )
 
   ament_add_gmock(test_pose_sensor test/test_pose_sensor.cpp)

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -5,20 +5,27 @@ find_package(ros2_control_cmake REQUIRED)
 set_compiler_options()
 export_windows_symbols()
 
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
+  controller_manager_msgs
+  diagnostic_updater
+  hardware_interface
+  pluginlib
+  rclcpp
+  realtime_tools
+  std_msgs
+  libstatistics_collector
+  generate_parameter_library
+)
 
-
-find_package(controller_interface REQUIRED)
-find_package(controller_manager_msgs REQUIRED)
-find_package(diagnostic_updater REQUIRED)
-find_package(hardware_interface REQUIRED)
-find_package(pluginlib REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(realtime_tools REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(libstatistics_collector REQUIRED)
-find_package(generate_parameter_library REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
 find_package(backward_ros REQUIRED)
-
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
 generate_parameter_library(controller_manager_parameters
   src/controller_manager_parameters.yaml
 )

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -261,16 +261,6 @@ ament_python_install_package(controller_manager
   SCRIPTS_DESTINATION lib/controller_manager
 )
 ament_export_targets(export_controller_manager HAS_LIBRARY_TARGET)
-ament_export_dependencies(
-controller_interface
-controller_manager_msgs
-diagnostic_updater
-hardware_interface
-pluginlib
-rclcpp
-realtime_tools
-std_msgs
-libstatistics_collector
-)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
 ament_package()
 ament_generate_version_header(${PROJECT_NAME})

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
+
 generate_parameter_library(controller_manager_parameters
   src/controller_manager_parameters.yaml
 )

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -5,27 +5,19 @@ find_package(ros2_control_cmake REQUIRED)
 set_compiler_options()
 export_windows_symbols()
 
-set(THIS_PACKAGE_INCLUDE_DEPENDS
-  controller_interface
-  controller_manager_msgs
-  diagnostic_updater
-  hardware_interface
-  pluginlib
-  rclcpp
-  realtime_tools
-  std_msgs
-  libstatistics_collector
-  generate_parameter_library
-)
 
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-find_package(ament_cmake_core REQUIRED)
-find_package(ament_cmake_gen_version_h REQUIRED)
+
+find_package(controller_interface REQUIRED)
+find_package(controller_manager_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(libstatistics_collector REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 find_package(backward_ros REQUIRED)
-foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${Dependency} REQUIRED)
-endforeach()
 
 generate_parameter_library(controller_manager_parameters
   src/controller_manager_parameters.yaml
@@ -41,8 +33,16 @@ target_include_directories(controller_manager PUBLIC
 )
 target_link_libraries(controller_manager PUBLIC
   controller_manager_parameters
+  controller_interface::controller_interface
+  controller_manager_msgs::controller_manager_msgs
+  diagnostic_updater::diagnostic_updater
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  realtime_tools::realtime_tools
+  std_msgs::std_msgs
+  libstatistics_collector::libstatistics_collector
 )
-ament_target_dependencies(controller_manager PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 add_executable(ros2_control_node src/ros2_control_node.cpp)
 target_link_libraries(ros2_control_node PRIVATE
@@ -57,7 +57,10 @@ if(BUILD_TESTING)
   # Plugin Libraries that are built and installed for use in testing
   add_library(test_controller SHARED test/test_controller/test_controller.cpp)
   target_link_libraries(test_controller PUBLIC controller_manager)
-  ament_target_dependencies(test_controller PUBLIC example_interfaces)
+  ament_target_dependencies(test_controller 
+  PUBLIC
+  example_interfaces::example_interfaces
+  )
   pluginlib_export_plugin_description_file(controller_interface test/test_controller/test_controller.xml)
   install(
     TARGETS test_controller
@@ -78,8 +81,11 @@ if(BUILD_TESTING)
   add_library(test_chainable_controller SHARED
     test/test_chainable_controller/test_chainable_controller.cpp
   )
-  ament_target_dependencies(test_chainable_controller PUBLIC realtime_tools)
-  target_link_libraries(test_chainable_controller PUBLIC controller_manager)
+  target_link_libraries(test_chainable_controller
+  PUBLIC 
+  controller_manager
+  realtime_tools::realtime_tools
+  )
   pluginlib_export_plugin_description_file(
     controller_interface test/test_chainable_controller/test_chainable_controller.xml)
   install(
@@ -248,6 +254,16 @@ ament_python_install_package(controller_manager
   SCRIPTS_DESTINATION lib/controller_manager
 )
 ament_export_targets(export_controller_manager HAS_LIBRARY_TARGET)
-ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_export_dependencies(
+controller_interface
+controller_manager_msgs
+diagnostic_updater
+hardware_interface
+pluginlib
+rclcpp
+realtime_tools
+std_msgs
+libstatistics_collector
+)
 ament_package()
 ament_generate_version_header(${PROJECT_NAME})

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -59,7 +59,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_controller PUBLIC controller_manager)
   ament_target_dependencies(test_controller 
   PUBLIC
-  example_interfaces::example_interfaces
+  ${example_interfaces_TARGETS}
   )
   pluginlib_export_plugin_description_file(controller_interface test/test_controller/test_controller.xml)
   install(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 project(hardware_interface LANGUAGES CXX)
 
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gen_version_h REQUIRED)
+find_package(backward_ros REQUIRED)
 find_package(ros2_control_cmake REQUIRED)
 set_compiler_options()
 export_windows_symbols()
@@ -20,9 +23,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pal_statistics
 )
 
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_gen_version_h REQUIRED)
-find_package(backward_ros REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)
 endforeach()
@@ -40,8 +40,20 @@ target_include_directories(hardware_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/hardware_interface>
 )
-ament_target_dependencies(hardware_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
+target_link_libraries(hardware_interface PUBLIC
+  control_msgs::control_msgs
+  lifecycle_msgs::lifecycle_msgs
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  rcpputils::rcpputils
+  rcutils::rcutils
+  realtime_tools::realtime_tools
+  TinyXML2::TinyXML2
+  tinyxml2_vendor::tinyxml2_vendor
+  joint_limits::joint_limits
+  urdf::urdf
+  pal_statistics::pal_statistics
+)
 add_library(mock_components SHARED
   src/mock_components/generic_system.cpp
 )
@@ -50,8 +62,21 @@ target_include_directories(mock_components PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/hardware_interface>
 )
-target_link_libraries(mock_components PUBLIC hardware_interface)
-ament_target_dependencies(mock_components PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(mock_components 
+PUBLIC hardware_interface
+control_msgs::control_msgs
+  lifecycle_msgs::lifecycle_msgs
+  pluginlib::pluginlib
+  rclcpp_lifecycle::rclcpp_lifecycle
+  rcpputils::rcpputils
+  rcutils::rcutils
+  realtime_tools::realtime_tools
+  TinyXML2::TinyXML2
+  tinyxml2_vendor::tinyxml2_vendor
+  joint_limits::joint_limits
+  urdf::urdf
+  pal_statistics::pal_statistics
+)
 
 pluginlib_export_plugin_description_file(
   hardware_interface mock_components_plugin_description.xml)
@@ -63,27 +88,22 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
-  ament_target_dependencies(test_macros rcpputils)
+  target_link_libraries(test_macros rcpputils::rcpputils)
 
   ament_add_gmock(test_inst_hardwares test/test_inst_hardwares.cpp)
-  target_link_libraries(test_inst_hardwares hardware_interface)
-  ament_target_dependencies(test_inst_hardwares rcpputils)
+  target_link_libraries(test_inst_hardwares hardware_interface rcpputils::rcpputils)
 
   ament_add_gmock(test_joint_handle test/test_handle.cpp)
-  target_link_libraries(test_joint_handle hardware_interface)
-  ament_target_dependencies(test_joint_handle rcpputils)
+  target_link_libraries(test_joint_handle hardware_interface rcpputils::rcpputils)
 
   ament_add_gmock(test_component_interfaces test/test_component_interfaces.cpp)
-  target_link_libraries(test_component_interfaces hardware_interface)
-  ament_target_dependencies(test_component_interfaces ros2_control_test_assets)
+  target_link_libraries(test_component_interfaces hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_component_interfaces_custom_export test/test_component_interfaces_custom_export.cpp)
-  target_link_libraries(test_component_interfaces_custom_export hardware_interface)
-  ament_target_dependencies(test_component_interfaces_custom_export ros2_control_test_assets)
-
+  target_link_libraries(test_component_interfaces_custom_export hardware_interface ros2_control_test_assets::ros2_control_test_assets)
+  
   ament_add_gmock(test_component_parser test/test_component_parser.cpp)
-  target_link_libraries(test_component_parser hardware_interface)
-  ament_target_dependencies(test_component_parser ros2_control_test_assets)
+  target_link_libraries(test_component_parser hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 
   add_library(test_hardware_components SHARED
   test/test_hardware_components/test_single_joint_actuator.cpp
@@ -92,9 +112,10 @@ if(BUILD_TESTING)
   test/test_hardware_components/test_two_joint_system.cpp
   test/test_hardware_components/test_system_with_command_modes.cpp
   )
-  target_link_libraries(test_hardware_components hardware_interface)
-  ament_target_dependencies(test_hardware_components
-    pluginlib)
+  target_link_libraries(test_hardware_components 
+  hardware_interface
+  pluginlib::pluginlib
+  )
   install(TARGETS test_hardware_components
     DESTINATION lib
   )
@@ -104,11 +125,11 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_generic_system test/mock_components/test_generic_system.cpp)
   target_include_directories(test_generic_system PRIVATE include)
-  target_link_libraries(test_generic_system hardware_interface)
-  ament_target_dependencies(test_generic_system
-    pluginlib
-    ros2_control_test_assets
-  )
+  target_link_libraries(test_generic_system 
+    hardware_interface
+    pluginlib::pluginlib
+    ros2_control_test_assets::ros2_control_test_assets
+   )
 endif()
 
 install(

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -64,8 +64,8 @@ target_include_directories(mock_components PUBLIC
 )
 target_link_libraries(mock_components 
 PUBLIC hardware_interface
-control_msgs::control_msgs
-  lifecycle_msgs::lifecycle_msgs
+  {control_msgs_TARGETS}
+  {lifecycle_msgs_TARGETS}
   pluginlib::pluginlib
   rclcpp_lifecycle::rclcpp_lifecycle
   rcpputils::rcpputils

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -41,8 +41,8 @@ target_include_directories(hardware_interface PUBLIC
   $<INSTALL_INTERFACE:include/hardware_interface>
 )
 target_link_libraries(hardware_interface PUBLIC
-  control_msgs::control_msgs
-  lifecycle_msgs::lifecycle_msgs
+  {control_msgs_TARGETS}
+  {lifecycle_msgs_TARGETS}
   pluginlib::pluginlib
   rclcpp_lifecycle::rclcpp_lifecycle
   rcpputils::rcpputils

--- a/hardware_interface_testing/CMakeLists.txt
+++ b/hardware_interface_testing/CMakeLists.txt
@@ -24,7 +24,11 @@ test/test_components/test_actuator.cpp
 test/test_components/test_sensor.cpp
 test/test_components/test_system.cpp
 test/test_components/test_actuator_exclusive_interfaces.cpp)
-ament_target_dependencies(test_components hardware_interface pluginlib ros2_control_test_assets)
+target_link_libraries(test_components PUBLIC
+  hardware_interface::hardware_interface
+  pluginlib::pluginlib
+  ros2_control_test_assets::ros2_control_test_assets
+)
 install(TARGETS test_components
 DESTINATION lib
 )
@@ -36,11 +40,16 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
 
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
-  ament_target_dependencies(test_resource_manager hardware_interface ros2_control_test_assets)
+  target_link_libraries(test_resource_manager PUBLIC
+    hardware_interface::hardware_interface
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 
   ament_add_gmock(test_resource_manager_prepare_perform_switch test/test_resource_manager_prepare_perform_switch.cpp)
-  ament_target_dependencies(test_resource_manager_prepare_perform_switch hardware_interface ros2_control_test_assets)
-
+  target_link_libraries(test_resource_manager_prepare_perform_switch PUBLIC
+    hardware_interface::hardware_interface
+    ros2_control_test_assets::ros2_control_test_assets
+  )
 endif()
 
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -37,7 +37,14 @@ target_include_directories(joint_limiter_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-ament_target_dependencies(joint_limiter_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_limiter_interface PUBLIC
+  pluginlib::pluginlib
+  realtime_tools::realtime_tools
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  trajectory_msgs::trajectory_msgs
+  urdf::urdf
+)
 
 add_library(joint_limits_helpers SHARED
   src/joint_limits_helpers.cpp
@@ -47,8 +54,14 @@ target_include_directories(joint_limits_helpers PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-ament_target_dependencies(joint_limits_helpers PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
-
+target_link_libraries(joint_limits_helpers PUBLIC
+  pluginlib::pluginlib
+  realtime_tools::realtime_tools
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  trajectory_msgs::trajectory_msgs
+  urdf::urdf
+)
 add_library(joint_saturation_limiter SHARED
   src/joint_saturation_limiter.cpp
   src/joint_range_limiter.cpp
@@ -59,9 +72,16 @@ target_include_directories(joint_saturation_limiter PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-target_link_libraries(joint_saturation_limiter PUBLIC joint_limits_helpers)
+target_link_libraries(joint_saturation_limiter PUBLIC 
+  joint_limits_helpers
+  pluginlib::pluginlib
+  realtime_tools::realtime_tools
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  trajectory_msgs::trajectory_msgs
+  urdf::urdf
+  )
 
-ament_target_dependencies(joint_saturation_limiter PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 pluginlib_export_plugin_description_file(joint_limits joint_limiters.xml)
 
@@ -95,29 +115,26 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/test/joint_saturation_limiter_param.yaml
   )
   target_include_directories(test_joint_saturation_limiter PRIVATE include)
-  target_link_libraries(test_joint_saturation_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_saturation_limiter
-    pluginlib
-    rclcpp
+  target_link_libraries(test_joint_saturation_limiter
+    joint_limiter_interface
+    pluginlib::pluginlib
+    rclcpp::rclcpp
   )
 
   ament_add_gmock(test_joint_range_limiter test/test_joint_range_limiter.cpp)
   target_include_directories(test_joint_range_limiter PRIVATE include)
-  target_link_libraries(test_joint_range_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_range_limiter
-    pluginlib
-    rclcpp
+  target_link_libraries(test_joint_range_limiter
+    joint_limiter_interface
+    pluginlib::pluginlib
+    rclcpp::rclcpp
   )
 
   ament_add_gmock(test_joint_soft_limiter test/test_joint_soft_limiter.cpp)
   target_include_directories(test_joint_soft_limiter PRIVATE include)
-  target_link_libraries(test_joint_soft_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_soft_limiter
-    pluginlib
-    rclcpp
+  target_link_libraries(test_joint_soft_limiter
+    joint_limiter_interface
+    pluginlib::pluginlib
+    rclcpp::rclcpp
   )
 
 endif()

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(joint_limiter_interface PUBLIC
   realtime_tools::realtime_tools
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
-  trajectory_msgs::trajectory_msgs
+  {trajectory_msgs_TARGETS}
   urdf::urdf
 )
 
@@ -59,7 +59,7 @@ target_link_libraries(joint_limits_helpers PUBLIC
   realtime_tools::realtime_tools
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
-  trajectory_msgs::trajectory_msgs
+  {trajectory_msgs_TARGETS}
   urdf::urdf
 )
 add_library(joint_saturation_limiter SHARED
@@ -78,7 +78,7 @@ target_link_libraries(joint_saturation_limiter PUBLIC
   realtime_tools::realtime_tools
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
-  trajectory_msgs::trajectory_msgs
+  {trajectory_msgs_TARGETS}
   urdf::urdf
   )
 


### PR DESCRIPTION
## Modernize CMakeLists to remove `ament_target_dependencies()` deprecation warnings

This PR updates the `CMakeLists.txt` file to replace deprecated `ament_target_dependencies()` calls with modern `target_link_libraries()` using namespaced targets, as recommended by ROS 2 on Rolling.



### ✅ Changes

- Replaced all `ament_target_dependencies()` usages with `target_link_libraries()` and appropriate namespaced targets.
- Ensured compatibility with ROS 2 Rolling while preserving functionality.

### 📦 Benefits

- Eliminates CMake deprecation warnings
- Aligns with modern CMake best practices
- Future-proofs the build system

---

Closes #2207 


