### PR TITLE
Allow hardware to return FAILURE or ERROR in on_configure

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -406,9 +406,9 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
           resource_manager_->set_component_state(component, state) ==
           hardware_interface::return_type::ERROR)
         {
-          throw std::runtime_error(
-            "Failed to set the initial state of the component : " + component + " to " +
-            state.label());
+          RCLCPP_ERROR_STREAM(
+            get_logger(), "Failed to set the initial state of the component : "
+                            << component << " to " << state.label());
         }
         components_to_activate.erase(component);
       }
@@ -441,9 +441,9 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
       resource_manager_->set_component_state(component, active_state) ==
       hardware_interface::return_type::ERROR)
     {
-      throw std::runtime_error(
-        "Failed to set the initial state of the component : " + component + " to " +
-        active_state.label());
+      RCLCPP_ERROR_STREAM(
+        get_logger(), "Failed to set the initial state of the component : "
+                        << component << " to " << active_state.label());
     }
   }
   robot_description_notification_timer_->cancel();


### PR DESCRIPTION
The current behavior for a hardware_interface returning FAILURE or ERROR in `on_configure()` is to throw an exception which kills the controller_manager.
```
[taskset-1] [resource_manager 1747326040.051327583]: Failed to 'activate' hardware 'right_arm_Hardware'
[taskset-1] terminate called after throwing an instance of 'std::runtime_error'
[taskset-1]   what():  Failed to set the initial state of the component : right_arm_Hardware to active
[taskset-1] Stack trace (most recent call last):
[taskset-1] #18   Object "", at 0xffffffffffffffff, in 
[taskset-1] #17   Object "/opt/ros/jazzy/lib/controller_manager/ros2_control_node", at 0x55b6789c3f34, in _start
[taskset-1] #16   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4bb005628a, in __libc_start_main
[taskset-1] #15   Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4bb00561c9, in 
[taskset-1] #14   Object "/opt/ros/jazzy/lib/controller_manager/ros2_control_node", at 0x55b6789c2ed4, in main
[taskset-1] #13   Object "/opt/ros/jazzy/lib/librclcpp.so", at 0x7f4bb0630343, in rclcpp::executors::MultiThreadedExecutor::spin()
[taskset-1] #12   Object "/opt/ros/jazzy/lib/librclcpp.so", at 0x7f4bb0630026, in rclcpp::executors::MultiThreadedExecutor::run(unsigned long)
[taskset-1] #11   Object "/opt/ros/jazzy/lib/librclcpp.so", at 0x7f4bb061dc39, in rclcpp::Executor::execute_any_executable(rclcpp::AnyExecutable&)
[taskset-1] #10   Object "/opt/ros/jazzy/lib/librclcpp.so", at 0x7f4bb061d50a, in rclcpp::Executor::execute_subscription(std::shared_ptr<rclcpp::SubscriptionBase>)
[taskset-1] #9    Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4bb08a4bd4, in 
[taskset-1] #8    Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4bb08315da, in controller_manager::ControllerManager::robot_description_callback(std_msgs::msg::String_<std::allocator<void> > const&)
[taskset-1] #7    Object "/opt/ros/jazzy/lib/libcontroller_manager.so", at 0x7f4bb07ff95e, in 
[taskset-1] #6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4bb0327390, in __cxa_throw
[taskset-1] #5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4bb0311a54, in std::terminate()
[taskset-1] #4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4bb03270d9, in 
[taskset-1] #3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x7f4bb0311ff4, in 
[taskset-1] #2    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4bb00548fe, in abort
[taskset-1] #1    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4bb007127d, in raise
[taskset-1] #0    Object "/usr/lib/x86_64-linux-gnu/libc.so.6", at 0x7f4bb00cab2c, in pthread_kill
[taskset-1] Aborted (Signal sent by tkill() 2953258 0)
```

This PR changes the behavior to print errors over exceptions and allows them to fix or wait for the hardware to be available and then re-request activation of the components & controllers without requiring a shutdown/restart.