### PR TITLE
Addition of a Default Node for Hardware Component

### DIFF
--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -183,6 +183,22 @@ public:
         info_.thread_priority);
       async_handler_->start_thread();
     }
+    
+    if (auto locked_executor = params.executor.lock())
+    {
+      std::string node_name = params.hardware_info.name;
+      std::replace(node_name.begin(), node_name.end(), '/', '_');
+      hardware_component_node_ = std::make_shared<rclcpp::Node>(node_name);
+      locked_executor->add_node(hardware_component_node_->get_node_base_interface());
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        params.logger,
+        "Executor is not available during hardware component initialization for '%s'.",
+        params.hardware_info.name.c_str());
+    }
+    
     hardware_interface::HardwareComponentInterfaceParams interface_params;
     interface_params.hardware_info = info_;
     interface_params.executor = params.executor;
@@ -641,6 +657,12 @@ public:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return actuator_clock_; }
 
+  /// Get the default node of the ActuatorInterface.
+  /**
+   * \return node of the ActuatorInterface.
+   */
+  rclcpp::Node::SharedPtr get_node() const { return hardware_component_node_; }
+
   /// Get the hardware info of the ActuatorInterface.
   /**
    * \return hardware info of the ActuatorInterface.
@@ -697,6 +719,7 @@ protected:
 private:
   rclcpp::Clock::SharedPtr actuator_clock_;
   rclcpp::Logger actuator_logger_;
+  rclcpp::Node::SharedPtr hardware_component_node_;
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> actuator_states_;
   std::unordered_map<std::string, CommandInterface::SharedPtr> actuator_commands_;

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -183,7 +183,7 @@ public:
         info_.thread_priority);
       async_handler_->start_thread();
     }
-    
+
     if (auto locked_executor = params.executor.lock())
     {
       std::string node_name = params.hardware_info.name;
@@ -198,7 +198,7 @@ public:
         "Executor is not available during hardware component initialization for '%s'.",
         params.hardware_info.name.c_str());
     }
-    
+
     hardware_interface::HardwareComponentInterfaceParams interface_params;
     interface_params.hardware_info = info_;
     interface_params.executor = params.executor;

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -428,6 +428,12 @@ public:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return sensor_clock_; }
 
+  /// Get the default node of the ActuatorInterface.
+  /**
+   * \return node of the ActuatorInterface.
+   */
+  rclcpp::Node::SharedPtr get_node() const { return hardware_component_node_; }
+
   /// Get the hardware info of the SensorInterface.
   /**
    * \return hardware info of the SensorInterface.

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -687,6 +687,12 @@ public:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return system_clock_; }
 
+  /// Get the default node of the ActuatorInterface.
+  /**
+   * \return node of the ActuatorInterface.
+   */
+  rclcpp::Node::SharedPtr get_node() const { return hardware_component_node_; }
+
   /// Get the hardware info of the SystemInterface.
   /**
    * \return hardware info of the SystemInterface.

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -187,6 +187,22 @@ public:
         info_.thread_priority);
       async_handler_->start_thread();
     }
+
+    if (auto locked_executor = params.executor.lock())
+    {
+      std::string node_name = params.hardware_info.name;
+      std::replace(node_name.begin(), node_name.end(), '/', '_');
+      hardware_component_node_ = std::make_shared<rclcpp::Node>(node_name);
+      locked_executor->add_node(hardware_component_node_->get_node_base_interface());
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        params.logger,
+        "Executor is not available during hardware component initialization for '%s'.",
+        params.hardware_info.name.c_str());
+    }
+
     hardware_interface::HardwareComponentInterfaceParams interface_params;
     interface_params.hardware_info = info_;
     interface_params.executor = params.executor;
@@ -737,6 +753,7 @@ protected:
 private:
   rclcpp::Clock::SharedPtr system_clock_;
   rclcpp::Logger system_logger_;
+  rclcpp::Node::SharedPtr hardware_component_node_;
   // interface names to Handle accessed through getters/setters
   std::unordered_map<std::string, StateInterface::SharedPtr> system_states_;
   std::unordered_map<std::string, CommandInterface::SharedPtr> system_commands_;


### PR DESCRIPTION
## Brief
Now that we have access to the CM's executor from #2323, the user can add their nodes to it and create publishers and subscribers from them. The next step, which this PR addresses, is adding a node by default, with the hardware components name, and giving the user access to it through a `get_node` method.

