### PR TITLE
hardware_interface: fix get_node() docs to reference HardwareComponentInterface

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -682,9 +682,9 @@ public:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return clock_; }
 
-  /// Get the default node of the Interface.
+  /// Get the default node of the HardwareComponentInterface.
   /**
-   * \return node of the Interface.
+   * \return node of the HardwareComponentInterface.
    */
   rclcpp::Node::SharedPtr get_node() const { return hardware_component_node_; }
 


### PR DESCRIPTION
- `get_node()` in the base class now correctly references **HardwareComponentInterface** instead of **Interface**.
- No functional or API changes; comment-only fix.

Pre-commit checks pass locally.
