### PR TITLE
Improve lexical casts methods

### DIFF
--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -15,7 +15,11 @@
 #ifndef HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
 #define HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
 
+#include <regex>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace hardware_interface
@@ -29,6 +33,77 @@ namespace hardware_interface
 double stod(const std::string & s);
 
 bool parse_bool(const std::string & bool_string);
+
+template <typename T>
+std::vector<T> parse_array(const std::string & array_string)
+{
+  // Use regex to check for a flat array: starts with [, ends with ], no nested brackets
+  const std::regex array_regex(R"(^\[\s*([^\[\]]*\s*(,\s*[^\[\]]+\s*)*)?\]$)");
+  if (!std::regex_match(array_string, array_regex))
+  {
+    throw std::invalid_argument(
+      "String must be a flat array: starts with '[' and ends with ']', no nested arrays");
+  }
+
+  // Use regex for the expression that either empty or contains only spaces
+  const std::regex empty_or_spaces_regex(R"(^\[\s*\]$)");
+  if (std::regex_match(array_string, empty_or_spaces_regex))
+  {
+    std::cerr << "Input is an empty array: " << array_string << std::endl;
+    return {};  // Return empty array if input is "[]"
+  }
+
+  // Use regex to find cases of comma-separated but only whitespaces or no spaces between them like
+  // "[,]" "[a,b,,c]"
+  const std::regex comma_separated_regex(R"(^\[\s*([^,\s]+(\s*,\s*[^,\s]+)*)?\s*\]$)");
+  if (!std::regex_match(array_string, comma_separated_regex))
+  {
+    throw std::invalid_argument(
+      "String must be a flat array with comma-separated values and no spaces between them");
+  }
+
+  std::vector<T> result = {};
+  if (array_string == "[]")
+  {
+    return result;  // Return empty array if input is "[]"
+  }
+
+  // regex for comma separated values and no spaces between them or just content like "[a,b,c]" or
+  // "[a]" or "[a, b, c]"
+  const std::regex value_regex(R"([^\s,\[\]]+)");
+  auto begin = std::sregex_iterator(array_string.begin(), array_string.end(), value_regex);
+  auto end = std::sregex_iterator();
+
+  for (auto it = begin; it != end; ++it)
+  {
+    const std::string value_str = it->str();  // Get the first capturing group
+    if constexpr (std::is_same_v<T, std::string>)
+    {
+      result.push_back(value_str);
+    }
+    else if constexpr (std::is_same_v<T, bool>)
+    {
+      result.push_back(parse_bool(value_str));
+    }
+    else if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>)
+    {
+      if (const auto value = hardware_interface::stod(value_str))
+      {
+        result.push_back(static_cast<T>(value));
+      }
+      else
+      {
+        throw std::invalid_argument(
+          "Failed converting string to floating point or integer: " + value_str);
+      }
+    }
+    else
+    {
+      throw std::invalid_argument("Unsupported type for parsing: " + std::string(typeid(T).name()));
+    }
+  }
+  return result;
+}
 
 std::vector<std::string> parse_string_array(const std::string & string_array_string);
 

--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -49,7 +49,6 @@ std::vector<T> parse_array(const std::string & array_string)
   const std::regex empty_or_spaces_regex(R"(^\[\s*\]$)");
   if (std::regex_match(array_string, empty_or_spaces_regex))
   {
-    std::cerr << "Input is an empty array: " << array_string << std::endl;
     return {};  // Return empty array if input is "[]"
   }
 

