### PR TITLE
Use target_link_libraries instead of ament_target_dependencies

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -28,7 +28,11 @@ target_include_directories(controller_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/controller_interface>
 )
-ament_target_dependencies(controller_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(controller_interface PUBLIC
+                      hardware_interface::hardware_interface
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      realtime_tools::realtime_tools
+                      fmt::fmt)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
@@ -71,18 +75,14 @@ if(BUILD_TESTING)
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_imu_sensor
-    sensor_msgs
-  )
+  target_link_libraries(test_imu_sensor ${sensor_msgs_TARGETS})
 
   ament_add_gmock(test_pose_sensor test/test_pose_sensor.cpp)
   target_link_libraries(test_pose_sensor
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_pose_sensor
-    geometry_msgs
-  )
+  target_link_libraries(test_pose_sensor ${geometry_msgs_TARGETS})
   ament_add_gmock(test_gps_sensor test/test_gps_sensor.cpp)
   target_link_libraries(test_gps_sensor
     controller_interface
@@ -104,9 +104,7 @@ if(BUILD_TESTING)
     controller_interface
     hardware_interface::hardware_interface
   )
-  ament_target_dependencies(test_led_rgb_device
-    std_msgs
-  )
+  target_link_libraries(test_led_rgb_device ${std_msgs_TARGETS})
 endif()
 
 install(

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -41,9 +41,18 @@ target_include_directories(controller_manager PUBLIC
   $<INSTALL_INTERFACE:include/controller_manager>
 )
 target_link_libraries(controller_manager PUBLIC
-  controller_manager_parameters
-)
-ament_target_dependencies(controller_manager PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+                      controller_manager_parameters
+                      controller_interface::controller_interface
+                      diagnostic_updater::diagnostic_updater
+                      hardware_interface::hardware_interface
+                      pluginlib::pluginlib
+                      rclcpp::rclcpp
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      realtime_tools::realtime_tools
+                      libstatistics_collector::libstatistics_collector
+                      fmt::fmt
+                      ${std_msgs_TARGETS}
+                      ${controller_manager_msgs_TARGETS})
 
 add_executable(ros2_control_node src/ros2_control_node.cpp)
 target_link_libraries(ros2_control_node PRIVATE
@@ -57,8 +66,9 @@ if(BUILD_TESTING)
 
   # Plugin Libraries that are built and installed for use in testing
   add_library(test_controller SHARED test/test_controller/test_controller.cpp)
-  target_link_libraries(test_controller PUBLIC controller_manager)
-  ament_target_dependencies(test_controller PUBLIC example_interfaces)
+  target_link_libraries(test_controller PUBLIC
+                        controller_manager
+                        ${example_interfaces_TARGETS})
   pluginlib_export_plugin_description_file(controller_interface test/test_controller/test_controller.xml)
   install(
     TARGETS test_controller
@@ -79,8 +89,9 @@ if(BUILD_TESTING)
   add_library(test_chainable_controller SHARED
     test/test_chainable_controller/test_chainable_controller.cpp
   )
-  ament_target_dependencies(test_chainable_controller PUBLIC realtime_tools)
-  target_link_libraries(test_chainable_controller PUBLIC controller_manager)
+  target_link_libraries(test_chainable_controller PUBLIC
+                        controller_manager
+                        realtime_tools::realtime_tools)
   pluginlib_export_plugin_description_file(
     controller_interface test/test_chainable_controller/test_chainable_controller.xml)
   install(
@@ -147,11 +158,9 @@ if(BUILD_TESTING)
     test_controller
     test_chainable_controller
     ros2_control_test_assets::ros2_control_test_assets
+    ${controller_manager_msgs_TARGETS}
   )
   set_tests_properties(test_controller_manager_srvs PROPERTIES TIMEOUT 120)
-  ament_target_dependencies(test_controller_manager_srvs
-    controller_manager_msgs
-  )
   ament_add_gmock(test_controller_manager_urdf_passing
     test/test_controller_manager_urdf_passing.cpp
   )
@@ -159,9 +168,7 @@ if(BUILD_TESTING)
     controller_manager
     test_controller
     ros2_control_test_assets::ros2_control_test_assets
-  )
-  ament_target_dependencies(test_controller_manager_urdf_passing
-    controller_manager_msgs
+    ${controller_manager_msgs_TARGETS}
   )
 
   add_library(test_controller_with_interfaces SHARED
@@ -218,9 +225,7 @@ if(BUILD_TESTING)
     controller_manager
     test_controller
     ros2_control_test_assets::ros2_control_test_assets
-  )
-  ament_target_dependencies(test_hardware_management_srvs
-    controller_manager_msgs
+    ${controller_manager_msgs_TARGETS}
   )
 
   find_package(ament_cmake_pytest REQUIRED)

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -40,9 +40,23 @@ target_compile_features(hardware_interface PUBLIC cxx_std_17)
 target_include_directories(hardware_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/hardware_interface>
+  ${pal_statistics_INCLUDE_DIRS}
 )
-target_link_libraries(hardware_interface PUBLIC fmt::fmt)
-ament_target_dependencies(hardware_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(hardware_interface PUBLIC
+                      rclcpp::rclcpp
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      pluginlib::pluginlib
+                      urdf::urdf
+                      realtime_tools::realtime_tools
+                      rcutils::rcutils
+                      rcpputils::rcpputils
+                      ${joint_limits_TARGETS}
+                      ${TinyXML2_LIBRARIES}
+                      ${tinyxml2_vendor_LIBRARIES}
+                      ${pal_statistics_LIBRARIES}
+                      ${control_msgs_TARGETS}
+                      ${lifecycle_msgs_TARGETS}
+                      fmt::fmt)
 
 add_library(mock_components SHARED
   src/mock_components/generic_system.cpp
@@ -53,7 +67,6 @@ target_include_directories(mock_components PUBLIC
   $<INSTALL_INTERFACE:include/hardware_interface>
 )
 target_link_libraries(mock_components PUBLIC hardware_interface)
-ament_target_dependencies(mock_components PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 pluginlib_export_plugin_description_file(
   hardware_interface mock_components_plugin_description.xml)
@@ -65,31 +78,26 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_macros test/test_macros.cpp)
   target_include_directories(test_macros PRIVATE include)
-  ament_target_dependencies(test_macros rcpputils)
+  target_link_libraries(test_macros rcpputils::rcpputils)
 
   ament_add_gmock(test_inst_hardwares test/test_inst_hardwares.cpp)
-  target_link_libraries(test_inst_hardwares hardware_interface)
-  ament_target_dependencies(test_inst_hardwares rcpputils)
+  target_link_libraries(test_inst_hardwares hardware_interface rcpputils::rcpputils)
 
   ament_add_gmock(test_joint_handle test/test_handle.cpp)
-  target_link_libraries(test_joint_handle hardware_interface)
-  ament_target_dependencies(test_joint_handle rcpputils)
+  target_link_libraries(test_joint_handle hardware_interface rcpputils::rcpputils)
 
   # Test helper methods
   ament_add_gmock(test_helpers test/test_helpers.cpp)
   target_link_libraries(test_helpers hardware_interface)
 
   ament_add_gmock(test_component_interfaces test/test_component_interfaces.cpp)
-  target_link_libraries(test_component_interfaces hardware_interface)
-  ament_target_dependencies(test_component_interfaces ros2_control_test_assets)
+  target_link_libraries(test_component_interfaces hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_component_interfaces_custom_export test/test_component_interfaces_custom_export.cpp)
-  target_link_libraries(test_component_interfaces_custom_export hardware_interface)
-  ament_target_dependencies(test_component_interfaces_custom_export ros2_control_test_assets)
+  target_link_libraries(test_component_interfaces_custom_export hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_component_parser test/test_component_parser.cpp)
-  target_link_libraries(test_component_parser hardware_interface)
-  ament_target_dependencies(test_component_parser ros2_control_test_assets)
+  target_link_libraries(test_component_parser hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 
   add_library(test_hardware_components SHARED
   test/test_hardware_components/test_single_joint_actuator.cpp
@@ -99,8 +107,6 @@ if(BUILD_TESTING)
   test/test_hardware_components/test_system_with_command_modes.cpp
   )
   target_link_libraries(test_hardware_components hardware_interface)
-  ament_target_dependencies(test_hardware_components
-    pluginlib)
   install(TARGETS test_hardware_components
     DESTINATION lib
   )
@@ -110,11 +116,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_generic_system test/mock_components/test_generic_system.cpp)
   target_include_directories(test_generic_system PRIVATE include)
-  target_link_libraries(test_generic_system hardware_interface)
-  ament_target_dependencies(test_generic_system
-    pluginlib
-    ros2_control_test_assets
-  )
+  target_link_libraries(test_generic_system hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 endif()
 
 install(

--- a/hardware_interface_testing/CMakeLists.txt
+++ b/hardware_interface_testing/CMakeLists.txt
@@ -6,7 +6,6 @@ set_compiler_options()
 export_windows_symbols()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
-  control_msgs
   hardware_interface
   lifecycle_msgs
   pluginlib
@@ -21,11 +20,17 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
 endforeach()
 
 add_library(test_components SHARED
-test/test_components/test_actuator.cpp
-test/test_components/test_sensor.cpp
-test/test_components/test_system.cpp
-test/test_components/test_actuator_exclusive_interfaces.cpp)
-ament_target_dependencies(test_components hardware_interface pluginlib ros2_control_test_assets)
+            test/test_components/test_actuator.cpp
+            test/test_components/test_sensor.cpp
+            test/test_components/test_system.cpp
+            test/test_components/test_actuator_exclusive_interfaces.cpp)
+
+target_link_libraries(test_components
+                      hardware_interface::hardware_interface
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      ros2_control_test_assets::ros2_control_test_assets
+                      pluginlib::pluginlib
+                      fmt::fmt)
 install(TARGETS test_components
 DESTINATION lib
 )
@@ -37,11 +42,18 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
 
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
-  target_link_libraries(test_resource_manager)
-  ament_target_dependencies(test_resource_manager hardware_interface ros2_control_test_assets)
+  target_link_libraries(test_resource_manager
+                        hardware_interface::hardware_interface
+                        rclcpp_lifecycle::rclcpp_lifecycle
+                        ros2_control_test_assets::ros2_control_test_assets
+                        ${lifecycle_msgs_TARGETS})
 
   ament_add_gmock(test_resource_manager_prepare_perform_switch test/test_resource_manager_prepare_perform_switch.cpp)
-  ament_target_dependencies(test_resource_manager_prepare_perform_switch hardware_interface ros2_control_test_assets)
+  target_link_libraries(test_resource_manager_prepare_perform_switch
+                        hardware_interface::hardware_interface
+                        rclcpp_lifecycle::rclcpp_lifecycle
+                        ros2_control_test_assets::ros2_control_test_assets
+                        ${lifecycle_msgs_TARGETS})
 
 endif()
 

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -28,7 +28,12 @@ target_include_directories(joint_limits INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-ament_target_dependencies(joint_limits INTERFACE ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_limits INTERFACE
+                      rclcpp::rclcpp
+                      rclcpp_lifecycle::rclcpp_lifecycle
+                      urdf::urdf
+                      realtime_tools::realtime_tools
+                      fmt::fmt)
 
 add_library(joint_limiter_interface SHARED
   src/joint_limiter_interface.cpp
@@ -38,7 +43,10 @@ target_include_directories(joint_limiter_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-ament_target_dependencies(joint_limiter_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_limiter_interface PUBLIC
+                      joint_limits
+                      pluginlib::pluginlib
+                      ${trajectory_msgs_TARGETS})
 
 add_library(joint_limits_helpers SHARED
   src/joint_limits_helpers.cpp
@@ -48,7 +56,7 @@ target_include_directories(joint_limits_helpers PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-ament_target_dependencies(joint_limits_helpers PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_limits_helpers PUBLIC joint_limits)
 
 add_library(joint_saturation_limiter SHARED
   src/joint_saturation_limiter.cpp
@@ -60,9 +68,9 @@ target_include_directories(joint_saturation_limiter PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
 )
-target_link_libraries(joint_saturation_limiter PUBLIC joint_limits_helpers)
-
-ament_target_dependencies(joint_saturation_limiter PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_saturation_limiter PUBLIC
+                      joint_limits_helpers
+                      joint_limiter_interface)
 
 pluginlib_export_plugin_description_file(joint_limits joint_limiters.xml)
 
@@ -96,30 +104,24 @@ if(BUILD_TESTING)
     ${CMAKE_CURRENT_SOURCE_DIR}/test/joint_saturation_limiter_param.yaml
   )
   target_include_directories(test_joint_saturation_limiter PRIVATE include)
-  target_link_libraries(test_joint_saturation_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_saturation_limiter
-    pluginlib
-    rclcpp
-  )
+  target_link_libraries(test_joint_saturation_limiter
+                        joint_limiter_interface
+                        pluginlib::pluginlib
+                        rclcpp::rclcpp)
 
   ament_add_gmock(test_joint_range_limiter test/test_joint_range_limiter.cpp)
   target_include_directories(test_joint_range_limiter PRIVATE include)
-  target_link_libraries(test_joint_range_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_range_limiter
-    pluginlib
-    rclcpp
-  )
+  target_link_libraries(test_joint_range_limiter
+                        joint_limiter_interface
+                        pluginlib::pluginlib
+                        rclcpp::rclcpp)
 
   ament_add_gmock(test_joint_soft_limiter test/test_joint_soft_limiter.cpp)
   target_include_directories(test_joint_soft_limiter PRIVATE include)
-  target_link_libraries(test_joint_soft_limiter joint_limiter_interface)
-  ament_target_dependencies(
-    test_joint_soft_limiter
-    pluginlib
-    rclcpp
-  )
+  target_link_libraries(test_joint_soft_limiter
+                        joint_limiter_interface
+                        pluginlib::pluginlib
+                        rclcpp::rclcpp)
 
 endif()
 

--- a/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
+++ b/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
@@ -41,7 +41,7 @@ public:
   JointSaturationLimiter();
 
   /** \brief Destructor */
-  ~JointSaturationLimiter();
+  virtual ~JointSaturationLimiter();
 
   bool on_init() override { return true; }
 

--- a/joint_limits/include/joint_limits/joint_soft_limiter.hpp
+++ b/joint_limits/include/joint_limits/joint_soft_limiter.hpp
@@ -30,6 +30,8 @@ namespace joint_limits
 class JointSoftLimiter : public JointSaturationLimiter<JointControlInterfacesData>
 {
 public:
+  virtual ~JointSoftLimiter() = default;
+
   bool on_init() override
   {
     const bool result = (number_of_joints_ == 1);

--- a/transmission_interface/CMakeLists.txt
+++ b/transmission_interface/CMakeLists.txt
@@ -27,8 +27,11 @@ target_include_directories(transmission_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/transmission_interface>
 )
-target_link_libraries(transmission_interface PUBLIC fmt::fmt)
-ament_target_dependencies(transmission_interface PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(transmission_interface PUBLIC
+                      hardware_interface::hardware_interface
+                      pluginlib::pluginlib
+                      rclcpp::rclcpp
+                      fmt::fmt)
 pluginlib_export_plugin_description_file(transmission_interface ros2_control_plugins.xml)
 
 if(BUILD_TESTING)
@@ -53,27 +56,30 @@ if(BUILD_TESTING)
   ament_add_gmock(test_simple_transmission_loader
     test/simple_transmission_loader_test.cpp
   )
-  target_link_libraries(test_simple_transmission_loader transmission_interface)
-  ament_target_dependencies(test_simple_transmission_loader ros2_control_test_assets)
+  target_link_libraries(test_simple_transmission_loader
+                        transmission_interface
+                        ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_four_bar_linkage_transmission_loader
     test/four_bar_linkage_transmission_loader_test.cpp
   )
-  target_link_libraries(test_four_bar_linkage_transmission_loader transmission_interface)
-  ament_target_dependencies(test_four_bar_linkage_transmission_loader ros2_control_test_assets)
+  target_link_libraries(test_four_bar_linkage_transmission_loader
+                        transmission_interface
+                        ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(test_differential_transmission_loader
     test/differential_transmission_loader_test.cpp
   )
-  target_link_libraries(test_differential_transmission_loader transmission_interface)
-  ament_target_dependencies(test_differential_transmission_loader ros2_control_test_assets)
+  target_link_libraries(test_differential_transmission_loader
+                        transmission_interface
+                        ros2_control_test_assets::ros2_control_test_assets)
 
   ament_add_gmock(
     test_utils
     test/utils_test.cpp
   )
   target_include_directories(test_utils PUBLIC include hardware_interface)
-  ament_target_dependencies(test_utils hardware_interface)
+  target_link_libraries(test_utils hardware_interface::hardware_interface)
 endif()
 
 install(


### PR DESCRIPTION
Closes https://github.com/ros-controls/ros2_control/pull/2210

Fixes: https://github.com/ros-controls/ros2_control/issues/2257
Fixes: https://github.com/ros-controls/control_toolbox/issues/369
Fixes: https://github.com/ros-controls/realtime_tools/issues/329
Fixes: https://github.com/ros-controls/kinematics_interface/issues/141