### PR TITLE
Further Struct based Method changes to support propagation in `gz_ros2_control`

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -621,7 +621,12 @@ void ControllerManager::init_resource_manager(const std::string & robot_descript
   {
     resource_manager_->import_joint_limiters(robot_description_);
   }
-  if (!resource_manager_->load_and_initialize_components(robot_description, update_rate_))
+  hardware_interface::ResourceManagerParams params;
+  params.robot_description = robot_description;
+  params.clock = trigger_clock_;
+  params.logger = this->get_logger();
+  params.executor = executor_;
+  if (!resource_manager_->load_and_initialize_components(params))
   {
     RCLCPP_WARN(
       get_logger(),

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -447,6 +447,57 @@ public:
    * \param[in] hardware_info hardware info
    */
   void import_component(
+    std::unique_ptr<SystemInterface> system, const HardwareComponentParams & params);
+
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] actuator pointer to the actuator interface.
+   * \param[in] params Struct of type HardwareComponentParams containing the hardware info
+   * and other parameters for the component.
+   */
+  void import_component(
+    std::unique_ptr<ActuatorInterface> actuator, const HardwareComponentParams & params);
+
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] sensor pointer to the sensor interface.
+   * \param[in] params Struct of type HardwareComponentParams containing the hardware info
+   * and other parameters for the component.
+   */
+  void import_component(
+    std::unique_ptr<SensorInterface> sensor, const HardwareComponentParams & params);
+
+  /// Import a hardware component which is not listed in the URDF
+  /**
+   * Components which are initialized outside a URDF can be added post initialization.
+   * Nevertheless, there should still be `HardwareInfo` available for this component,
+   * either parsed from a URDF string (easiest) or filled manually.
+   *
+   * \note this might invalidate existing state and command interfaces and should thus
+   * not be called when a controller is running.
+   * \note given that no hardware_info is available, the component has to be configured
+   * externally and prior to the call to import.
+   * \param[in] system pointer to the system interface.
+   * \param[in] params Struct of type HardwareComponentParams containing the hardware info
+   * and other parameters for the component.
+   */
+  void import_component(
     std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info);
 
   /// Return status for all components.

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1909,28 +1909,52 @@ std::string ResourceManager::get_command_interface_data_type(const std::string &
 void ResourceManager::import_component(
   std::unique_ptr<ActuatorInterface> actuator, const HardwareInfo & hardware_info)
 {
-  std::lock_guard<std::recursive_mutex> guard(resources_lock_);
-  resource_storage_->initialize_actuator(std::move(actuator), hardware_info);
-  read_write_status.failed_hardware_names.reserve(
-    resource_storage_->actuators_.size() + resource_storage_->sensors_.size() +
-    resource_storage_->systems_.size());
+  HardwareComponentParams params;
+  params.hardware_info = hardware_info;
+  import_component(std::move(actuator), params);
 }
 
 void ResourceManager::import_component(
   std::unique_ptr<SensorInterface> sensor, const HardwareInfo & hardware_info)
 {
+  HardwareComponentParams params;
+  params.hardware_info = hardware_info;
+  import_component(std::move(sensor), params);
+}
+
+void ResourceManager::import_component(
+  std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info)
+{
+  HardwareComponentParams params;
+  params.hardware_info = hardware_info;
+  import_component(std::move(system), params);
+}
+
+void ResourceManager::import_component(
+  std::unique_ptr<ActuatorInterface> actuator, const HardwareComponentParams & params)
+{
   std::lock_guard<std::recursive_mutex> guard(resources_lock_);
-  resource_storage_->initialize_sensor(std::move(sensor), hardware_info);
+  resource_storage_->initialize_actuator(std::move(actuator), params);
   read_write_status.failed_hardware_names.reserve(
     resource_storage_->actuators_.size() + resource_storage_->sensors_.size() +
     resource_storage_->systems_.size());
 }
 
 void ResourceManager::import_component(
-  std::unique_ptr<SystemInterface> system, const HardwareInfo & hardware_info)
+  std::unique_ptr<SensorInterface> sensor, const HardwareComponentParams & params)
 {
   std::lock_guard<std::recursive_mutex> guard(resources_lock_);
-  resource_storage_->initialize_system(std::move(system), hardware_info);
+  resource_storage_->initialize_sensor(std::move(sensor), params);
+  read_write_status.failed_hardware_names.reserve(
+    resource_storage_->actuators_.size() + resource_storage_->sensors_.size() +
+    resource_storage_->systems_.size());
+}
+
+void ResourceManager::import_component(
+  std::unique_ptr<SystemInterface> system, const HardwareComponentParams & params)
+{
+  std::lock_guard<std::recursive_mutex> guard(resources_lock_);
+  resource_storage_->initialize_system(std::move(system), params);
   read_write_status.failed_hardware_names.reserve(
     resource_storage_->actuators_.size() + resource_storage_->sensors_.size() +
     resource_storage_->systems_.size());


### PR DESCRIPTION
## Brief
Post #2323 we need to update the downstream repos to also support the new Struct based approach. A PR for `gz_ros2_control` has been put in at https://github.com/ros-controls/gz_ros2_control/pull/613

Small changes for that to work are present in this PR