### PR TITLE
Enable controller activation for inactive hardware component

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -2011,16 +2011,6 @@ bool ResourceManager::prepare_command_mode_switch(
         continue;
       }
       if (
-        !start_interfaces_buffer.empty() &&
-        component.get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-      {
-        RCLCPP_WARN(
-          logger, "Component '%s' is in INACTIVE state, but has start interfaces to switch: \n%s",
-          component.get_name().c_str(),
-          interfaces_to_string(start_interfaces_buffer, stop_interfaces_buffer).c_str());
-        return false;
-      }
-      if (
         component.get_lifecycle_state().id() ==
           lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE ||
         component.get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
@@ -2109,16 +2099,6 @@ bool ResourceManager::perform_command_mode_switch(
           logger, "Component '%s' after filtering has no command interfaces to perform switch",
           component.get_name().c_str());
         continue;
-      }
-      if (
-        !start_interfaces_buffer.empty() &&
-        component.get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-      {
-        RCLCPP_WARN(
-          logger, "Component '%s' is in INACTIVE state, but has start interfaces to switch: \n%s",
-          component.get_name().c_str(),
-          interfaces_to_string(start_interfaces_buffer, stop_interfaces_buffer).c_str());
-        return false;
       }
       if (
         component.get_lifecycle_state().id() ==

--- a/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
+++ b/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
@@ -210,32 +210,28 @@ TEST_F(
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0);
 
-  // When TestActuatorHardware is INACTIVE expect not OK
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
+  // When TestActuatorHardware is INACTIVE expect OK
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.0, 1e-7)
-    << "Start interfaces with inactive should result in no change";
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.001, 1e-7);
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.0, 1e-7)
-    << "Start interfaces with inactive should result in no change";
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.101, 1e-7);
 
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.0, 1e-7)
-    << "Start interfaces with inactive should result in no change";
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.102, 1e-7);
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.0, 1e-7)
-    << "Start interfaces with inactive should result in no change";
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.202, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.001, 1e-7);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.203, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator))
-    << "Inactive with empty start interfaces is OK";
+    << "Inactive is OK";
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.101, 1e-7);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.303, 1e-7);
 };
 
 // System  : INACTIVE
@@ -247,58 +243,54 @@ TEST_F(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, "inactive",
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active");
 
-  // When TestSystemCommandModes is INACTIVE expect not OK
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_system, legal_keys_system));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0)
-    << "Start interfaces with inactive should result in no change";
+  // When TestSystemCommandModes is INACTIVE expect OK
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, legal_keys_system));
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 1.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_system, legal_keys_system));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0)
-    << "Start interfaces with inactive should result in no change";
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, legal_keys_system));
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
 
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_system, empty_keys));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0)
-    << "Start interfaces with inactive should result in no change";
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_system, empty_keys));
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 102.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_system, empty_keys));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0)
-    << "Start interfaces with inactive should result in no change";
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_system, empty_keys));
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 202.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_system));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 1.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 203.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
   EXPECT_FALSE(rm_->perform_command_mode_switch(empty_keys, legal_keys_system));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_EQ(claimed_actuator_position_state_->get_optional().value(), 0.0)
     << "System interfaces shouldn't affect the actuator";
 
   // When TestActuatorHardware is ACTIVE expect OK
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.001, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, legal_keys_actuator));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.101, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.102, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.202, 1e-7);
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.203, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator));
-  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 101.0);
+  EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 303.0);
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.303, 1e-7);
 };
 
@@ -451,13 +443,13 @@ TEST_F(
   EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.404, 1e-7);
 
   // Similar to the proximal activation
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.404, 1e-7);
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys))
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.405, 1e-7);
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys))
     << "Start interfaces with inactive should result in no change";
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.404, 1e-7)
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7)
     << "Start interfaces with inactive should result in no change";
 
   // Now return ERROR with write fail value
@@ -476,17 +468,17 @@ TEST_F(
 
   EXPECT_TRUE(rm_->prepare_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.405, 1e-7);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.506, 1e-7);
   EXPECT_TRUE(rm_->perform_command_mode_switch(empty_keys, legal_keys_actuator));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.606, 1e-7);
 
-  EXPECT_FALSE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
+  EXPECT_TRUE(rm_->prepare_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7);
-  EXPECT_FALSE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.607, 1e-7);
+  EXPECT_TRUE(rm_->perform_command_mode_switch(legal_keys_actuator, empty_keys));
   EXPECT_EQ(claimed_system_acceleration_state_->get_optional().value(), 0.0);
-  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.505, 1e-7);
+  EXPECT_NEAR(claimed_actuator_position_state_->get_optional().value(), 0.707, 1e-7);
 };
 
 // System  : UNCONFIGURED


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/ros2_control/issues/2484

This will re-enable the controller activation for an inactive hardware component. If the hardware wants to avoid this behavior, they can implement the logic inside the hardware component. However, when an DEACTIVATE is returned over the read/write cycle (https://github.com/ros-controls/ros2_control/pull/2334), the controllers will continue to deactivate without maintaining in active state