### PR TITLE
Deactivate controllers with command interfaces to hardware on DEACTIVATE

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2720,7 +2720,6 @@ void ControllerManager::read(const rclcpp::Time & time, const rclcpp::Duration &
         // if this controller has command interfaces add it to the deactivate_controllers_list
         if (!command_interface_names.empty())
         {
-          RCLCPP_ERROR(get_logger(), "Deactivating controller: [%s]", controller.c_str());
           rt_buffer_.deactivate_controllers_list.push_back(controller);
         }
       }
@@ -3037,7 +3036,6 @@ void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration 
         // if this controller has command interfaces add it to the deactivate_controllers_list
         if (!command_interface_names.empty())
         {
-          RCLCPP_ERROR(get_logger(), "Deactivating controller: [%s]", controller.c_str());
           rt_buffer_.deactivate_controllers_list.push_back(controller);
         }
       }

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2663,9 +2663,9 @@ std::vector<std::string> ControllerManager::get_controller_names()
 void ControllerManager::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   periodicity_stats_.AddMeasurement(1.0 / period.seconds());
-  auto [ok, failed_hardware_names] = resource_manager_->read(time, period);
+  auto [result, failed_hardware_names] = resource_manager_->read(time, period);
 
-  if (!ok)
+  if (result == hardware_interface::return_type::ERROR)
   {
     rt_buffer_.deactivate_controllers_list.clear();
     // Determine controllers to stop
@@ -2690,6 +2690,52 @@ void ControllerManager::read(const rclcpp::Time & time, const rclcpp::Duration &
       rt_controller_list, {}, rt_buffer_.deactivate_controllers_list, "read");
     deactivate_controllers(rt_controller_list, rt_buffer_.deactivate_controllers_list);
     // TODO(destogl): do auto-start of broadcasters
+  }
+  else if (result == hardware_interface::return_type::DEACTIVATE)
+  {
+    rt_buffer_.deactivate_controllers_list.clear();
+    auto loaded_controllers = get_loaded_controllers();
+    // Only stop controllers with active command interfaces to the failed_hardware_names
+    for (const auto & hardware_name : failed_hardware_names)
+    {
+      auto controllers = resource_manager_->get_cached_controllers_to_hardware(hardware_name);
+      for (const auto & controller : controllers)
+      {
+        auto controller_spec = std::find_if(
+          loaded_controllers.begin(), loaded_controllers.end(),
+          [&](const controller_manager::ControllerSpec & spec)
+          { return spec.c->get_name() == controller; });
+        if (controller_spec == loaded_controllers.end())
+        {
+          RCLCPP_WARN(
+            get_logger(),
+            "Deactivate failed to find controller [%s] in loaded controllers. "
+            "This can happen due to multiple returns of 'DEACTIVATE' from [%s] read()",
+            controller.c_str(), hardware_name.c_str());
+          continue;
+        }
+        std::vector<std::string> command_interface_names;
+        extract_command_interfaces_for_controller(
+          *controller_spec, resource_manager_, command_interface_names);
+        // if this controller has command interfaces add it to the deactivate_controllers_list
+        if (!command_interface_names.empty())
+        {
+          RCLCPP_ERROR(get_logger(), "Deactivating controller: [%s]", controller.c_str());
+          rt_buffer_.deactivate_controllers_list.push_back(controller);
+        }
+      }
+    }
+    RCLCPP_ERROR_EXPRESSION(
+      get_logger(), !rt_buffer_.deactivate_controllers_list.empty(),
+      "Deactivating controllers [%s] as their command interfaces are tied to DEACTIVATEing "
+      "hardware components",
+      rt_buffer_.get_concatenated_string(rt_buffer_.deactivate_controllers_list).c_str());
+    std::vector<ControllerSpec> & rt_controller_list =
+      rt_controllers_wrapper_.update_and_get_used_by_rt_list();
+
+    perform_hardware_command_mode_change(
+      rt_controller_list, {}, rt_buffer_.deactivate_controllers_list, "write");
+    deactivate_controllers(rt_controller_list, rt_buffer_.deactivate_controllers_list);
   }
 }
 
@@ -2932,9 +2978,9 @@ controller_interface::return_type ControllerManager::update(
 
 void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
-  auto [ok, failed_hardware_names] = resource_manager_->write(time, period);
+  auto [result, failed_hardware_names] = resource_manager_->write(time, period);
 
-  if (!ok)
+  if (result == hardware_interface::return_type::ERROR)
   {
     rt_buffer_.deactivate_controllers_list.clear();
     // Determine controllers to stop
@@ -2961,6 +3007,52 @@ void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration 
       rt_controller_list, {}, rt_buffer_.deactivate_controllers_list, "write");
     deactivate_controllers(rt_controller_list, rt_buffer_.deactivate_controllers_list);
     // TODO(destogl): do auto-start of broadcasters
+  }
+  else if (result == hardware_interface::return_type::DEACTIVATE)
+  {
+    rt_buffer_.deactivate_controllers_list.clear();
+    auto loaded_controllers = get_loaded_controllers();
+    // Only stop controllers with active command interfaces to the failed_hardware_names
+    for (const auto & hardware_name : failed_hardware_names)
+    {
+      auto controllers = resource_manager_->get_cached_controllers_to_hardware(hardware_name);
+      for (const auto & controller : controllers)
+      {
+        auto controller_spec = std::find_if(
+          loaded_controllers.begin(), loaded_controllers.end(),
+          [&](const controller_manager::ControllerSpec & spec)
+          { return spec.c->get_name() == controller; });
+        if (controller_spec == loaded_controllers.end())
+        {
+          RCLCPP_WARN(
+            get_logger(),
+            "Deactivate failed to find controller [%s] in loaded controllers. "
+            "This can happen due to multiple returns of 'DEACTIVATE' from [%s] write()",
+            controller.c_str(), hardware_name.c_str());
+          continue;
+        }
+        std::vector<std::string> command_interface_names;
+        extract_command_interfaces_for_controller(
+          *controller_spec, resource_manager_, command_interface_names);
+        // if this controller has command interfaces add it to the deactivate_controllers_list
+        if (!command_interface_names.empty())
+        {
+          RCLCPP_ERROR(get_logger(), "Deactivating controller: [%s]", controller.c_str());
+          rt_buffer_.deactivate_controllers_list.push_back(controller);
+        }
+      }
+    }
+    RCLCPP_ERROR_EXPRESSION(
+      get_logger(), !rt_buffer_.deactivate_controllers_list.empty(),
+      "Deactivating controllers [%s] as their command interfaces are tied to DEACTIVATEing "
+      "hardware components",
+      rt_buffer_.get_concatenated_string(rt_buffer_.deactivate_controllers_list).c_str());
+    std::vector<ControllerSpec> & rt_controller_list =
+      rt_controllers_wrapper_.update_and_get_used_by_rt_list();
+
+    perform_hardware_command_mode_change(
+      rt_controller_list, {}, rt_buffer_.deactivate_controllers_list, "write");
+    deactivate_controllers(rt_controller_list, rt_buffer_.deactivate_controllers_list);
   }
 }
 

