### PR TITLE
Read `data_type` for all types of interfaces

### DIFF
--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -394,6 +394,9 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
     interface.parameters = parse_parameters_from_xml(params_it);
   }
 
+  interface.data_type = parse_data_type_attribute(interfaces_it);
+  interface.size = static_cast<int>(parse_size_attribute(interfaces_it));
+
   return interface;
 }
 
@@ -487,10 +490,6 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   while (command_interfaces_it)
   {
     component.command_interfaces.push_back(parse_interfaces_from_xml(command_interfaces_it));
-    component.command_interfaces.back().data_type =
-      parse_data_type_attribute(command_interfaces_it);
-    component.command_interfaces.back().size =
-      static_cast<int>(parse_size_attribute(command_interfaces_it));
     command_interfaces_it = command_interfaces_it->NextSiblingElement(kCommandInterfaceTag);
   }
 
@@ -499,9 +498,6 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   while (state_interfaces_it)
   {
     component.state_interfaces.push_back(parse_interfaces_from_xml(state_interfaces_it));
-    component.state_interfaces.back().data_type = parse_data_type_attribute(state_interfaces_it);
-    component.state_interfaces.back().size =
-      static_cast<int>(parse_size_attribute(state_interfaces_it));
     state_interfaces_it = state_interfaces_it->NextSiblingElement(kStateInterfaceTag);
   }
 

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -980,6 +980,75 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_d
   EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].size, 1);
 }
 
+TEST_F(
+  TestComponentParser,
+  successfully_parse_valid_urdf_system_with_bool_data_type_on_joint_sensor_and_gpio)
+{
+  std::string urdf_to_test =
+    std::string(ros2_control_test_assets::urdf_head) +
+    ros2_control_test_assets::
+      valid_urdf_ros2_control_system_robot_with_size_and_data_type_on_joint_sensor_and_gpio +
+    ros2_control_test_assets::urdf_tail;
+  const auto control_hardware = parse_control_resources_from_urdf(urdf_to_test);
+  ASSERT_THAT(control_hardware, SizeIs(1));
+  auto hardware_info = control_hardware.front();
+
+  EXPECT_EQ(hardware_info.name, "RRBotSystemWithSizeAndDataType");
+  EXPECT_EQ(hardware_info.type, "system");
+  EXPECT_EQ(
+    hardware_info.hardware_plugin_name,
+    "ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType");
+
+  ASSERT_THAT(hardware_info.joints, SizeIs(1));
+
+  ASSERT_FALSE(hardware_info.is_async);
+  ASSERT_EQ(hardware_info.thread_priority, std::numeric_limits<int>::max());
+  EXPECT_EQ(hardware_info.joints[0].name, "joint1");
+  EXPECT_EQ(hardware_info.joints[0].type, "joint");
+  EXPECT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(2));
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[0].size, 1);
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[1].name, "enable");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[1].data_type, "bool");
+  EXPECT_EQ(hardware_info.joints[0].command_interfaces[1].size, 1);
+  EXPECT_THAT(hardware_info.joints[0].state_interfaces, SizeIs(2));
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].name, HW_IF_POSITION);
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[0].size, 1);
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].name, "status");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].data_type, "bool");
+  EXPECT_EQ(hardware_info.joints[0].state_interfaces[1].size, 1);
+
+  ASSERT_THAT(hardware_info.sensors, SizeIs(1));
+  EXPECT_EQ(hardware_info.sensors[0].name, "trigger");
+  EXPECT_EQ(hardware_info.sensors[0].type, "sensor");
+  EXPECT_THAT(hardware_info.sensors[0].state_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].name, "safety");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].data_type, "bool");
+  EXPECT_EQ(hardware_info.sensors[0].state_interfaces[0].size, 1);
+  EXPECT_THAT(hardware_info.sensors[0].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.sensors[0].command_interfaces[0].name, "safety");
+  EXPECT_EQ(hardware_info.sensors[0].command_interfaces[0].data_type, "bool");
+  EXPECT_EQ(hardware_info.sensors[0].command_interfaces[0].size, 1);
+
+  ASSERT_THAT(hardware_info.gpios, SizeIs(1));
+
+  EXPECT_EQ(hardware_info.gpios[0].name, "flange_IOS");
+  EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
+  EXPECT_THAT(hardware_info.gpios[0].command_interfaces, SizeIs(1));
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].name, "digital_output");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].data_type, "bool");
+  EXPECT_EQ(hardware_info.gpios[0].command_interfaces[0].size, 2);
+  EXPECT_THAT(hardware_info.gpios[0].state_interfaces, SizeIs(2));
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].name, "analog_input");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].data_type, "double");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[0].size, 3);
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].name, "image");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].data_type, "cv::Mat");
+  EXPECT_EQ(hardware_info.gpios[0].state_interfaces[1].size, 1);
+}
+
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_and_disabled_interfaces)
 {
   std::string urdf_to_test =

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -735,6 +735,32 @@ const auto valid_urdf_ros2_control_parameter_empty =
   </ros2_control>
 )";
 
+const auto valid_urdf_ros2_control_system_robot_with_size_and_data_type_on_joint_sensor_and_gpio =
+  R"(
+  <ros2_control name="RRBotSystemWithSizeAndDataType" type="system">
+    <hardware>
+      <plugin>ros2_control_demo_hardware/RRBotSystemWithSizeAndDataType</plugin>
+      <param name="example_param_write_for_sec">2</param>
+      <param name="example_param_read_for_sec">2</param>
+    </hardware>
+    <joint name="joint1">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="status" data_type="bool"/>
+      <command_interface name="enable" data_type="bool"/>
+    </joint>
+    <sensor name="trigger">
+      <command_interface name="safety" data_type="bool"/>
+      <state_interface name="safety" data_type="bool"/>
+    </sensor>
+    <gpio name="flange_IOS">
+      <command_interface name="digital_output" size="2" data_type="bool"/>
+      <state_interface name="analog_input" size="3"/>
+      <state_interface name="image" data_type="cv::Mat"/>
+    </gpio>
+  </ros2_control>
+)";
+
 // Errors
 const auto invalid_urdf_ros2_control_invalid_child =
   R"(


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/ros2_control/issues/2234