### PR TITLE
Fix the joint limiter exception while configuring component

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1459,6 +1459,7 @@ bool ResourceManager::load_and_initialize_components(
   const std::string actuator_type = "actuator";
 
   std::lock_guard<std::recursive_mutex> resource_guard(resources_lock_);
+  std::lock_guard<std::recursive_mutex> limiters_guard(joint_limiters_lock_);
   for (const auto & individual_hardware_info : hardware_info)
   {
     // Check for identical names
@@ -2240,6 +2241,7 @@ return_type ResourceManager::set_component_state(
   };
 
   std::lock_guard<std::recursive_mutex> guard(resources_lock_);
+  std::lock_guard<std::recursive_mutex> limiters_guard(joint_limiters_lock_);
   bool found = find_set_component_state(
     std::bind(&ResourceStorage::set_component_state<Actuator>, resource_storage_.get(), _1, _2),
     resource_storage_->actuators_);


### PR DESCRIPTION
Should ideally fix the following issue
```

[ros2_control_node-2] [0m[INFO] [1753705858.095960584] [controller_manager]: Successful initialization of hardware 'ros2_control_tiago_pro_system_ethercat'[0m
[ros2_control_node-2] terminate called after throwing an instance of 'std::out_of_range'
[ros2_control_node-2]   what():  map::at
[ros2_control_node-2] Stack trace (most recent call last) in thread 6452:
[ros2_control_node-2] #15   Object "", at 0xffffffffffffffff, in 
[ros2_control_node-2] [0m[INFO] [1753705858.106254624] [resource_manager]: 'configure' hardware 'ros2_control_tiago_pro_system_ethercat' [0m
[ros2_control_node-2] [0m[INFO] [1753705858.119735003] [io_ethercat]: Configure successful[0m
[ros2_control_node-2] #14   Source "../sysdeps/unix/sysv/linux/x86_64/clone3.S", line 81, in __clone3 [0x7f2161c5884f]
[ros2_control_node-2] #13   Source "./nptl/pthread_create.c", line 442, in start_thread [0x7f2161bc6ac2]
[ros2_control_node-2] [0m[INFO] [1753705858.234331190] [arm_left_1_actuator]: Configure successful.[0m
[ros2_control_node-2] #12   Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e57252, in 
[ros2_control_node-2] #11   Object "/opt/pal/alum/lib/controller_manager/ros2_control_node", at 0x5622b8b3f125, in 
[ros2_control_node-2] #10   Object "/opt/pal/alum/lib/libcontroller_manager.so", at 0x7f21622c3c19, in controller_manager::ControllerManager::update(rclcpp::Time const&, rclcpp::Duration const&)
[ros2_control_node-2] #9    Object "/opt/pal/alum/lib/libhardware_interface.so", at 0x7f21619fe19c, in hardware_interface::ResourceManager::enforce_command_limits(rclcpp::Duration const&)
[ros2_control_node-2] #8    Object "/opt/pal/alum/lib/libhardware_interface.so", at 0x7f2161a08fb9, in 
[ros2_control_node-2] #7    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e2049f, in std::__throw_out_of_range(char const*)
[ros2_control_node-2] #6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e294d7, in __cxa_throw
[ros2_control_node-2] #5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e29276, in std::terminate()
[ros2_control_node-2] #4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e2920b, in 
[ros2_control_node-2] #3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30", at 0x7f2161e1db9d, in 
[ros2_control_node-2] #2    Source "./stdlib/abort.c", line 79, in abort [0x7f2161b5a7f2]
[ros2_control_node-2] #1    Source "../sysdeps/posix/raise.c", line 26, in raise [0x7f2161b74475]
[ros2_control_node-2] #0  | Source "./nptl/pthread_kill.c", line 89, in __pthread_kill_internal
[ros2_control_node-2]     | Source "./nptl/pthread_kill.c", line 78, in __pthread_kill_implementation
[ros2_control_node-2]       Source "./nptl/pthread_kill.c", line 44, in __pthread_kill [0x7f2161bc89fc]
[ros2_control_node-2] Aborted (Signal sent by tkill() 6430 1000)
[ERROR] [ros2_control_node-2]: process has died [pid 6430, exit code -6, cmd '/opt/pal/alum/lib/controller_manager/ros2_control_node --ros-args --params-file /home/pal/.pal/rt_device_manager_cfg/actuators.yaml --params-file /opt/pal/alum/share/rt_device_manager_cfg_tiago_pro/config/controller_manager.yaml --params-file /home/pal/.pal/rt_device_manager_cfg/dummy_config.yaml --params-file /home/pal/.pal/rt_device_manager_cfg/ios.yaml --params-file /opt/pal/alum/share/rt_device_manager_cfg_tiago_pro/config/rt_device_manager.yaml --params-file /home/pal/.pal/rt_device_manager_cfg/sensors.yaml -r ~/robot_description:=/robot_description'].
```