--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -87,9 +87,9 @@ std::vector<T> parse_array(const std::string & array_string)
     }
     else if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>)
     {
-      if (const auto value = hardware_interface::stod(value_str))
+      if (const T value = static_cast<T>(hardware_interface::stod(value_str)))
       {
-        result.push_back(static_cast<T>(value));
+        result.push_back(value);
       }
       else
       {

--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -87,11 +87,12 @@ std::vector<T> parse_array(const std::string & array_string)
     }
     else if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>)
     {
-      if (const T value = static_cast<T>(hardware_interface::stod(value_str)))
+      try
       {
+        const T value = static_cast<T>(hardware_interface::stod(value_str));
         result.push_back(value);
       }
-      else
+      catch (const std::exception &)
       {
         throw std::invalid_argument(
           "Failed converting string to floating point or integer: " + value_str);

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
+#include <algorithm>
+#include <cctype>
 #include <locale>
 #include <optional>
 #include <stdexcept>

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -15,11 +15,8 @@
 #include <iostream>
 #include <locale>
 #include <optional>
-#include <regex>
-#include <sstream>
 #include <stdexcept>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include "hardware_interface/lexical_casts.hpp"
@@ -66,85 +63,23 @@ double stod(const std::string & s)
 
 bool parse_bool(const std::string & bool_string)
 {
-  return bool_string == "true" || bool_string == "True";
-}
+  // Copy input to temp and make lowercase
+  std::string temp = bool_string;
+  std::transform(
+    temp.begin(), temp.end(), temp.begin(), [](unsigned char c) { return std::tolower(c); });
 
-template <typename T>
-std::vector<T> parse_array(const std::string & array_string)
-{
-  // Use regex to check for a flat array: starts with [, ends with ], no nested brackets
-  const std::regex array_regex(R"(^\[\s*([^\[\]]*\s*(,\s*[^\[\]]+\s*)*)?\]$)");
-  if (!std::regex_match(array_string, array_regex))
+  if (temp == "true")
   {
-    throw std::invalid_argument(
-      "String must be a flat array: starts with '[' and ends with ']', no nested arrays");
+    return true;
   }
-
-  // Use regex for the expression that either empty or contains only spaces
-  const std::regex empty_or_spaces_regex(R"(^\[\s*\]$)");
-  if (std::regex_match(array_string, empty_or_spaces_regex))
+  if (temp == "false")
   {
-    std::cerr << "Input is an empty array: " << array_string << std::endl;
-    return {};  // Return empty array if input is "[]"
+    return false;
   }
-
-  // Use regex to find cases of comma-separated but only whitespaces or no spaces between them like
-  // "[,]" "[a,b,,c]"
-  const std::regex comma_separated_regex(R"(^\[\s*([^,\s]+(\s*,\s*[^,\s]+)*)?\s*\]$)");
-  if (!std::regex_match(array_string, comma_separated_regex))
-  {
-    throw std::invalid_argument(
-      "String must be a flat array with comma-separated values and no spaces between them");
-  }
-
-  std::vector<T> result = {};
-  if (array_string == "[]")
-  {
-    return result;  // Return empty array if input is "[]"
-  }
-
-  // regex for comma separated values and no spaces between them or just content like "[a,b,c]" or
-  // "[a]" or "[a, b, c]"
-  //  The regex captures values between commas, allowing for optional spaces around them
-  //  It captures the first group of non-whitespace characters that are not commas
-  //  and allows for multiple such groups separated by commas.
-  //  Example matches: "a", "b", "c", "a, b", "a, b, c"
-  //  It does not allow nested arrays or empty values.
-  std::cerr << "Parsing array string: " << array_string << std::endl;
-  const std::regex value_regex(R"([^\s,\[\]]+)");
-  auto begin = std::sregex_iterator(array_string.begin(), array_string.end(), value_regex);
-  auto end = std::sregex_iterator();
-
-  for (auto it = begin; it != end; ++it)
-  {
-    const std::string value_str = it->str();  // Get the first capturing group
-    std::cerr << "Found value: '" << value_str << "'" << std::endl;
-    if constexpr (std::is_same_v<T, std::string>)
-    {
-      result.push_back(value_str);
-    }
-    else if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>)
-    {
-      if (const auto value = impl::stod(value_str))
-      {
-        result.push_back(static_cast<T>(*value));
-      }
-      else
-      {
-        throw std::invalid_argument(
-          "Failed converting string to floating point or integer: " + value_str);
-      }
-    }
-    else if constexpr (std::is_same_v<T, bool>)
-    {
-      result.push_back(parse_bool(value_str));
-    }
-    else
-    {
-      throw std::invalid_argument("Unsupported type for parsing: " + std::string(typeid(T).name()));
-    }
-  }
-  return result;
+  // If input is not "true" or "false" (any casing), throw or handle as error
+  throw std::invalid_argument(
+    "Input string : '" + bool_string +
+    "' is not a valid boolean value. Expected 'true' or 'false'.");
 }
 
 std::vector<std::string> parse_string_array(const std::string & string_array_string)

--- a/hardware_interface/test/test_lexical_casts.cpp
+++ b/hardware_interface/test/test_lexical_casts.cpp
@@ -36,13 +36,23 @@ TEST(TestLexicalCasts, test_parse_bool)
 
   ASSERT_TRUE(parse_bool("true"));
   ASSERT_TRUE(parse_bool("True"));
+  ASSERT_TRUE(parse_bool("TRUE"));
+  ASSERT_TRUE(parse_bool("TrUe"));
 
   // Any other value should return false
   ASSERT_FALSE(parse_bool("false"));
   ASSERT_FALSE(parse_bool("False"));
-  ASSERT_FALSE(parse_bool(""));
-  ASSERT_FALSE(parse_bool("abc"));
-  ASSERT_FALSE(parse_bool("1"));
+  ASSERT_FALSE(parse_bool("FALSE"));
+  ASSERT_FALSE(parse_bool("fAlSe"));
+
+  // Invalid inputs should throw an exception
+  ASSERT_THROW(parse_bool("1"), std::invalid_argument);
+  ASSERT_THROW(parse_bool("0"), std::invalid_argument);
+  ASSERT_THROW(parse_bool("yes"), std::invalid_argument);
+  ASSERT_THROW(parse_bool("no"), std::invalid_argument);
+  ASSERT_THROW(parse_bool(""), std::invalid_argument);
+  ASSERT_THROW(parse_bool("abc"), std::invalid_argument);
+  ASSERT_THROW(parse_bool("1"), std::invalid_argument);
 }
 
 TEST(TestLexicalCasts, test_parse_string_array)
