### PR TITLE
hardware_interface: fix get_node() docs in HardwareComponentInterface

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -682,9 +682,9 @@ public:
    */
   rclcpp::Clock::SharedPtr get_clock() const { return clock_; }
 
-  /// Get the default node of the Interface.
+  /// Get the default node of the HardwareComponentInterface.
   /**
-   * \return node of the Interface.
+   * \return node of the HardwareComponentInterface.
    */
   rclcpp::Node::SharedPtr get_node() const { return hardware_component_node_; }
 


### PR DESCRIPTION

This PR adapts the fix from issue #2419 to the current codebase.

In older versions of `ros2_control`, `get_node()` existed separately in
`system_interface.hpp` and `sensor_interface.hpp`, and the Doxygen comments there
incorrectly referenced **ActuatorInterface**.

In the current version, `get_node()` lives only in the base class
(`hardware_component_interface.hpp`). However, its comment still incorrectly
referred to **System_Interface**.

This PR corrects the documentation to properly reference
**HardwareComponentInterface**.

- Comment-only change
- No functional or API impact

Fixes #2419