--- a/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
+++ b/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
@@ -46,7 +46,6 @@ class TestableControllerManager : public controller_manager::ControllerManager
 
   FRIEND_TEST(TestControllerManagerWithTestableCM, check_cached_controllers_for_hardware);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_error);
-  FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_deactivate);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_error);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_deactivate);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_multiple_hardware_error);
@@ -430,125 +429,10 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_er
     EXPECT_LE(test_broadcaster_all->internal_counter, previous_counter_higher);
     EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
   }
-}
-
-TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_deactivate)
-{
-  auto strictness = GetParam().strictness;
-  SetupAndConfigureControllers(strictness);
-
-  rclcpp_lifecycle::State state_active(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    hardware_interface::lifecycle_state_names::ACTIVE);
-
-  {
-    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
-    EXPECT_GE(test_controller_actuator->internal_counter, 1u)
-      << "Controller is started at the end of update";
-    EXPECT_GE(test_controller_system->internal_counter, 1u)
-      << "Controller is started at the end of update";
-    EXPECT_GE(test_broadcaster_all->internal_counter, 1u)
-      << "Controller is started at the end of update";
-    EXPECT_GE(test_broadcaster_sensor->internal_counter, 1u)
-      << "Controller is started at the end of update";
-  }
-
-  EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller_actuator->get_lifecycle_state().id());
-  EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_controller_system->get_lifecycle_state().id());
-  EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_broadcaster_all->get_lifecycle_state().id());
-  EXPECT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-    test_broadcaster_sensor->get_lifecycle_state().id());
-
-  // Execute first time without any errors
-  {
-    auto new_counter = test_controller_actuator->internal_counter + 1;
-    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
-    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter) << "Execute without errors";
-    EXPECT_EQ(test_controller_system->internal_counter, new_counter) << "Execute without errors";
-    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter) << "Execute without errors";
-    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter) << "Execute without errors";
-  }
-
-  // Simulate deactivate in read() on TEST_ACTUATOR_HARDWARE_NAME by setting first command interface
-  // to READ_DEACTIVATE_VALUE
-  test_controller_actuator->set_first_command_interface_value_to =
-    test_constants::READ_DEACTIVATE_VALUE;
-  {
-    auto new_counter = test_controller_actuator->internal_counter + 1;
-    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
-    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter)
-      << "Execute without errors to write value";
-    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
-      << "Execute without errors to write value";
-    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
-      << "Execute without errors to write value";
-    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
-      << "Execute without errors to write value";
-  }
-
-  {
-    auto previous_counter = test_controller_actuator->internal_counter;
-    auto new_counter = test_controller_system->internal_counter + 1;
-
-    // here happens deactivate in hardware and
-    // "actuator controller" is deactivated but "broadcaster all" should stay active
-    EXPECT_NO_THROW(cm_->read(time_, PERIOD));
-    EXPECT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
-      test_controller_actuator->get_lifecycle_state().id());
-    EXPECT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      test_controller_system->get_lifecycle_state().id());
-    EXPECT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      test_broadcaster_all->get_lifecycle_state().id());
-    EXPECT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
-      test_broadcaster_sensor->get_lifecycle_state().id());
-
-    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
-    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter)
-      << "Execute has read error and it is not updated";
-    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
-      << "Execute without errors to write value";
-    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
-      << "Broadcaster for all interfaces is not updated";
-    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
-      << "Execute without errors to write value";
-  }
-
-  // Recover hardware and activate again all controllers
-  {
-    ASSERT_EQ(
-      cm_->resource_manager_->set_component_state(
-        ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME, state_active),
-      hardware_interface::return_type::OK);
-    auto status_map = cm_->resource_manager_->get_components_status();
-    ASSERT_EQ(
-      status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
-
-    auto previous_counter_lower = test_controller_actuator->internal_counter;
-    auto previous_counter_higher = test_controller_system->internal_counter;
-
-    switch_test_controllers({TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
-
-    EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
-    EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
-    EXPECT_GT(test_controller_system->internal_counter, previous_counter_higher);
-    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
-    EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
-  }
 
   // Simulate deactivate in read() on TEST_ACTUATOR_HARDWARE_NAME and TEST_SYSTEM_HARDWARE_NAME
   // by setting first command interface to READ_DEACTIVATE_VALUE
+  // (this should be the same as returning ERROR)
   test_controller_actuator->set_first_command_interface_value_to =
     test_constants::READ_DEACTIVATE_VALUE;
   test_controller_system->set_first_command_interface_value_to =
@@ -556,6 +440,7 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_de
   {
     auto previous_counter_lower = test_controller_actuator->internal_counter + 1;
     auto previous_counter_higher = test_controller_system->internal_counter + 1;
+    auto new_counter = test_broadcaster_sensor->internal_counter + 1;
 
     EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
 
@@ -563,9 +448,9 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_de
       << "Execute without errors to write value";
     EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
       << "Execute without errors to write value";
-    EXPECT_EQ(test_broadcaster_all->internal_counter, previous_counter_higher)
+    EXPECT_EQ(test_broadcaster_all->internal_counter, previous_counter_lower)
       << "Execute without errors to write value";
-    EXPECT_EQ(test_broadcaster_sensor->internal_counter, previous_counter_higher)
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
       << "Execute without errors to write value";
   }
 
@@ -582,7 +467,7 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_de
       lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
       test_controller_system->get_lifecycle_state().id());
     EXPECT_EQ(
-      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
       test_broadcaster_all->get_lifecycle_state().id());
     EXPECT_EQ(
       lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
@@ -593,7 +478,7 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_de
       << "Execute has read error and it is not updated";
     EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
       << "Execute has read error and it is not updated";
-    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+    EXPECT_EQ(test_broadcaster_all->internal_counter, previous_counter_lower)
       << "Broadcaster for all interfaces is not updated";
     EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
       << "Execute without errors to write value";
@@ -622,13 +507,15 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_de
     auto previous_counter_higher = test_broadcaster_sensor->internal_counter;
 
     switch_test_controllers(
-      {TEST_CONTROLLER_SYSTEM_NAME, TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
+      {TEST_CONTROLLER_SYSTEM_NAME, TEST_CONTROLLER_ACTUATOR_NAME, TEST_BROADCASTER_ALL_NAME}, {},
+      strictness);
 
     EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
     EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
     EXPECT_GT(test_controller_system->internal_counter, previous_counter);
     EXPECT_LE(test_controller_system->internal_counter, previous_counter_higher);
-    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_lower);
+    EXPECT_LE(test_broadcaster_all->internal_counter, previous_counter_higher);
     EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
   }
 }

--- a/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
+++ b/controller_manager/test/test_controller_manager_hardware_error_handling.cpp
@@ -46,7 +46,9 @@ class TestableControllerManager : public controller_manager::ControllerManager
 
   FRIEND_TEST(TestControllerManagerWithTestableCM, check_cached_controllers_for_hardware);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_error);
