### PR TITLE
Fix docstring for hardware lifecycle

### DIFF
--- a/hardware_interface/doc/hardware_components_userdoc.rst
+++ b/hardware_interface/doc/hardware_components_userdoc.rst
@@ -41,7 +41,7 @@ The hardware transitions to the following state after each method:
 * **INACTIVE** (``on_configure``, ``on_deactivate``):
 
   Communication with the hardware is established and hardware component is configured.
-  States can be read and command interfaces (System and Actuator only) are available.
+  States can be read, but command interfaces (System and Actuator only) are not available.
 
   As of now, it is left to the hardware component implementation to continue using the command received from the ``CommandInterfaces`` or to skip them completely.
 

--- a/hardware_interface/include/hardware_interface/actuator_interface.hpp
+++ b/hardware_interface/include/hardware_interface/actuator_interface.hpp
@@ -68,10 +68,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  *
  * INACTIVE (on_configure, on_deactivate):
  *   Communication with the hardware is started and it is configured.
- *   States can be read and command interfaces are available.
- *
- *    As of now, it is left to the hardware component implementation to continue using the command
- * received from the ``CommandInterfaces`` or to skip them completely.
+ *   States can be read, but command interfaces are not available.
  *
  * FINALIZED (on_shutdown):
  *   Hardware interface is ready for unloading/destruction.
@@ -79,7 +76,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  *
  * ACTIVE (on_activate):
  *   Power circuits of hardware are active and hardware can be moved, e.g., brakes are disabled.
- *   Command interfaces available.
+ *   Command interfaces are available.
  *
  * \todo
  * Implement

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -72,10 +72,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  *
  * INACTIVE (on_configure, on_deactivate):
  *   Communication with the hardware is started and it is configured.
- *   States can be read and command interfaces are available.
- *
- *    As of now, it is left to the hardware component implementation to continue using the command
- *received from the ``CommandInterfaces`` or to skip them completely.
+ *   States can be read, but command interfaces are not available.
  *
  * FINALIZED (on_shutdown):
  *   Hardware interface is ready for unloading/destruction.

--- a/hardware_interface/include/hardware_interface/system_interface.hpp
+++ b/hardware_interface/include/hardware_interface/system_interface.hpp
@@ -80,7 +80,7 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
  *
  * ACTIVE (on_activate):
  *   Power circuits of hardware are active and hardware can be moved, e.g., brakes are disabled.
- *   Command interfaces available.
+ *   Command interfaces are available.
  *
  * \todo
  * Implement


### PR DESCRIPTION
There was a behavior change with https://github.com/ros-controls/ros2_control/pull/2347, resulting in a failing demo example: https://github.com/ros-controls/ros2_control_demos/issues/864

The docstring from https://github.com/ros-controls/ros2_control/pull/2081 is now wrong and changed with this PR.
Also related to https://github.com/ros-controls/ros2_control/issues/931