@@ -65,4 +75,82 @@ TEST(TestLexicalCasts, test_parse_string_array)
   ASSERT_EQ(parse_string_array("[abc,def]"), std::vector<std::string>({"abc", "def"}));
   ASSERT_EQ(parse_string_array("[abc, def]"), std::vector<std::string>({"abc", "def"}));
   ASSERT_EQ(parse_string_array("[ abc, def ]"), std::vector<std::string>({"abc", "def"}));
+}
+
+TEST(TestLexicalCasts, test_parse_double_array)
+{
+  using hardware_interface::parse_array;
+
+  ASSERT_THROW(parse_array<double>(""), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("1.23"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[1.23"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("1.23]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[[1.23, 4.56], 7.89]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[ ,   ]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[1.23,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[,1.234]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<double>("[1.232,,1.324]"), std::invalid_argument);
+
+  ASSERT_EQ(parse_array<double>("[]"), std::vector<double>());
+  ASSERT_EQ(parse_array<double>("[ ]"), std::vector<double>());
+  ASSERT_EQ(parse_array<double>("[1.23]"), std::vector<double>({1.23}));
+  ASSERT_EQ(parse_array<double>("[-1.23]"), std::vector<double>({-1.23}));
+  ASSERT_EQ(parse_array<double>("[1.23,4.56]"), std::vector<double>({1.23, 4.56}));
+  ASSERT_EQ(parse_array<double>("[-1.23,-4.56]"), std::vector<double>({-1.23, -4.56}));
+  ASSERT_EQ(parse_array<double>("[-1.23, 4.56]"), std::vector<double>({-1.23, 4.56}));
+  ASSERT_EQ(parse_array<double>("[ -1.23, -124.56 ]"), std::vector<double>({-1.23, -124.56}));
+  ASSERT_EQ(parse_array<double>("[ 1.23, 4 ]"), std::vector<double>({1.23, 4.0}));
+  ASSERT_EQ(parse_array<double>("[ 1.23, 4.56, -7 ]"), std::vector<double>({1.23, 4.56, -7.0}));
+  ASSERT_EQ(parse_array<double>("[ 1.23, 123, -7.89 ]"), std::vector<double>({1.23, 123.0, -7.89}));
+  ASSERT_EQ(parse_array<double>("[ 1.23, 4.56, -7.89 ]"), std::vector<double>({1.23, 4.56, -7.89}));
+}
+
+TEST(TestLexicalCasts, test_parse_int_array)
+{
+  using hardware_interface::parse_array;
+
+  ASSERT_THROW(parse_array<int>(""), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("123"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[232"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("123]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[[1.23, 4], 7]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[ ,   ]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[1,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[,1]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<int>("[1,,2]"), std::invalid_argument);
+
+  ASSERT_EQ(parse_array<int>("[]"), std::vector<int>());
+  ASSERT_EQ(parse_array<int>("[ ]"), std::vector<int>());
+  ASSERT_EQ(parse_array<int>("[1]"), std::vector<int>({1}));
+  ASSERT_EQ(parse_array<int>("[-1]"), std::vector<int>({-1}));
+  ASSERT_EQ(parse_array<int>("[1,2]"), std::vector<int>({1, 2}));
+  ASSERT_EQ(parse_array<int>("[-1,-2]"), std::vector<int>({-1, -2}));
+  ASSERT_EQ(parse_array<int>("[ -1, -124 ]"), std::vector<int>({-1, -124}));
+  ASSERT_EQ(parse_array<int>("[ -1, -124, +123 ]"), std::vector<int>({-1, -124, 123}));
+}
+
+TEST(TestLexicalCasts, test_parse_bool_array)
+{
+  using hardware_interface::parse_array;
+
+  ASSERT_THROW(parse_array<bool>(""), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("true"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[true"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("true]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[[true, false], true]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[ ,   ]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[true,]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[,false]"), std::invalid_argument);
+  ASSERT_THROW(parse_array<bool>("[true,,false]"), std::invalid_argument);
+
+  ASSERT_EQ(parse_array<bool>("[]"), std::vector<bool>());
+  ASSERT_EQ(parse_array<bool>("[ ]"), std::vector<bool>());
+  ASSERT_EQ(parse_array<bool>("[true]"), std::vector<bool>({true}));
+  ASSERT_EQ(parse_array<bool>("[false]"), std::vector<bool>({false}));
+  ASSERT_EQ(parse_array<bool>("[true,false]"), std::vector<bool>({true, false}));
+  ASSERT_EQ(parse_array<bool>("[false,true]"), std::vector<bool>({false, true}));
+  ASSERT_EQ(parse_array<bool>("[ true, false ]"), std::vector<bool>({true, false}));
 }

--- a/hardware_interface/test/test_lexical_casts.cpp
+++ b/hardware_interface/test/test_lexical_casts.cpp
@@ -54,13 +54,13 @@ TEST(TestLexicalCasts, test_parse_string_array)
   ASSERT_THROW(parse_string_array("[abc"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("abc]"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("[[abc, def], hij]"), std::invalid_argument);
-  ASSERT_THROW(parse_string_array("[ ]"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("[,]"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("[abc,]"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("[,abc]"), std::invalid_argument);
   ASSERT_THROW(parse_string_array("[abc,,def]"), std::invalid_argument);
 
   ASSERT_EQ(parse_string_array("[]"), std::vector<std::string>());
+  ASSERT_EQ(parse_string_array("[ ]"), std::vector<std::string>());
   ASSERT_EQ(parse_string_array("[abc]"), std::vector<std::string>({"abc"}));
   ASSERT_EQ(parse_string_array("[abc,def]"), std::vector<std::string>({"abc", "def"}));
   ASSERT_EQ(parse_string_array("[abc, def]"), std::vector<std::string>({"abc", "def"}));


### PR DESCRIPTION
I added a template `parse_array` method that parses the information and be able to create the vector for types, `int`, `bool`, `double` and `std::string`. I've also added some tests for this