+  FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_deactivate);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_error);
+  FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_deactivate);
   FRIEND_TEST(TestControllerManagerWithTestableCM, stop_controllers_on_multiple_hardware_error);
 
 public:
@@ -430,6 +432,207 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_er
   }
 }
 
+TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_read_deactivate)
+{
+  auto strictness = GetParam().strictness;
+  SetupAndConfigureControllers(strictness);
+
+  rclcpp_lifecycle::State state_active(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    hardware_interface::lifecycle_state_names::ACTIVE);
+
+  {
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_GE(test_controller_actuator->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_controller_system->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_broadcaster_all->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_broadcaster_sensor->internal_counter, 1u)
+      << "Controller is started at the end of update";
+  }
+
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_controller_actuator->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_controller_system->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_broadcaster_all->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_broadcaster_sensor->get_lifecycle_state().id());
+
+  // Execute first time without any errors
+  {
+    auto new_counter = test_controller_actuator->internal_counter + 1;
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter) << "Execute without errors";
+  }
+
+  // Simulate deactivate in read() on TEST_ACTUATOR_HARDWARE_NAME by setting first command interface
+  // to READ_DEACTIVATE_VALUE
+  test_controller_actuator->set_first_command_interface_value_to =
+    test_constants::READ_DEACTIVATE_VALUE;
+  {
+    auto new_counter = test_controller_actuator->internal_counter + 1;
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  {
+    auto previous_counter = test_controller_actuator->internal_counter;
+    auto new_counter = test_controller_system->internal_counter + 1;
+
+    // here happens deactivate in hardware and
+    // "actuator controller" is deactivated but "broadcaster all" should stay active
+    EXPECT_NO_THROW(cm_->read(time_, PERIOD));
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_actuator->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_controller_system->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_all->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_sensor->get_lifecycle_state().id());
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter)
+      << "Execute has read error and it is not updated";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Broadcaster for all interfaces is not updated";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  // Recover hardware and activate again all controllers
+  {
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    auto status_map = cm_->resource_manager_->get_components_status();
+    ASSERT_EQ(
+      status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter_higher = test_controller_system->internal_counter;
+
+    switch_test_controllers({TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
+
+    EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
+    EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_controller_system->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
+  }
+
+  // Simulate deactivate in read() on TEST_ACTUATOR_HARDWARE_NAME and TEST_SYSTEM_HARDWARE_NAME
+  // by setting first command interface to READ_DEACTIVATE_VALUE
+  test_controller_actuator->set_first_command_interface_value_to =
+    test_constants::READ_DEACTIVATE_VALUE;
+  test_controller_system->set_first_command_interface_value_to =
+    test_constants::READ_DEACTIVATE_VALUE;
+  {
+    auto previous_counter_lower = test_controller_actuator->internal_counter + 1;
+    auto previous_counter_higher = test_controller_system->internal_counter + 1;
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter_lower)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+  }
+
+  {
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter_higher = test_controller_system->internal_counter;
+    auto new_counter = test_broadcaster_sensor->internal_counter + 1;
+
+    EXPECT_NO_THROW(cm_->read(time_, PERIOD));
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_actuator->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_system->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_all->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_sensor->get_lifecycle_state().id());
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter_lower)
+      << "Execute has read error and it is not updated";
+    EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
+      << "Execute has read error and it is not updated";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Broadcaster for all interfaces is not updated";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  // Recover hardware and activate again all controllers
+  {
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_SYSTEM_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    auto status_map = cm_->resource_manager_->get_components_status();
+    ASSERT_EQ(
+      status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+    ASSERT_EQ(
+      status_map[TEST_SYSTEM_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter = test_controller_system->internal_counter;
+    auto previous_counter_higher = test_broadcaster_sensor->internal_counter;
+
+    switch_test_controllers(
+      {TEST_CONTROLLER_SYSTEM_NAME, TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
+
+    EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
+    EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_controller_system->internal_counter, previous_counter);
+    EXPECT_LE(test_controller_system->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
+  }
+}
+
 TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_controller_error)
 {
   auto strictness = GetParam().strictness;
@@ -741,6 +944,209 @@ TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_e
     EXPECT_LE(test_controller_system->internal_counter, previous_counter_higher);
     EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_lower);
     EXPECT_LE(test_broadcaster_all->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
+  }
+}
+
+TEST_P(TestControllerManagerWithTestableCM, stop_controllers_on_hardware_write_deactivate)
+{
+  auto strictness = GetParam().strictness;
+  SetupAndConfigureControllers(strictness);
+
+  rclcpp_lifecycle::State state_active(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    hardware_interface::lifecycle_state_names::ACTIVE);
+
+  {
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_GE(test_controller_actuator->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_controller_system->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_broadcaster_all->internal_counter, 1u)
+      << "Controller is started at the end of update";
+    EXPECT_GE(test_broadcaster_sensor->internal_counter, 1u)
+      << "Controller is started at the end of update";
+  }
+
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_controller_actuator->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_controller_system->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_broadcaster_all->get_lifecycle_state().id());
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+    test_broadcaster_sensor->get_lifecycle_state().id());
+
+  // Execute first time without any errors
+  {
+    auto new_counter = test_controller_actuator->internal_counter + 1;
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter) << "Execute without errors";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter) << "Execute without errors";
+  }
+
+  // Simulate deactivate in write() on TEST_ACTUATOR_HARDWARE_NAME by setting first command
+  // interface to WRITE_DEACTIVATE_VALUE
+  test_controller_actuator->set_first_command_interface_value_to =
+    test_constants::WRITE_DEACTIVATE_VALUE;
+  {
+    auto new_counter = test_controller_actuator->internal_counter + 1;
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  {
+    auto previous_counter = test_controller_actuator->internal_counter;
+    auto new_counter = test_controller_system->internal_counter + 1;
+
+    // here happens deactivate in hardware and
+    // "actuator controller" is deactivated but "broadcaster all" should stay active
+    EXPECT_NO_THROW(cm_->write(time_, PERIOD));
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_actuator->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_controller_system->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_all->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_sensor->get_lifecycle_state().id());
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_controller_system->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  // Recover hardware and activate again all controllers
+  {
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    auto status_map = cm_->resource_manager_->get_components_status();
+    ASSERT_EQ(
+      status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter_higher = test_controller_system->internal_counter;
+
+    switch_test_controllers({TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
+
+    EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
+    EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_controller_system->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
+  }
+
+  // Simulate deactivate in write() on TEST_ACTUATOR_HARDWARE_NAME and TEST_SYSTEM_HARDWARE_NAME
+  // by setting first command interface to WRITE_DEACTIVATE_VALUE
+  test_controller_actuator->set_first_command_interface_value_to =
+    test_constants::WRITE_DEACTIVATE_VALUE;
+  test_controller_system->set_first_command_interface_value_to =
+    test_constants::WRITE_DEACTIVATE_VALUE;
+  {
+    auto previous_counter_lower = test_controller_actuator->internal_counter + 1;
+    auto previous_counter_higher = test_controller_system->internal_counter + 1;
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter_lower)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, previous_counter_higher)
+      << "Execute without errors to write value";
+  }
+
+  {
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter_higher = test_controller_system->internal_counter;
+    auto new_counter = test_broadcaster_sensor->internal_counter + 1;
+
+    // here happens deactivate in hardware and
+    // "actuator controller" is deactivated but "broadcaster's" should stay active
+    EXPECT_NO_THROW(cm_->write(time_, PERIOD));
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_actuator->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+      test_controller_system->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_all->get_lifecycle_state().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
+      test_broadcaster_sensor->get_lifecycle_state().id());
+
+    EXPECT_EQ(controller_interface::return_type::OK, cm_->update(time_, PERIOD));
+    EXPECT_EQ(test_controller_actuator->internal_counter, previous_counter_lower)
+      << "Execute has write error and it is not updated";
+    EXPECT_EQ(test_controller_system->internal_counter, previous_counter_higher)
+      << "Execute has write error and it is not updated";
+    EXPECT_EQ(test_broadcaster_all->internal_counter, new_counter)
+      << "Broadcaster for all interfaces is not updated";
+    EXPECT_EQ(test_broadcaster_sensor->internal_counter, new_counter)
+      << "Execute without errors to write value";
+  }
+
+  // Recover hardware and activate again all controllers
+  {
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_ACTUATOR_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    ASSERT_EQ(
+      cm_->resource_manager_->set_component_state(
+        ros2_control_test_assets::TEST_SYSTEM_HARDWARE_NAME, state_active),
+      hardware_interface::return_type::OK);
+    auto status_map = cm_->resource_manager_->get_components_status();
+    ASSERT_EQ(
+      status_map[TEST_ACTUATOR_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+    ASSERT_EQ(
+      status_map[TEST_SYSTEM_HARDWARE_NAME].state.id(),
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+    auto previous_counter_lower = test_controller_actuator->internal_counter;
+    auto previous_counter = test_controller_system->internal_counter;
+    auto previous_counter_higher = test_broadcaster_sensor->internal_counter;
+
+    switch_test_controllers(
+      {TEST_CONTROLLER_SYSTEM_NAME, TEST_CONTROLLER_ACTUATOR_NAME}, {}, strictness);
+
+    EXPECT_GT(test_controller_actuator->internal_counter, previous_counter_lower);
+    EXPECT_LE(test_controller_actuator->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_controller_system->internal_counter, previous_counter);
+    EXPECT_LE(test_controller_system->internal_counter, previous_counter_higher);
+    EXPECT_GT(test_broadcaster_all->internal_counter, previous_counter_higher);
     EXPECT_GT(test_broadcaster_sensor->internal_counter, previous_counter_higher);
   }
 }

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -43,7 +43,7 @@ class ControllerManager;
 
 struct HardwareReadWriteStatus
 {
-  bool ok;
+  return_type result;
   std::vector<std::string> failed_hardware_names;
 };
 

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -2388,16 +2388,13 @@ HardwareReadWriteStatus ResourceManager::read(
           component_name.c_str());
         ret_val = return_type::ERROR;
       }
-      if (ret_val == hardware_interface::return_type::DEACTIVATE)
-      {
-        RCLCPP_WARN(
-          get_logger(), "DEACTIVATE returned from read cycle is treated the same as ERROR.");
-        ret_val = hardware_interface::return_type::ERROR;
-      }
-      if (ret_val == return_type::ERROR)
+      RCLCPP_WARN_EXPRESSION(
+        get_logger(), ret_val == hardware_interface::return_type::DEACTIVATE,
+        "DEACTIVATE returned from read cycle is treated the same as ERROR.");
+      if (ret_val != return_type::OK)
       {
         component.error();
-        read_write_status.result = ret_val;
+        read_write_status.result = return_type::ERROR;
         read_write_status.failed_hardware_names.push_back(component_name);
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component_name);
       }

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -2307,20 +2307,18 @@ HardwareReadWriteStatus ResourceManager::read(
           component_name.c_str());
         ret_val = return_type::ERROR;
       }
