### PR TITLE
Fix runtime variant access bug in `HardwareComponentInterface::get_command` helper method

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -582,6 +582,14 @@ public:
     lifecycle_state_ = new_state;
   }
 
+  /// Set the value of a state interface.
+  /**
+   * \tparam T The type of the value to be stored.
+   * \param[in] interface_name The name of the state interface to access.
+   * \param[in] value The value to store.
+   * \throws std::runtime_error This method throws a runtime error if it cannot
+   * access the state interface.
+   */
   template <typename T>
   void set_state(const std::string & interface_name, const T & value)
   {
@@ -600,6 +608,14 @@ public:
     std::ignore = handle->set_value(lock, value);
   }
 
+  /// Get the value from a state interface.
+  /**
+   * \tparam T The type of the value to be retrieved.
+   * \param[in] interface_name The name of the state interface to access.
+   * \return The value obtained from the interface.
+   * \throws std::runtime_error This method throws a runtime error if it cannot
+   * access the state interface or its stored value.
+   */
   template <typename T = double>
   T get_state(const std::string & interface_name) const
   {
@@ -626,6 +642,15 @@ public:
     return opt_value.value();
   }
 
+  /// Set the value of a command interface.
+  /**
+   * \tparam T The type of the value to be stored.
+   * \param interface_name The name of the command
+   * interface to access.
+   * \param value The value to store.
+   * \throws This method throws a runtime error if it
+   * cannot access the command interface.
+   */
   template <typename T>
   void set_command(const std::string & interface_name, const T & value)
   {
@@ -644,6 +669,14 @@ public:
     std::ignore = handle->set_value(lock, value);
   }
 
+  ///  Get the value from a command interface.
+  /**
+   * \tparam T The type of the value to be retrieved.
+   * \param[in] interface_name The name of the command interface to access.
+   * \return The value obtained from the interface.
+   * \throws std::runtime_error This method throws a runtime error if it cannot
+   * access the command interface or its stored value.
+   */
   template <typename T = double>
   T get_command(const std::string & interface_name) const
   {


### PR DESCRIPTION
A fix for https://github.com/ros-controls/ros2_control/issues/2401, where the underlying variant type of a command interface was always read as a double, ignoring the passed template parameter. This PR also adds some documentation to get_command and related methods.