### PR TITLE
Remove extra semicolons [-Wpedantic]

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -89,7 +89,7 @@ std::string interfaces_to_string(
   }
   ss << "]" << std::endl;
   return ss.str();
-};
+}
 
 void find_common_hardware_interfaces(
   const std::vector<std::string> & hw_command_itfs,

--- a/joint_limits/include/joint_limits/data_structures.hpp
+++ b/joint_limits/include/joint_limits/data_structures.hpp
@@ -38,10 +38,10 @@
 namespace joint_limits
 {
 
-DEFINE_LIMIT_STRUCT(PositionLimits);
-DEFINE_LIMIT_STRUCT(VelocityLimits);
-DEFINE_LIMIT_STRUCT(EffortLimits);
-DEFINE_LIMIT_STRUCT(AccelerationLimits);
+DEFINE_LIMIT_STRUCT(PositionLimits)
+DEFINE_LIMIT_STRUCT(VelocityLimits)
+DEFINE_LIMIT_STRUCT(EffortLimits)
+DEFINE_LIMIT_STRUCT(AccelerationLimits)
 
 struct JointControlInterfacesData
 {


### PR DESCRIPTION
This PR removes unnecessary trailing semicolons that were triggering -Wpedantic compiler warnings.

Fixes issue #2475.
Scope is minimal (good first issue).

Removed redundant semicolons from:
- joint_limits/include/joint_limits/data_structures.hpp (lines 41–44)
- hardware_interface/src/resource_manager.cpp (line 92)

Confirmed that code compiles cleanly without warnings.