### PR TITLE
Add deprecated `get_optional` to Transmission Handle

### DIFF
--- a/transmission_interface/include/transmission_interface/handle.hpp
+++ b/transmission_interface/include/transmission_interface/handle.hpp
@@ -23,9 +23,7 @@ namespace transmission_interface
 class Handle
 {
 public:
-  Handle(
-    const std::string & prefix_name, const std::string & interface_name,
-    double * value_ptr = nullptr)
+  Handle(const std::string & prefix_name, const std::string & interface_name, double * value_ptr)
   : prefix_name_(prefix_name), interface_name_(interface_name), value_ptr_(value_ptr)
   {
   }
@@ -55,10 +53,23 @@ public:
     return *value_ptr_;
   }
 
-  void set_value(double value)
+  [[deprecated(
+    "For Transmission Handles use get_value() instead to retrieve the value. This method will be "
+    "removed by the ROS 2 Kilted Kaiju release.")]]
+  std::optional<double> get_optional() const
+  {
+    if (value_ptr_)
+    {
+      return *value_ptr_;
+    }
+    return std::nullopt;
+  }
+
+  bool set_value(double value)
   {
     THROW_ON_NULLPTR(this->value_ptr_);
     *this->value_ptr_ = value;
+    return true;
   }
 
 protected:

--- a/transmission_interface/include/transmission_interface/handle.hpp
+++ b/transmission_interface/include/transmission_interface/handle.hpp
@@ -15,6 +15,7 @@
 #ifndef TRANSMISSION_INTERFACE__HANDLE_HPP_
 #define TRANSMISSION_INTERFACE__HANDLE_HPP_
 
+#include <optional>
 #include <string>
 #include "hardware_interface/macros.hpp"
 


### PR DESCRIPTION
With https://github.com/ros-controls/ros2_control/pull/2223 we recently reverted back to the old version of the Handles in the transmission interface, however, if the user code base uses the methods `get_optional` and std::ignore for the `set_value`, he/she will have compilation issues. In order to avoid such things, I'm adding these deprecated methods only to Jazzy, so their pipelines will continue to work