### PR TITLE
Add enforce_command_limits parameter to GPL parameters

### DIFF
--- a/controller_manager/doc/parameters_context.yaml
+++ b/controller_manager/doc/parameters_context.yaml
@@ -25,3 +25,7 @@ diagnostics.threshold.hardware_components.periodicity: |
 
 diagnostics.threshold.hardware_components.execution_time.mean_error: |
   The ``execution_time`` diagnostics will be published for all hardware components. The ``mean_error`` for a synchronous hardware component will be computed against zero, as it should be as low as possible. However, the ``mean_error`` for an asynchronous hardware component will be computed against its desired read/write period, as the hardware component can take a maximum of the desired period to execute the read/write cycle.
+
+enforce_command_limits: |
+  When true, If the command is outside the limits, the command is clamped to be within the limits depending on the type of configured joint limits in the URDF.
+  If the command is within the limits, the command is passed through without any changes.

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -79,11 +79,6 @@ robot_description [std_msgs::msg::String]
 Parameters
 -----------
 
-enforce_command_limits (optional; bool; default: ``false`` for Jazzy and earlier distro and ``true`` for Rolling and newer distros)
-  Enforces the joint limits to the joint command interfaces.
-  If the command is outside the limits, the command is clamped to be within the limits depending on the type of configured joint limits in the URDF.
-  If the command is within the limits, the command is passed through without any changes.
-
 <controller_name>.type
   Name of a plugin exported using ``pluginlib`` for a controller.
   This is a class from which controller's instance with name "``controller_name``" is created.

--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -673,7 +673,6 @@ private:
   std::string robot_description_;
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr robot_description_subscription_;
   rclcpp::TimerBase::SharedPtr robot_description_notification_timer_;
-  bool enforce_command_limits_;
 
   controller_manager::MovingAverageStatistics periodicity_stats_;
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -490,7 +490,7 @@ void ControllerManager::init_controller_manager()
   // Get parameters needed for RT "update" loop to work
   if (is_resource_manager_initialized())
   {
-    if (enforce_command_limits_)
+    if (params_->enforce_command_limits)
     {
       resource_manager_->import_joint_limiters(robot_description_);
     }
@@ -556,12 +556,8 @@ void ControllerManager::init_controller_manager()
         RCLCPP_INFO(get_logger(), "Shutting down the controller manager.");
       }));
 
-  // Declare the enforce_command_limits parameter such a way that it is enabled by default for
-  // rolling and newer alone
-  enforce_command_limits_ =
-    this->get_parameter_or("enforce_command_limits", RCLCPP_VERSION_MAJOR >= 29 ? true : false);
   RCLCPP_INFO_EXPRESSION(
-    get_logger(), enforce_command_limits_, "Enforcing command limits is enabled...");
+    get_logger(), params_->enforce_command_limits, "Enforcing command limits is enabled...");
 }
 
 void ControllerManager::initialize_parameters()
@@ -615,7 +611,7 @@ void ControllerManager::robot_description_callback(const std_msgs::msg::String &
 
 void ControllerManager::init_resource_manager(const std::string & robot_description)
 {
-  if (enforce_command_limits_)
+  if (params_->enforce_command_limits)
   {
     resource_manager_->import_joint_limiters(robot_description_);
   }

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -6,10 +6,18 @@ controller_manager:
     description: "The frequency of controller manager's real-time update loop. This loop reads states from hardware, updates controllers and writes commands to hardware."
   }
 
+  enforce_command_limits: {
+    type: bool,
+    default_value: true,
+    read_only: true,
+    description: "If true, the controller manager will enforce command limits defined in the robot description. If false, no limits will be enforced.",
+  }
+
   hardware_components_initial_state:
     unconfigured: {
       type: string_array,
       default_value: [],
+      read_only: true,
       description: "Defines which hardware components will be only loaded when controller manager is started. These hardware components will need to be configured and activated manually or via a hardware spawner.",
       validation: {
         unique<>: null,
@@ -19,6 +27,7 @@ controller_manager:
     inactive: {
       type: string_array,
       default_value: [],
+      read_only: true,
       description: "Defines which hardware components will be configured when controller manager is started. These hardware components will need to be activated manually or via a hardware spawner.",
       validation: {
         unique<>: null,
@@ -28,6 +37,7 @@ controller_manager:
     shutdown_on_initial_state_failure: {
       type: bool,
       default_value: false,
+      read_only: true,
       description: "Specifies whether the controller manager should shut down if setting the desired initial state fails during startup.",
     }
 


### PR DESCRIPTION
This PR moves the parameter declared in the code that works for older and newer versions to GPL parameters list. 

When this PR is backported, the default parameter could be changed to `false`