### PR TITLE
[Spawner] Fix the scope issue of the logger

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -165,6 +165,7 @@ def main(args=None):
         for param_file in param_files:
             if not os.path.isfile(param_file):
                 raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
+    logger = rclpy.logging.get_logger("ros2_control_controller_spawner_" + controller_names[0])
 
     try:
         spawner_node_name = "spawner_" + controller_names[0]
@@ -172,29 +173,29 @@ def main(args=None):
         max_retries = 5
         retry_delay = 3  # seconds
         for attempt in range(max_retries):
-            tmp_logger = rclpy.logging.get_logger(spawner_node_name)
             try:
-                tmp_logger.debug(
+                logger.debug(
                     bcolors.OKGREEN + "Waiting for the spawner lock to be acquired!" + bcolors.ENDC
                 )
                 # timeout after 20 seconds and try again
                 lock.acquire(timeout=20)
-                tmp_logger.debug(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
+                logger.debug(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
                 break
             except Timeout:
-                tmp_logger.warning(
+                logger.warning(
                     bcolors.WARNING
                     + f"Attempt {attempt+1} failed. Retrying in {retry_delay} seconds..."
                     + bcolors.ENDC
                 )
                 time.sleep(retry_delay)
         else:
-            tmp_logger.error(
+            logger.error(
                 bcolors.ERROR + "Failed to acquire lock after multiple attempts." + bcolors.ENDC
             )
             return 1
 
         node = Node(spawner_node_name)
+        logger = node.get_logger()
 
         spawner_namespace = node.get_namespace()
 
@@ -216,7 +217,7 @@ def main(args=None):
                 controller_manager_timeout,
                 service_call_timeout,
             ):
-                node.get_logger().warning(
+                logger.warning(
                     bcolors.WARNING
                     + "Controller already loaded, skipping load_controller"
                     + bcolors.ENDC
@@ -249,7 +250,7 @@ def main(args=None):
                     service_call_timeout,
                 )
                 if not ret.ok:
-                    node.get_logger().fatal(
+                    logger.fatal(
                         bcolors.FAIL
                         + "Failed loading controller "
                         + bcolors.BOLD
@@ -257,7 +258,7 @@ def main(args=None):
                         + bcolors.ENDC
                     )
                     return 1
-                node.get_logger().info(
+                logger.info(
                     bcolors.OKBLUE + "Loaded " + bcolors.BOLD + controller_name + bcolors.ENDC
                 )
 
@@ -270,9 +271,7 @@ def main(args=None):
                     service_call_timeout,
                 )
                 if not ret.ok:
-                    node.get_logger().error(
-                        bcolors.FAIL + "Failed to configure controller" + bcolors.ENDC
-                    )
+                    logger.error(bcolors.FAIL + "Failed to configure controller" + bcolors.ENDC)
                     return 1
 
                 if not args.inactive and not args.activate_as_group:
@@ -287,12 +286,12 @@ def main(args=None):
                         service_call_timeout,
                     )
                     if not ret.ok:
-                        node.get_logger().error(
+                        logger.error(
                             f"{bcolors.FAIL}Failed to activate controller : {controller_name}{bcolors.ENDC}"
                         )
                         return 1
 
-                    node.get_logger().info(
+                    logger.info(
                         bcolors.OKGREEN
                         + "Configured and activated "
                         + bcolors.BOLD
@@ -312,12 +311,12 @@ def main(args=None):
                 service_call_timeout,
             )
             if not ret.ok:
-                node.get_logger().error(
+                logger.error(
                     f"{bcolors.FAIL}Failed to activate the parsed controllers list : {controller_names}{bcolors.ENDC}"
                 )
                 return 1
 
-            node.get_logger().info(
+            logger.info(
                 bcolors.OKGREEN
                 + f"Configured and activated all the parsed controllers list : {controller_names}!"
                 + bcolors.ENDC
@@ -326,14 +325,14 @@ def main(args=None):
         if not unload_controllers_upon_exit:
             return 0
 
-        node.get_logger().info("Waiting until interrupt to unload controllers")
+        logger.info("Waiting until interrupt to unload controllers")
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
         if unload_controllers_upon_exit:
-            node.get_logger().info("KeyboardInterrupt successfully captured!")
+            logger.info("KeyboardInterrupt successfully captured!")
             if not args.inactive:
-                node.get_logger().info("Deactivating and unloading controllers...")
+                logger.info("Deactivating and unloading controllers...")
                 # TODO(saikishor) we might have an issue in future, if any of these controllers is in chained mode
                 ret = switch_controllers(
                     node,
@@ -346,14 +345,10 @@ def main(args=None):
                     service_call_timeout,
                 )
                 if not ret.ok:
-                    node.get_logger().error(
-                        bcolors.FAIL + "Failed to deactivate controller" + bcolors.ENDC
-                    )
+                    logger.error(bcolors.FAIL + "Failed to deactivate controller" + bcolors.ENDC)
                     return 1
 
-                node.get_logger().info(
-                    f"Successfully deactivated controllers : {controller_names}"
-                )
+                logger.info(f"Successfully deactivated controllers : {controller_names}")
 
             unload_status = True
             for controller_name in controller_names:
@@ -366,21 +361,21 @@ def main(args=None):
                 )
                 if not ret.ok:
                     unload_status = False
-                    node.get_logger().error(
+                    logger.error(
                         bcolors.FAIL
                         + f"Failed to unload controller : {controller_name}"
                         + bcolors.ENDC
                     )
 
             if unload_status:
-                node.get_logger().info(f"Successfully unloaded controllers : {controller_names}")
+                logger.info(f"Successfully unloaded controllers : {controller_names}")
             else:
                 return 1
         else:
-            node.get_logger().info("KeyboardInterrupt received! Exiting....")
+            logger.info("KeyboardInterrupt received! Exiting....")
             pass
     except ServiceNotFoundError as err:
-        node.get_logger().fatal(str(err))
+        logger.fatal(str(err))
         return 1
     finally:
         node.destroy_node()


### PR DESCRIPTION
This should fix: #2063

```
  9: [INFO] [1752116798.192371328] [test_controller_manager]: Successfully switched controllers!
  9: [INFO] [1752116798.200599001] [spawner_ctrl_3]: Configured and activated ctrl_3
  9: [INFO] [1752116798.201679810] [spawner_ctrl_3]: Waiting until interrupt to unload controllers
  9: Traceback (most recent call last):
  9:   File "/home/runner/work/ros2_control/ros2_control/.work/target_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 331, in main
  9:     time.sleep(1)
  9: KeyboardInterrupt
  9: 
  9: During handling of the above exception, another exception occurred:
  9: 
  9: Traceback (most recent call last):
  9:   File "<frozen runpy>", line 198, in _run_module_as_main
  9:   File "<frozen runpy>", line 88, in _run_code
  9:   File "/usr/lib/python3/dist-packages/coverage/__main__.py", line 10, in <module>
  9:     sys.exit(main())
  9:              ^^^^^^
  9:   File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 970, in main
  9:     status = CoverageScript().command_line(argv)
  9:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  9:   File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 681, in command_line
  9:     return self.do_run(options, args)
  9:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  9:   File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 858, in do_run
  9:     runner.run()
  9:   File "/usr/lib/python3/dist-packages/coverage/execfile.py", line 211, in run
  9:     exec(code, main_mod.__dict__)
  9:   File "/home/runner/work/ros2_control/ros2_control/.work/target_ws/install/controller_manager/lib/controller_manager/spawner", line 33, in <module>
  9:     sys.exit(load_entry_point('controller-manager==5.3.0', 'console_scripts', 'spawner')())
  9:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  9:   File "/home/runner/work/ros2_control/ros2_control/.work/target_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 334, in main
  9:     node.get_logger().info("KeyboardInterrupt successfully captured!")
  9:     ^^^^^^^^^^^^^^^^^
  9:   File "/opt/ros/kilted/lib/python3.12/site-packages/rclpy/node.py", line 380, in get_logger
  9:     def get_logger(self) -> RcutilsLogger:
  9: 
  9: KeyboardInterrupt
  9: /home/runner/work/ros2_control/ros2_control/.work/target_ws/src/ros2_control/controller_manager/test/test_spawner_unspawner.cpp:582: Failure
  9: Expected equality of these values:
  9:   cm_->get_loaded_controllers().size()
  9:     Which is: 1
  9:   0ul
  9:     Which is: 0
  9: 
  9: [INFO] [1752116802.554998220] [test_controller_manager.pal_statistics]: Async messages lost 0
  9: [INFO] [1752116802.555035840] [test_controller_manager.pal_statistics]: publish_async_failures_ 0
```