### PR TITLE
[Transmissions] Add `absolute_position` and `torque` interfaces

### DIFF
--- a/transmission_interface/test/differential_transmission_test.cpp
+++ b/transmission_interface/test/differential_transmission_test.cpp
@@ -22,11 +22,13 @@
 
 using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_TORQUE;
 using hardware_interface::HW_IF_VELOCITY;
 using testing::DoubleNear;
 using transmission_interface::ActuatorHandle;
 using transmission_interface::DifferentialTransmission;
 using transmission_interface::Exception;
+using transmission_interface::HW_IF_ABSOLUTE_POSITION;
 using transmission_interface::JointHandle;
 // Floating-point value comparison threshold
 const double EPS = 1e-5;
@@ -125,6 +127,8 @@ TEST(ConfigureTest, FailsWithBadHandles)
   testConfigureWithBadHandles(HW_IF_POSITION);
   testConfigureWithBadHandles(HW_IF_VELOCITY);
   testConfigureWithBadHandles(HW_IF_EFFORT);
+  testConfigureWithBadHandles(HW_IF_TORQUE);
+  testConfigureWithBadHandles(HW_IF_ABSOLUTE_POSITION);
 }
 
 class TransmissionSetup : public ::testing::Test
@@ -220,6 +224,7 @@ TEST_F(BlackBoxTest, IdentityMap)
       testIdentityMap(transmission, input_value, HW_IF_POSITION);
       testIdentityMap(transmission, input_value, HW_IF_VELOCITY);
       testIdentityMap(transmission, input_value, HW_IF_EFFORT);
+      testIdentityMap(transmission, input_value, HW_IF_TORQUE);
     }
   }
 }
@@ -236,7 +241,7 @@ TEST_F(WhiteBoxTest, DontMoveJoints)
 
   DifferentialTransmission trans(actuator_reduction, joint_reduction, joint_offset);
 
-  // Actuator input (used for effort, velocity and position)
+  // Actuator input (used for effort, velocity, position, torque and absolute position)
   *a_vec[0] = 0.0;
   *a_vec[1] = 0.0;
 
@@ -275,6 +280,30 @@ TEST_F(WhiteBoxTest, DontMoveJoints)
     EXPECT_THAT(joint_offset[0], DoubleNear(j_val[0], EPS));
     EXPECT_THAT(joint_offset[1], DoubleNear(j_val[1], EPS));
   }
+
+  // Torque interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_TORQUE, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_TORQUE, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_TORQUE, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_TORQUE, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(0.0, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(0.0, DoubleNear(j_val[1], EPS));
+  }
+
+  // Absolute position interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_ABSOLUTE_POSITION, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_ABSOLUTE_POSITION, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_ABSOLUTE_POSITION, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_ABSOLUTE_POSITION, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(joint_offset[0], DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(joint_offset[1], DoubleNear(j_val[1], EPS));
+  }
 }
 
 TEST_F(WhiteBoxTest, MoveFirstJointOnly)
@@ -284,7 +313,7 @@ TEST_F(WhiteBoxTest, MoveFirstJointOnly)
 
   DifferentialTransmission trans(actuator_reduction, joint_reduction);
 
-  // Actuator input (used for effort, velocity and position)
+  // Actuator input (used for effort, velocity, position, torque and absolute position)
   *a_vec[0] = 10.0;
   *a_vec[1] = 10.0;
 
@@ -323,6 +352,30 @@ TEST_F(WhiteBoxTest, MoveFirstJointOnly)
     EXPECT_THAT(0.5, DoubleNear(j_val[0], EPS));
     EXPECT_THAT(0.0, DoubleNear(j_val[1], EPS));
   }
+
+  // Torque interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_TORQUE, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_TORQUE, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_TORQUE, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_TORQUE, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(400.0, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(0.0, DoubleNear(j_val[1], EPS));
+  }
+
+  // Absolute position interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_ABSOLUTE_POSITION, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_ABSOLUTE_POSITION, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_ABSOLUTE_POSITION, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_ABSOLUTE_POSITION, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(0.5, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(0.0, DoubleNear(j_val[1], EPS));
+  }
 }
 
 TEST_F(WhiteBoxTest, MoveSecondJointOnly)
@@ -332,7 +385,7 @@ TEST_F(WhiteBoxTest, MoveSecondJointOnly)
 
   DifferentialTransmission trans(actuator_reduction, joint_reduction);
 
-  // Actuator input (used for effort, velocity and position)
+  // Actuator input (used for effort, velocity, position, torque and absolute position)
   *a_vec[0] = 10.0;
   *a_vec[1] = -10.0;
 
@@ -366,6 +419,30 @@ TEST_F(WhiteBoxTest, MoveSecondJointOnly)
     auto a2_handle = ActuatorHandle("act2", HW_IF_POSITION, a_vec[1]);
     auto joint1_handle = JointHandle("joint1", HW_IF_POSITION, j_vec[0]);
     auto joint2_handle = JointHandle("joint2", HW_IF_POSITION, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(0.0, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(0.5, DoubleNear(j_val[1], EPS));
+  }
+
+  // Torque interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_TORQUE, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_TORQUE, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_TORQUE, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_TORQUE, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(0.0, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(400.0, DoubleNear(j_val[1], EPS));
+  }
+
+  // Absolute position interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_ABSOLUTE_POSITION, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_ABSOLUTE_POSITION, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_ABSOLUTE_POSITION, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_ABSOLUTE_POSITION, j_vec[1]);
     trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
     trans.actuator_to_joint();
     EXPECT_THAT(0.0, DoubleNear(j_val[0], EPS));
