### PR TITLE
Fix `github.ref` check for concurrency settings

### DIFF
--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -15,9 +15,9 @@ on:
       - 'ros2_control-not-released.humble.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -33,9 +33,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/humble-coverage-build.yml
+++ b/.github/workflows/humble-coverage-build.yml
@@ -29,9 +29,9 @@ on:
       - 'codecov.yml'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage_humble:

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -18,9 +18,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -18,9 +18,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -33,9 +33,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on humble branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:

--- a/.github/workflows/jazzy-abi-compatibility.yml
+++ b/.github/workflows/jazzy-abi-compatibility.yml
@@ -15,9 +15,9 @@ on:
       - 'ros2_control-not-released.jazzy.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -33,9 +33,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -18,9 +18,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/jazzy-rhel-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-binary-build.yml
@@ -18,9 +18,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -33,9 +33,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on jazzy branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -16,9 +16,9 @@ on:
       - 'ros2_control-not-released.kilted.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   abi_check:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -35,9 +35,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -30,9 +30,9 @@ on:
       - 'ros2_control.rolling.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-humble:

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -30,9 +30,9 @@ on:
       - 'ros2_control.rolling.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-jazzy:

--- a/.github/workflows/rolling-compatibility-kilted-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-kilted-binary-build.yml
@@ -30,9 +30,9 @@ on:
       - 'ros2_control.rolling.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-on-kilted:

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -29,9 +29,9 @@ on:
       - 'codecov.yml'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   coverage_rolling:

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -19,9 +19,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 
 jobs:

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -19,9 +19,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/rolling-semi-binary-build-win.yml
+++ b/.github/workflows/rolling-semi-binary-build-win.yml
@@ -32,9 +32,9 @@ on:
       - 'ros2_control.windows.rolling.repos'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary-windows:

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -35,9 +35,9 @@ on:
     - cron: '03 1 * * MON-FRI'
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:


### PR DESCRIPTION
`github.ref`:
> The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>.
which means the leading slash was wrong, see [this canceled job for example](https://github.com/ros-controls/kinematics_interface/actions/runs/17260587722).

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context