### PR TITLE
Add changes to cast the other data types to double

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -34,6 +34,8 @@
 #include "hardware_interface/lexical_casts.hpp"
 #include "hardware_interface/macros.hpp"
 
+#include "rclcpp/logging.hpp"
+
 namespace
 {
 template <typename T>
@@ -213,9 +215,23 @@ public:
     // TODO(saikishor) return value_ if old functionality is removed
     if constexpr (std::is_same_v<T, double>)
     {
-      // If the template is of type double, check if the value_ptr_ is not nullptr
-      THROW_ON_NULLPTR(value_ptr_);
-      return *value_ptr_;
+      switch (data_type_)
+      {
+        case HandleDataType::DOUBLE:
+          THROW_ON_NULLPTR(value_ptr_);
+          return *value_ptr_;
+        case HandleDataType::BOOL:
+          RCLCPP_WARN_ONCE(
+            rclcpp::get_logger(get_name()),
+            "Casting bool to double for interface : %s. Better use get_optional<bool>().",
+            get_name().c_str());
+          return static_cast<double>(std::get<bool>(value_));
+        default:
+          throw std::runtime_error(
+            fmt::format(
+              FMT_COMPILE("Data type : '{}' cannot be casted to double for interface : {}"),
+              data_type_.to_string(), get_name()));
+      }
     }
     try
     {
@@ -294,6 +310,9 @@ public:
   std::shared_mutex & get_mutex() const { return handle_mutex_; }
 
   HandleDataType get_data_type() const { return data_type_; }
+
+  /// Returns true if the handle data type can be casted to double.
+  bool is_castable_to_double() const { return data_type_.is_castable_to_double(); }
 
 private:
   void copy(const Handle & other) noexcept

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -184,6 +184,24 @@ public:
     }
   }
 
+  /**
+   * @brief Check if the HandleDataType can be casted to double.
+   * @return True if the HandleDataType can be casted to double, false otherwise.
+   * @note Once we add support for more data types, this function should be updated
+   */
+  bool is_castable_to_double() const
+  {
+    switch (value_)
+    {
+      case DOUBLE:
+        return true;
+      case BOOL:
+        return true;  // bool can be converted to double
+      default:
+        return false;  // unknown type cannot be converted
+    }
+  }
+
   HandleDataType from_string(const std::string & data_type) { return HandleDataType(data_type); }
 
 private:

--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -178,6 +178,12 @@ public:
    */
   HandleDataType get_data_type() const { return command_interface_.get_data_type(); }
 
+  /**
+   * @brief Check if the state interface can be casted to double.
+   * @return True if the state interface can be casted to double, false otherwise.
+   */
+  bool is_castable_to_double() const { return command_interface_.is_castable_to_double(); }
+
 protected:
   CommandInterface & command_interface_;
   Deleter deleter_;

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -138,6 +138,12 @@ public:
    */
   HandleDataType get_data_type() const { return state_interface_.get_data_type(); }
 
+  /**
+   * @brief Check if the state interface can be casted to double.
+   * @return True if the state interface can be casted to double, false otherwise.
+   */
+  bool is_castable_to_double() const { return state_interface_.is_castable_to_double(); }
+
 protected:
   const StateInterface & state_interface_;
   Deleter deleter_;

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -225,13 +225,14 @@ TEST(TestHandle, interface_description_bool_data_type)
   ASSERT_FALSE(handle.get_optional<bool>().value()) << "Default value should be false";
   ASSERT_TRUE(handle.set_value(true));
   ASSERT_TRUE(handle.get_optional<bool>().value());
+  ASSERT_EQ(handle.get_optional(), 1.0);
   ASSERT_TRUE(handle.set_value(false));
   ASSERT_FALSE(handle.get_optional<bool>().value());
+  ASSERT_EQ(handle.get_optional(), 0.0);
 
   // Test the assertions
   ASSERT_THROW({ std::ignore = handle.set_value(-1.0); }, std::runtime_error);
   ASSERT_THROW({ std::ignore = handle.set_value(0.0); }, std::runtime_error);
-  ASSERT_THROW({ std::ignore = handle.get_optional<double>(); }, std::runtime_error);
 }
 
 TEST(TestHandle, handle_constructor_double_data_type)
@@ -274,13 +275,14 @@ TEST(TestHandle, handle_constructor_bool_data_type)
     << "Default value should be true as it is initialized";
   ASSERT_TRUE(handle.set_value(false));
   ASSERT_FALSE(handle.get_optional<bool>().value());
+  ASSERT_EQ(handle.get_optional(), 0.0);
   ASSERT_TRUE(handle.set_value(true));
   ASSERT_TRUE(handle.get_optional<bool>().value());
+  ASSERT_EQ(handle.get_optional(), 1.0);
 
   // Test the assertions
   ASSERT_THROW({ std::ignore = handle.set_value(-1.0); }, std::runtime_error);
   ASSERT_THROW({ std::ignore = handle.set_value(0.0); }, std::runtime_error);
-  ASSERT_THROW({ std::ignore = handle.get_optional<double>(); }, std::runtime_error);
 }
 
 TEST(TestHandle, interface_description_unknown_data_type)


### PR DESCRIPTION
Add a way to be able to cast the other data types to double when `get_optional` is called directly instead of throwing an exception. This makes things easier for using in multiple places