### PR TITLE
Increase controller period tolerance further

### DIFF
--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -909,7 +909,7 @@ TEST_P(TestControllerManagerWithUpdateRates, per_controller_equal_and_higher_upd
     // [cm_update_rate, 2*cm_update_rate)
     EXPECT_THAT(
       test_controller->update_period_.seconds(),
-      testing::AllOf(testing::Ge(0.7 / cm_update_rate), testing::Lt((1.3 / cm_update_rate))));
+      testing::AllOf(testing::Ge(0.7 / cm_update_rate), testing::Lt((1.6 / cm_update_rate))));
     ASSERT_EQ(
       test_controller->internal_counter,
       cm_->get_loaded_controllers()[0].execution_time_statistics->GetCount());


### PR DESCRIPTION
Increasing this is not a problem as this is the instantaneous one and in a non-RT system it is expected to have a higher controller period, however, what might be interesting to us in the Average which is also in the same test, for that reason, increasing shouldn't be a problem :)