### PR TITLE
install missing test configurations

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -204,7 +204,12 @@ if(BUILD_TESTING)
   )
 
   find_package(ament_cmake_pytest REQUIRED)
-  install(FILES test/test_ros2_control_node.yaml
+  install(FILES
+    test/test_ros2_control_node.yaml
+    test/test_controller_spawner_wildcard_entries.yaml
+    test/test_controller_spawner_with_basic_controllers.yaml
+    test/test_controller_spawner_with_interfaces.yaml
+    test/test_controller_spawner_with_type.yaml
     DESTINATION test)
   ament_add_pytest_test(test_ros2_control_node test/test_ros2_control_node_launch.py)
 endif()


### PR DESCRIPTION
This installs some test configuration files required for running the tests. Fixes test issue in https://github.com/ros-controls/ros2_control/pull/2480.