### PR TITLE
Update doc to clarify BEST_EFFORT behavior when switching controllers

### DIFF
--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -8,10 +8,13 @@
 #  * the strictness (STRICT, BEST_EFFORT, AUTO, or FORCE_AUTO)
 #    * STRICT means that switching will fail if anything goes wrong (an invalid
 #      controller name, a controller that failed to activate, etc.).
-#    * BEST_EFFORT means that even when something goes wrong with one controller,
-#      the service will still try to activate/deactivate the remaining controllers.
-#      However, this will still fail if either all controllers to be activated or all controllers to be
-#      deactivated are unknown controllers or controllers yet to be loaded/configured.
+#    * BEST_EFFORT:
+#      Transitions are only triggered if the controller is not yet in the target state.
+#      If it is already in the target state, no error occurs.
+#      Returns 'false' if no controller of 'activate_controllers' or 'deactivate_controllers' exists,
+#      or the pending transitions of all existing controllers of 'activate_controllers'
+#      or 'deactivate_controllers' fail.
+#      Returns 'true' otherwise.
 #    * AUTO means that the controller manager will automatically resolve the controller
 #      chain in order to activate and/or deactivate the specified controllers.
 #      This is useful in complex systems when you want all dependent controllers to start

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -11,7 +11,7 @@
 #    * BEST_EFFORT means that even when something goes wrong with one controller,
 #      the service will still try to activate/deactivate the remaining controllers.
 #      However, this will still fail if either all controllers to be activated or all controllers to be
-#      deactivated have invalid names.
+#      deactivated are unknown controllers or controllers yet to be loaded/configured.
 #    * AUTO means that the controller manager will automatically resolve the controller
 #      chain in order to activate and/or deactivate the specified controllers.
 #      This is useful in complex systems when you want all dependent controllers to start

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -7,9 +7,11 @@
 #  * the list of controller names to deactivate, and
 #  * the strictness (BEST_EFFORT or STRICT)
 #    * STRICT means that switching will fail if anything goes wrong (an invalid
-#      controller name, a controller that failed to activate, etc. )
+#      controller name, a controller that failed to activate, etc. ).
 #    * BEST_EFFORT means that even when something goes wrong with one controller,
-#      the service will still try to activate/deactivate the remaining controllers
+#      the service will still try to activate/deactivate the remaining controllers.
+#      This will still fail if either all controllers to be activated or all controllers to be 
+#      deactivated have invalid names.
 #    * AUTO means that the controller manager will automatically resolve the controller
 #      chain in order to activate and/or deactivate the specified controllers.
 #      This is useful in complex systems when you want all dependent controllers to start
@@ -28,9 +30,9 @@
 #  * the timeout before aborting pending controllers. Zero for infinite
 
 # The return value "ok" indicates if the controllers were switched
-# successfully or not.  The meaning of success depends on the
+# successfully or not. The meaning of success depends on the
 # specified strictness.
-# The return value "message" provides some human-readable information
+# The return value "message" provides some human-readable information.
 
 
 string[] activate_controllers

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -5,7 +5,7 @@
 # To switch controllers, specify
 #  * the list of controller names to activate,
 #  * the list of controller names to deactivate, and
-#  * the strictness (BEST_EFFORT or STRICT)
+#  * the strictness (STRICT, BEST_EFFORT, AUTO, or FORCE_AUTO)
 #    * STRICT means that switching will fail if anything goes wrong (an invalid
 #      controller name, a controller that failed to activate, etc.).
 #    * BEST_EFFORT means that even when something goes wrong with one controller,

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -7,7 +7,7 @@
 #  * the list of controller names to deactivate, and
 #  * the strictness (BEST_EFFORT or STRICT)
 #    * STRICT means that switching will fail if anything goes wrong (an invalid
-#      controller name, a controller that failed to activate, etc. ).
+#      controller name, a controller that failed to activate, etc.).
 #    * BEST_EFFORT means that even when something goes wrong with one controller,
 #      the service will still try to activate/deactivate the remaining controllers.
 #      This will still fail if either all controllers to be activated or all controllers to be

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -11,7 +11,7 @@
 #    * BEST_EFFORT:
 #      Transitions are only triggered if the controller is not yet in the target state.
 #      If it is already in the target state, no error occurs.
-#      Returns 'false' if no controller of 'activate_controllers' or 'deactivate_controllers' exists,
+#      Returns 'false' if all controllers of 'activate_controllers' or 'deactivate_controllers' are not yet loaded or configured,
 #      or the pending transitions of all existing controllers of 'activate_controllers'
 #      or 'deactivate_controllers' fail.
 #      Returns 'true' otherwise.

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -10,7 +10,7 @@
 #      controller name, a controller that failed to activate, etc. ).
 #    * BEST_EFFORT means that even when something goes wrong with one controller,
 #      the service will still try to activate/deactivate the remaining controllers.
-#      This will still fail if either all controllers to be activated or all controllers to be 
+#      This will still fail if either all controllers to be activated or all controllers to be
 #      deactivated have invalid names.
 #    * AUTO means that the controller manager will automatically resolve the controller
 #      chain in order to activate and/or deactivate the specified controllers.

--- a/controller_manager_msgs/srv/SwitchController.srv
+++ b/controller_manager_msgs/srv/SwitchController.srv
@@ -10,7 +10,7 @@
 #      controller name, a controller that failed to activate, etc.).
 #    * BEST_EFFORT means that even when something goes wrong with one controller,
 #      the service will still try to activate/deactivate the remaining controllers.
-#      This will still fail if either all controllers to be activated or all controllers to be
+#      However, this will still fail if either all controllers to be activated or all controllers to be
 #      deactivated have invalid names.
 #    * AUTO means that the controller manager will automatically resolve the controller
 #      chain in order to activate and/or deactivate the specified controllers.


### PR DESCRIPTION
When migrating our codebase from humble to jazzy/rolling, I encountered a change in behavior when calling the SwitchController service. If affects the BEST_EFFORT strictness and was introduced in https://github.com/ros-controls/ros2_control/pull/2060.

This PR aims to clarify the documentation regarding the new behavior.