### PR TITLE
add dependency on 'urdf' back

### DIFF
--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp
   rclcpp_lifecycle
+  urdf
 )
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Fix the removed `urdf` dependency from https://github.com/ros-controls/ros2_control/pull/2480.