### PR TITLE
Fix wrong strict arg of switch_controllers method

### DIFF
--- a/rqt_controller_manager/rqt_controller_manager/controller_manager.py
+++ b/rqt_controller_manager/rqt_controller_manager/controller_manager.py
@@ -444,7 +444,7 @@ class ControllerManager(Plugin):
                 controller_manager_name=self._cm_name,
                 activate_controllers=activate,
                 deactivate_controllers=deactivate,
-                strict=SwitchController.Request.STRICT,
+                strictness=SwitchController.Request.STRICT,
                 activate_asap=False,
                 timeout=0.3,
             )


### PR DESCRIPTION
Fixes https://github.com/ros-controls/ros2_control/issues/2409

the argument should be `strictness` as shown below:

https://github.com/ros-controls/ros2_control/blob/6f67786f9b45b5dc7bb16a3581375fe3963e0291/controller_manager/controller_manager/controller_manager_services.py#L273-L282