### PR TITLE
Build topic_based_hardware_interfaces in downstream job

### DIFF
--- a/downstream.humble.repos
+++ b/downstream.humble.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/cyberbotics/webots_ros2.git
     version: master
-  PickNikRobotics/topic_based_ros2_control:
-    type: git
-    url: https://github.com/PickNikRobotics/topic_based_ros2_control.git
-    version: main

--- a/downstream.jazzy.repos
+++ b/downstream.jazzy.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/cyberbotics/webots_ros2.git
     version: master
-  PickNikRobotics/topic_based_ros2_control:
-    type: git
-    url: https://github.com/PickNikRobotics/topic_based_ros2_control.git
-    version: main

--- a/downstream.kilted.repos
+++ b/downstream.kilted.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/cyberbotics/webots_ros2.git
     version: master
-  PickNikRobotics/topic_based_ros2_control:
-    type: git
-    url: https://github.com/PickNikRobotics/topic_based_ros2_control.git
-    version: main

--- a/downstream.rolling.repos
+++ b/downstream.rolling.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/cyberbotics/webots_ros2.git
     version: master
-  PickNikRobotics/topic_based_ros2_control:
-    type: git
-    url: https://github.com/PickNikRobotics/topic_based_ros2_control.git
-    version: main

--- a/ros_controls.humble.repos
+++ b/ros_controls.humble.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
     version: humble
+  ros-controls/topic_based_hardware_interfaces:
+    type: git
+    url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+    version: main

--- a/ros_controls.jazzy.repos
+++ b/ros_controls.jazzy.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
     version: jazzy
+  ros-controls/topic_based_hardware_interfaces:
+    type: git
+    url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+    version: main

--- a/ros_controls.kilted.repos
+++ b/ros_controls.kilted.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
     version: master
+  ros-controls/topic_based_hardware_interfaces:
+    type: git
+    url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+    version: main

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
     version: master
+  ros-controls/topic_based_hardware_interfaces:
+    type: git
+    url: https://github.com/ros-controls/topic_based_hardware_interfaces.git
+    version: main


### PR DESCRIPTION
Build ros-controls/topic_based_hardware_interfaces in downstream job instead of the old PickNik one.