+      if (ret_val == hardware_interface::return_type::DEACTIVATE)
+      {
+        RCLCPP_WARN(
+          get_logger(), "DEACTIVATE returned from read cycle is treated the same as ERROR.");
+        ret_val = hardware_interface::return_type::ERROR;
+      }
       if (ret_val == return_type::ERROR)
       {
         component.error();
         read_write_status.result = ret_val;
         read_write_status.failed_hardware_names.push_back(component_name);
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component_name);
-      }
-      else if (ret_val == return_type::DEACTIVATE)
-      {
-        rclcpp_lifecycle::State inactive_state(
-          lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_state_names::INACTIVE);
-        set_component_state(component_name, inactive_state);
-        read_write_status.result = ret_val;
-        read_write_status.failed_hardware_names.push_back(component_name);
       }
     }
   };

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -2232,7 +2232,7 @@ bool ResourceManager::enforce_command_limits(const rclcpp::Duration & period)
 HardwareReadWriteStatus ResourceManager::read(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
-  read_write_status.ok = true;
+  read_write_status.result = return_type::OK;
   read_write_status.failed_hardware_names.clear();
 
   // This is needed while we load and initialize the components
@@ -2310,7 +2310,7 @@ HardwareReadWriteStatus ResourceManager::read(
       if (ret_val == return_type::ERROR)
       {
         component.error();
-        read_write_status.ok = false;
+        read_write_status.result = ret_val;
         read_write_status.failed_hardware_names.push_back(component_name);
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component_name);
       }
@@ -2319,14 +2319,9 @@ HardwareReadWriteStatus ResourceManager::read(
         rclcpp_lifecycle::State inactive_state(
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_state_names::INACTIVE);
         set_component_state(component_name, inactive_state);
+        read_write_status.result = ret_val;
+        read_write_status.failed_hardware_names.push_back(component_name);
       }
-      // If desired: automatic re-activation. We could add a flag for this...
-      // else
-      // {
-      // using lifecycle_msgs::msg::State;
-      // rclcpp_lifecycle::State state(State::PRIMARY_STATE_ACTIVE, lifecycle_state_names::ACTIVE);
-      // set_component_state(component.get_name(), state);
-      // }
     }
   };
 