@@ -419,6 +496,30 @@ TEST_F(WhiteBoxTest, MoveBothJoints)
     auto a2_handle = ActuatorHandle("act2", HW_IF_POSITION, a_vec[1]);
     auto joint1_handle = JointHandle("joint1", HW_IF_POSITION, j_vec[0]);
     auto joint2_handle = JointHandle("joint2", HW_IF_POSITION, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(-2.01250, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(4.06875, DoubleNear(j_val[1], EPS));
+  }
+
+  // Torque interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_TORQUE, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_TORQUE, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_TORQUE, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_TORQUE, j_vec[1]);
+    trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
+    trans.actuator_to_joint();
+    EXPECT_THAT(140.0, DoubleNear(j_val[0], EPS));
+    EXPECT_THAT(520.0, DoubleNear(j_val[1], EPS));
+  }
+
+  // Absolute position interface
+  {
+    auto a1_handle = ActuatorHandle("act1", HW_IF_ABSOLUTE_POSITION, a_vec[0]);
+    auto a2_handle = ActuatorHandle("act2", HW_IF_ABSOLUTE_POSITION, a_vec[1]);
+    auto joint1_handle = JointHandle("joint1", HW_IF_ABSOLUTE_POSITION, j_vec[0]);
+    auto joint2_handle = JointHandle("joint2", HW_IF_ABSOLUTE_POSITION, j_vec[1]);
     trans.configure({joint1_handle, joint2_handle}, {a1_handle, a2_handle});
     trans.actuator_to_joint();
     EXPECT_THAT(-2.01250, DoubleNear(j_val[0], EPS));

--- a/transmission_interface/test/simple_transmission_test.cpp
+++ b/transmission_interface/test/simple_transmission_test.cpp
@@ -20,9 +20,11 @@
 
 using hardware_interface::HW_IF_EFFORT;
 using hardware_interface::HW_IF_POSITION;
+using hardware_interface::HW_IF_TORQUE;
 using hardware_interface::HW_IF_VELOCITY;
 using transmission_interface::ActuatorHandle;
 using transmission_interface::Exception;
+using transmission_interface::HW_IF_ABSOLUTE_POSITION;
 using transmission_interface::JointHandle;
 using transmission_interface::SimpleTransmission;
 
@@ -118,18 +120,15 @@ protected:
   void testIdentityMap(
     SimpleTransmission & trans, const std::string & interface_name, const double ref_val)
   {
-    // Effort interface
-    {
-      auto actuator_handle = ActuatorHandle("act1", interface_name, &a_val);
-      auto joint_handle = JointHandle("joint1", interface_name, &j_val);
-      trans.configure({joint_handle}, {actuator_handle});
+    auto actuator_handle = ActuatorHandle("act1", interface_name, &a_val);
+    auto joint_handle = JointHandle("joint1", interface_name, &j_val);
+    trans.configure({joint_handle}, {actuator_handle});
 
-      a_val = ref_val;
+    a_val = ref_val;
 
-      trans.actuator_to_joint();
-      trans.joint_to_actuator();
-      EXPECT_THAT(ref_val, DoubleNear(a_val, EPS));
-    }
+    trans.actuator_to_joint();
+    trans.joint_to_actuator();
+    EXPECT_THAT(ref_val, DoubleNear(a_val, EPS));
   }
 };
 
@@ -158,6 +157,18 @@ TEST_P(BlackBoxTest, IdentityMap)
   testIdentityMap(trans, HW_IF_EFFORT, 0.0);
   reset_values();
   testIdentityMap(trans, HW_IF_EFFORT, -1.0);
+
+  testIdentityMap(trans, HW_IF_TORQUE, 1.0);
+  reset_values();
+  testIdentityMap(trans, HW_IF_TORQUE, 0.0);
+  reset_values();
+  testIdentityMap(trans, HW_IF_TORQUE, -1.0);
+
+  testIdentityMap(trans, HW_IF_ABSOLUTE_POSITION, 1.0);
+  reset_values();
+  testIdentityMap(trans, HW_IF_ABSOLUTE_POSITION, 0.0);
+  reset_values();
+  testIdentityMap(trans, HW_IF_ABSOLUTE_POSITION, -1.0);
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -205,6 +216,26 @@ TEST_F(WhiteBoxTest, MoveJoint)
   {
     auto actuator_handle = ActuatorHandle("act1", HW_IF_POSITION, &a_val);
     auto joint_handle = JointHandle("joint1", HW_IF_POSITION, &j_val);
+    trans.configure({joint_handle}, {actuator_handle});
+
+    trans.actuator_to_joint();
+    EXPECT_THAT(1.1, DoubleNear(j_val, EPS));
+  }
+
+  // Torque interface
+  {
+    auto actuator_handle = ActuatorHandle("act1", HW_IF_TORQUE, &a_val);
+    auto joint_handle = JointHandle("joint1", HW_IF_TORQUE, &j_val);
+    trans.configure({joint_handle}, {actuator_handle});
+
+    trans.actuator_to_joint();
+    EXPECT_THAT(10.0, DoubleNear(j_val, EPS));
+  }
+
+  // Absolute position interface
+  {
+    auto actuator_handle = ActuatorHandle("act1", HW_IF_ABSOLUTE_POSITION, &a_val);
+    auto joint_handle = JointHandle("joint1", HW_IF_ABSOLUTE_POSITION, &j_val);
     trans.configure({joint_handle}, {actuator_handle});
 
     trans.actuator_to_joint();


### PR DESCRIPTION
This PR adds the torque and absolute position interface to the simple and differential transmissions.

The torque formula is the same used for effort and the absolute position the same as the position.

Adding these two new interfaces is backwards compatible. If torque and absolute position interfaces are not available then the new contents from this PR do nothing.