### PR TITLE
[spawner] Fix Lock timeout error crashes

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -160,7 +160,7 @@ def main(args=None):
     switch_timeout = args.switch_timeout
     strictness = SwitchController.Request.STRICT
     unload_controllers_upon_exit = False
-    node: Node | None = None
+    node = None
 
     if param_files:
         for param_file in param_files:
@@ -379,7 +379,7 @@ def main(args=None):
         logger.fatal(str(err))
         return 1
     finally:
-        if node is not None:
+        if node:
             node.destroy_node()
         lock.release()
         rclpy.shutdown()


### PR DESCRIPTION
Fixes #2385 

Changes the following:
- Use `bcolors.FAIL` instead of non-existant `bcolors.ERROR`
- Check if the node is created before trying to destroy it.