@@ -2341,7 +2336,7 @@ HardwareReadWriteStatus ResourceManager::read(
 HardwareReadWriteStatus ResourceManager::write(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & period)
 {
-  read_write_status.ok = true;
+  read_write_status.result = return_type::OK;
   read_write_status.failed_hardware_names.clear();
 
   // This is needed while we load and initialize the components
@@ -2420,7 +2415,7 @@ HardwareReadWriteStatus ResourceManager::write(
       if (ret_val == return_type::ERROR)
       {
         component.error();
-        read_write_status.ok = false;
+        read_write_status.result = ret_val;
         read_write_status.failed_hardware_names.push_back(component_name);
         resource_storage_->remove_all_hardware_interfaces_from_available_list(component_name);
       }
@@ -2429,6 +2424,8 @@ HardwareReadWriteStatus ResourceManager::write(
         rclcpp_lifecycle::State inactive_state(
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, lifecycle_state_names::INACTIVE);
         set_component_state(component_name, inactive_state);
+        read_write_status.result = ret_val;
+        read_write_status.failed_hardware_names.push_back(component_name);
       }
     }
   };

--- a/hardware_interface/src/system.cpp
+++ b/hardware_interface/src/system.cpp
@@ -372,9 +372,8 @@ return_type System::write(const rclcpp::Time & time, const rclcpp::Duration & pe
     last_write_cycle_time_ = time;
     return return_type::OK;
   }
-  if (
-    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
-    impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+  // only call write in the active state
+  if (impl_->get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
   {
     const auto trigger_result = impl_->trigger_write(time, period);
     if (trigger_result.result == return_type::ERROR)

--- a/hardware_interface/test/mock_components/test_generic_system.cpp
+++ b/hardware_interface/test/mock_components/test_generic_system.cpp
@@ -895,7 +895,7 @@ void generic_system_functional_test(
   ASSERT_EQ(0.44, j2v_c.get_optional().value());
 
   // write() does not change values
-  ASSERT_TRUE(rm.write(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.write(TIME, PERIOD).result, hardware_interface::return_type::OK);
   ASSERT_EQ(3.45, j1p_s.get_optional().value());
   ASSERT_EQ(0.0, j1v_s.get_optional().value());
   ASSERT_EQ(2.78, j2p_s.get_optional().value());
@@ -906,7 +906,7 @@ void generic_system_functional_test(
   ASSERT_EQ(0.44, j2v_c.get_optional().value());
 
   // read() mirrors commands + offset to states
-  ASSERT_TRUE(rm.read(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.read(TIME, PERIOD).result, hardware_interface::return_type::OK);
   ASSERT_EQ(0.11 + offset, j1p_s.get_optional().value());
   ASSERT_EQ(0.22, j1v_s.get_optional().value());
   ASSERT_EQ(0.33 + offset, j2p_s.get_optional().value());
@@ -1001,7 +1001,7 @@ void generic_system_error_group_test(
   ASSERT_EQ(0.44, j2v_c.get_optional().value());
 
   // write() does not change values
-  ASSERT_TRUE(rm.write(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.write(TIME, PERIOD).result, hardware_interface::return_type::OK);
   ASSERT_EQ(3.45, j1p_s.get_optional().value());
   ASSERT_EQ(0.0, j1v_s.get_optional().value());
   ASSERT_EQ(2.78, j2p_s.get_optional().value());
@@ -1012,7 +1012,7 @@ void generic_system_error_group_test(
   ASSERT_EQ(0.44, j2v_c.get_optional().value());
 
   // read() mirrors commands to states
-  ASSERT_TRUE(rm.read(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.read(TIME, PERIOD).result, hardware_interface::return_type::OK);
   ASSERT_EQ(0.11, j1p_s.get_optional().value());
   ASSERT_EQ(0.22, j1v_s.get_optional().value());
   ASSERT_EQ(0.33, j2p_s.get_optional().value());
@@ -1043,7 +1043,7 @@ void generic_system_error_group_test(
   ASSERT_TRUE(j1v_c.set_value(std::numeric_limits<double>::infinity()));
   // read() should now bring error in the first component
   auto read_result = rm.read(TIME, PERIOD);
-  ASSERT_FALSE(read_result.ok);
+  EXPECT_EQ(read_result.result, hardware_interface::return_type::ERROR);
   if (validate_same_group)
   {
     // If they belong to the same group, show the error in all hardware components of same group
@@ -1079,12 +1079,12 @@ void generic_system_error_group_test(
   // Error should be recoverable only after reactivating the hardware component
   ASSERT_TRUE(j1p_c.set_value(0.0));
   ASSERT_TRUE(j1v_c.set_value(0.0));
-  ASSERT_FALSE(rm.read(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.read(TIME, PERIOD).result, hardware_interface::return_type::ERROR);
 
   // Now it should be recoverable
   deactivate_components(rm, {component1});
   activate_components(rm, {component1});
-  ASSERT_TRUE(rm.read(TIME, PERIOD).ok);
+  EXPECT_EQ(rm.read(TIME, PERIOD).result, hardware_interface::return_type::OK);
 
   deactivate_components(rm, {component1, component2});
   status_map = rm.get_components_status();

--- a/hardware_interface/test/test_component_interfaces.cpp
+++ b/hardware_interface/test/test_component_interfaces.cpp
@@ -1184,7 +1184,26 @@ TEST(TestComponentInterfaces, dummy_system)
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::INACTIVE, state.label());
 
-  // Read and Write are working because it is INACTIVE
+  // Values should 0 because only read should work when INACTIVE
+  for (auto step = 0u; step < 10; ++step)
+  {
+    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
+
+    EXPECT_EQ(0, state_interfaces[0]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[1]->get_optional().value());  // velocity
+    EXPECT_EQ(0, state_interfaces[2]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[3]->get_optional().value());  // velocity
+    EXPECT_EQ(0, state_interfaces[4]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[5]->get_optional().value());  // velocity
+
+    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
+  }
+
+  state = system_hw.activate();
+  EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_EQ(hardware_interface::lifecycle_state_names::ACTIVE, state.label());
+
+  // Read and Write are working because it is ACTIVE
   for (auto step = 0u; step < 10; ++step)
   {
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
@@ -1202,31 +1221,6 @@ TEST(TestComponentInterfaces, dummy_system)
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
   }
 
-  state = system_hw.activate();
-  EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state.id());
-  EXPECT_EQ(hardware_interface::lifecycle_state_names::ACTIVE, state.label());
-
-  // Read and Write are working because it is ACTIVE
-  for (auto step = 0u; step < 10; ++step)
-  {
-    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
-
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[0]->get_optional().value());                          // position value
-    EXPECT_EQ(velocity_value, state_interfaces[1]->get_optional().value());  // velocity
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[2]->get_optional().value());                          // position value
-    EXPECT_EQ(velocity_value, state_interfaces[3]->get_optional().value());  // velocity
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[4]->get_optional().value());                          // position value
-    EXPECT_EQ(velocity_value, state_interfaces[5]->get_optional().value());  // velocity
-
-    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
-  }
-
   state = system_hw.shutdown();
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::FINALIZED, state.label());
@@ -1236,11 +1230,11 @@ TEST(TestComponentInterfaces, dummy_system)
   {
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
 
-    EXPECT_EQ(20 * velocity_value, state_interfaces[0]->get_optional().value());  // position value
+    EXPECT_EQ(10 * velocity_value, state_interfaces[0]->get_optional().value());  // position value
     EXPECT_EQ(0.0, state_interfaces[1]->get_optional().value());                  // velocity
-    EXPECT_EQ(20 * velocity_value, state_interfaces[2]->get_optional().value());  // position value
+    EXPECT_EQ(10 * velocity_value, state_interfaces[2]->get_optional().value());  // position value
     EXPECT_EQ(0.0, state_interfaces[3]->get_optional().value());                  // velocity
-    EXPECT_EQ(20 * velocity_value, state_interfaces[4]->get_optional().value());  // position value
+    EXPECT_EQ(10 * velocity_value, state_interfaces[4]->get_optional().value());  // position value
     EXPECT_EQ(0.0, state_interfaces[5]->get_optional().value());                  // velocity
 
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
@@ -1389,7 +1383,26 @@ TEST(TestComponentInterfaces, dummy_system_default)
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::INACTIVE, state.label());
 
-  // Read and Write are working because it is INACTIVE
+  // Values should 0 because only read should work when INACTIVE
+  for (auto step = 0u; step < 10; ++step)
+  {
+    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
+
+    EXPECT_EQ(0, state_interfaces[si_joint1_pos]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[si_joint1_vel]->get_optional().value());  // velocity
+    EXPECT_EQ(0, state_interfaces[si_joint2_pos]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[si_joint2_vel]->get_optional().value());  // velocity
+    EXPECT_EQ(0, state_interfaces[si_joint3_pos]->get_optional().value());  // position value
+    EXPECT_EQ(0, state_interfaces[si_joint3_vel]->get_optional().value());  // velocity
+
+    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
+  }
+
+  state = system_hw.activate();
+  EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state.id());
+  EXPECT_EQ(hardware_interface::lifecycle_state_names::ACTIVE, state.label());
+
+  // Read and Write are working because it is ACTIVE
   for (auto step = 0u; step < 10; ++step)
   {
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
@@ -1416,31 +1429,6 @@ TEST(TestComponentInterfaces, dummy_system_default)
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
   }
 
-  state = system_hw.activate();
-  EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, state.id());
-  EXPECT_EQ(hardware_interface::lifecycle_state_names::ACTIVE, state.label());
-
-  // Read and Write are working because it is ACTIVE
-  for (auto step = 0u; step < 10; ++step)
-  {
-    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
-
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[si_joint1_pos]->get_optional().value());  // position value
-    EXPECT_EQ(velocity_value, state_interfaces[si_joint1_vel]->get_optional().value());  // velocity
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[si_joint2_pos]->get_optional().value());  // position value
-    EXPECT_EQ(velocity_value, state_interfaces[si_joint2_vel]->get_optional().value());  // velocity
-    EXPECT_EQ(
-      (10 + step) * velocity_value,
-      state_interfaces[si_joint3_pos]->get_optional().value());  // position value
-    EXPECT_EQ(velocity_value, state_interfaces[si_joint3_vel]->get_optional().value());  // velocity
-
-    ASSERT_EQ(hardware_interface::return_type::OK, system_hw.write(TIME, PERIOD));
-  }
-
   state = system_hw.shutdown();
   EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, state.id());
   EXPECT_EQ(hardware_interface::lifecycle_state_names::FINALIZED, state.label());
@@ -1451,15 +1439,15 @@ TEST(TestComponentInterfaces, dummy_system_default)
     ASSERT_EQ(hardware_interface::return_type::OK, system_hw.read(TIME, PERIOD));
 
     EXPECT_EQ(
-      20 * velocity_value,
+      10 * velocity_value,
       state_interfaces[si_joint1_pos]->get_optional().value());               // position value
     EXPECT_EQ(0.0, state_interfaces[si_joint1_vel]->get_optional().value());  // velocity
     EXPECT_EQ(
-      20 * velocity_value,
+      10 * velocity_value,
       state_interfaces[si_joint2_pos]->get_optional().value());               // position value
     EXPECT_EQ(0.0, state_interfaces[si_joint2_vel]->get_optional().value());  // velocity
     EXPECT_EQ(
-      20 * velocity_value,
+      10 * velocity_value,
       state_interfaces[si_joint3_pos]->get_optional().value());               // position value
     EXPECT_EQ(0.0, state_interfaces[si_joint3_vel]->get_optional().value());  // velocity
 

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1523,7 +1523,7 @@ public:
     }
   }
 
-  void check_read_or_write_deactivate(
+  void check_write_deactivate(
     FunctionT method_that_deactivates, FunctionT other_method, const double deactivate_value)
   {
     // define state to set components to
@@ -1677,8 +1677,8 @@ TEST_F(ResourceManagerTestReadWriteError, handle_deactivate_on_hardware_read)
   setup_resource_manager_and_do_initial_checks();
 
   using namespace std::placeholders;
-  // check read methods failures
-  check_read_or_write_deactivate(
+  // check read methods failures (DEACTIVATE is the same as ERROR on read)
+  check_read_or_write_failure(
     std::bind(&TestableResourceManager::read, rm, _1, _2),
     std::bind(&TestableResourceManager::write, rm, _1, _2), test_constants::READ_DEACTIVATE_VALUE);
 }
@@ -1689,7 +1689,7 @@ TEST_F(ResourceManagerTestReadWriteError, handle_deactivate_on_hardware_write)
 
   using namespace std::placeholders;
   // check write methods failures
-  check_read_or_write_deactivate(
+  check_write_deactivate(
     std::bind(&TestableResourceManager::write, rm, _1, _2),
     std::bind(&TestableResourceManager::read, rm, _1, _2), test_constants::WRITE_DEACTIVATE_VALUE);
 }

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1367,13 +1367,13 @@ public:
     check_if_interface_available(true, true);
     // with default values read and write should run without any problems
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
     {
-      auto [ok, failed_hardware_names] = rm->write(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->write(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
     check_if_interface_available(true, true);
@@ -1415,8 +1415,8 @@ public:
     ASSERT_TRUE(claimed_itfs[0].set_value(fail_value));
     ASSERT_TRUE(claimed_itfs[1].set_value(fail_value - 10.0));
     {
-      auto [ok, failed_hardware_names] = method_that_fails(time, duration);
-      EXPECT_FALSE(ok);
+      auto [result, failed_hardware_names] = method_that_fails(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::ERROR);
       EXPECT_FALSE(failed_hardware_names.empty());
       ASSERT_THAT(
         failed_hardware_names,
@@ -1441,8 +1441,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1451,8 +1451,8 @@ public:
     ASSERT_TRUE(claimed_itfs[0].set_value(fail_value - 10.0));
     ASSERT_TRUE(claimed_itfs[1].set_value(fail_value));
     {
-      auto [ok, failed_hardware_names] = method_that_fails(time, duration);
-      EXPECT_FALSE(ok);
+      auto [result, failed_hardware_names] = method_that_fails(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::ERROR);
       EXPECT_FALSE(failed_hardware_names.empty());
       ASSERT_THAT(
         failed_hardware_names,
@@ -1477,8 +1477,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1488,8 +1488,8 @@ public:
     ASSERT_TRUE(claimed_itfs[0].set_value(fail_value));
     ASSERT_TRUE(claimed_itfs[1].set_value(fail_value));
     {
-      auto [ok, failed_hardware_names] = method_that_fails(time, duration);
-      EXPECT_FALSE(ok);
+      auto [result, failed_hardware_names] = method_that_fails(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::ERROR);
       EXPECT_FALSE(failed_hardware_names.empty());
       ASSERT_THAT(
         failed_hardware_names,
@@ -1516,8 +1516,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1536,8 +1536,8 @@ public:
     ASSERT_TRUE(claimed_itfs[1].set_value(deactivate_value - 10.0));
     {
       // deactivate on error
-      auto [ok, failed_hardware_names] = method_that_deactivates(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = method_that_deactivates(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       auto status_map = rm->get_components_status();
       EXPECT_EQ(
@@ -1561,8 +1561,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1572,8 +1572,8 @@ public:
     ASSERT_TRUE(claimed_itfs[1].set_value(deactivate_value));
     {
       // deactivate on flag
-      auto [ok, failed_hardware_names] = method_that_deactivates(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = method_that_deactivates(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       auto status_map = rm->get_components_status();
       EXPECT_EQ(
@@ -1596,8 +1596,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1608,8 +1608,8 @@ public:
     ASSERT_TRUE(claimed_itfs[1].set_value(deactivate_value));
     {
       // deactivate on flag
-      auto [ok, failed_hardware_names] = method_that_deactivates(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = method_that_deactivates(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       auto status_map = rm->get_components_status();
       EXPECT_EQ(
@@ -1633,8 +1633,8 @@ public:
     }
     // write is sill OK
     {
-      auto [ok, failed_hardware_names] = other_method(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = other_method(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       check_if_interface_available(true, true);
     }
@@ -1792,15 +1792,15 @@ public:
     check_if_interface_available(true, true);
     // with default values read and write should run without any problems
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
     {
       ASSERT_TRUE(claimed_itfs[0].set_value(10.0));
       ASSERT_TRUE(claimed_itfs[1].set_value(20.0));
-      auto [ok, failed_hardware_names] = rm->write(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->write(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
 
@@ -1839,8 +1839,8 @@ public:
 
     for (size_t i = 1; i < 100; i++)
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       if (i % (cm_update_rate_ / system_rw_rate_) == 0 && test_for_changing_values)
       {
@@ -1881,8 +1881,8 @@ public:
       {
         ASSERT_EQ(state_itfs[1].get_optional().value(), prev_system_state_value);
       }
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_EQ(write_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
 
       if (test_for_changing_values)
@@ -2139,14 +2139,14 @@ TEST_F(
 
   const auto read = [&]()
   {
-    const auto [ok, failed_hardware_names] = rm->read(time, duration);
-    EXPECT_TRUE(ok);
+    const auto [result, failed_hardware_names] = rm->read(time, duration);
+    EXPECT_EQ(result, hardware_interface::return_type::OK);
     EXPECT_TRUE(failed_hardware_names.empty());
   };
   const auto write = [&]()
   {
-    const auto [ok, failed_hardware_names] = rm->write(time, duration);
-    EXPECT_TRUE(ok);
+    const auto [result, failed_hardware_names] = rm->write(time, duration);
+    EXPECT_EQ(result, hardware_interface::return_type::OK);
     EXPECT_TRUE(failed_hardware_names.empty());
   };
 
@@ -2266,15 +2266,15 @@ public:
     check_if_interface_available(true, true);
     // with default values read and write should run without any problems
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_THAT(failed_hardware_names, testing::IsEmpty());
     }
     {
       // claimed_itfs[0].set_value(10.0);
       // claimed_itfs[1].set_value(20.0);
-      auto [ok, failed_hardware_names] = rm->write(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->write(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_THAT(failed_hardware_names, testing::IsEmpty());
     }
     node_.get_clock()->sleep_until(time + duration);
@@ -2311,8 +2311,8 @@ public:
     const double system_increment = 20.0;
     for (size_t i = 1; i < 100; i++)
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
       // The values are computations exactly within the test_components
       if (check_for_updated_values)
@@ -2330,8 +2330,8 @@ public:
         state_itfs[0].get_optional().value(), prev_act_state_value, actuator_increment / 2.0);
       ASSERT_NEAR(
         state_itfs[1].get_optional().value(), prev_system_state_value, system_increment / 2.0);
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_EQ(write_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
       time = node_.get_clock()->now();
@@ -2520,15 +2520,15 @@ public:
     check_if_interface_available(true, true);
     // with default values read and write should run without any problems
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
     {
       ASSERT_TRUE(claimed_itfs[0].set_value(10.0));
       ASSERT_TRUE(claimed_itfs[1].set_value(20.0));
-      auto [ok, failed_hardware_names] = rm->write(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->write(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
     }
 
@@ -2560,15 +2560,15 @@ public:
   void check_limit_enforcement()
   {
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
 
       ASSERT_TRUE(claimed_itfs[0].set_value(2.0));
       ASSERT_TRUE(claimed_itfs[1].set_value(-4.0));
 
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_EQ(write_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
       time = node_.get_clock()->now();
@@ -2577,14 +2577,14 @@ public:
     {
       // read now and check that without limit enforcement the values are half of command as this is
       // the logic implemented in test components
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
 
       EXPECT_EQ(state_itfs[0].get_optional().value(), 1.0);
       EXPECT_EQ(state_itfs[1].get_optional().value(), -2.0);
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_TRUE(write_result == hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
       time = node_.get_clock()->now();
@@ -2593,8 +2593,8 @@ public:
     // Let's enforce for one loop and then run the read and write again and reset interfaces to zero
     // state
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
 
       EXPECT_EQ(state_itfs[0].get_optional().value(), 1.0);
@@ -2615,14 +2615,14 @@ public:
       EXPECT_NEAR(claimed_itfs[0].get_optional().value(), 1.048, 0.00001);
       EXPECT_EQ(claimed_itfs[1].get_optional().value(), 0.0);
 
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_EQ(write_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
       time = node_.get_clock()->now();
 
-      auto [read_ok, failed_hardware_names_read] = rm->read(time, duration);
-      EXPECT_TRUE(read_ok);
+      auto [read_result, failed_hardware_names_read] = rm->read(time, duration);
+      EXPECT_EQ(read_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_read.empty());
 
       ASSERT_NEAR(
@@ -2635,8 +2635,8 @@ public:
     {
       ASSERT_GT(state_itfs[2].get_optional().value(), 1.05);
       ASSERT_TRUE(claimed_itfs[0].set_value(test_constants::RESET_STATE_INTERFACES_VALUE));
-      auto [read_ok, failed_hardware_names_read] = rm->read(time, duration);
-      EXPECT_TRUE(read_ok);
+      auto [read_result, failed_hardware_names_read] = rm->read(time, duration);
+      EXPECT_EQ(read_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_read.empty());
       ASSERT_EQ(state_itfs[2].get_optional().value(), 0.0);
       ASSERT_TRUE(claimed_itfs[0].set_value(0.0));
@@ -2650,8 +2650,8 @@ public:
     // Now loop and see that the joint limits are being enforced progressively
     for (size_t i = 1; i < 300; i++)
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
 
       EXPECT_EQ(state_itfs[0].get_optional().value(), new_state_value_1);
@@ -2682,15 +2682,15 @@ public:
       new_state_value_1 = claimed_itfs[0].get_optional().value() / 2.0;
       new_state_value_2 = claimed_itfs[1].get_optional().value() / 2.0;
 
-      auto [ok_write, failed_hardware_names_write] = rm->write(time, duration);
-      EXPECT_TRUE(ok_write);
+      auto [write_result, failed_hardware_names_write] = rm->write(time, duration);
+      EXPECT_EQ(write_result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names_write.empty());
       node_.get_clock()->sleep_until(time + duration);
       time = node_.get_clock()->now();
     }
     {
-      auto [ok, failed_hardware_names] = rm->read(time, duration);
-      EXPECT_TRUE(ok);
+      auto [result, failed_hardware_names] = rm->read(time, duration);
+      EXPECT_EQ(result, hardware_interface::return_type::OK);
       EXPECT_TRUE(failed_hardware_names.empty());
 
       EXPECT_NEAR(state_itfs[0].get_optional().value(), 0.823, 0.00001);


### PR DESCRIPTION
Closes #2318

While testing with hardware I found it was easiest to only return DEACTIVATE from write() so that my hardware_interface didn't have to keep track of the number of times DEACTIVATE has been returned in read(). I also found that allowing write() while the hardware is INACTIVE does not make sense because ALL commanding controllers are stopped on deactivation and the hardware would not know which command_interfaces might be allowed returning DEACTIVATE again which would cause the controller_manager to get stuck in a loop attempting to stop any controllers with with command interfaces to the hardware.

I also added 2 new test to make sure the controller_manager correctly handles DEACTIVATE on read/write.