### PR TITLE
Add parameter to allow controllers with inactive hardware components

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -417,6 +417,8 @@ ControllerManager::ControllerManager(
   params.activate_all = activate_all_hw_components;
   params.update_rate = static_cast<unsigned int>(params_->update_rate);
   params.executor = executor_;
+  params.allow_control_with_inactive_hardware =
+    params_->defaults.allow_control_with_inactive_hardware;
   resource_manager_ = std::make_unique<hardware_interface::ResourceManager>(params, true);
   init_controller_manager();
 }

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -53,6 +53,12 @@ controller_manager:
           ]],
         }
       }
+    allow_control_with_inactive_hardware: {
+      type: bool,
+      default_value: false,
+      read_only: true,
+      description: "If true, controllers are allowed to claim resources from inactive hardware components. If false, controllers can only claim resources from active hardware components. Moreover, when the hardware component returns DEACTIVATE on read/write cycle, the controllers using those interfaces will continue to run, when the parameter is set to false. If set to true, the controllers using those interfaces will be deactivated.",
+    }
 
   diagnostics:
     threshold:

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -631,6 +631,7 @@ protected:
   rclcpp::Clock::SharedPtr get_clock() const;
 
   bool components_are_loaded_and_initialized_ = false;
+  bool allow_control_with_inactive_hardware_ = false;
 
   mutable std::recursive_mutex resource_interfaces_lock_;
   mutable std::recursive_mutex claimed_command_interfaces_lock_;

--- a/hardware_interface/include/hardware_interface/types/resource_manager_params.hpp
+++ b/hardware_interface/include/hardware_interface/types/resource_manager_params.hpp
@@ -62,6 +62,19 @@ struct ResourceManagerParams
   bool activate_all = false;
 
   /**
+   * @brief If true, controllers are allowed to claim resources from inactive hardware components.
+   * If false, controllers can only claim resources from active hardware components.
+   * Moreover, when the hardware component returns DEACTIVATE on read/write cycle,
+   * the controllers using those interfaces will continue to run, when the parameter is set to
+   * false. If set to true, the controllers using those interfaces will be deactivated.
+   * @warning Allowing control with inactive hardware is not recommended for safety reasons.
+   * Use with caution only if you really know what you are doing.
+   * @note This parameter might be deprecated or removed in the future releases. Please use with
+   * caution.
+   */
+  bool allow_control_with_inactive_hardware = false;
+
+  /**
    * @brief The update rate (in Hz) of the ControllerManager.
    * This can be used by ResourceManager to configure asynchronous hardware components
    * or for other timing considerations.


### PR DESCRIPTION
Gives https://github.com/ros-controls/ros2_control/issues/2484 a possibility to fix with a parameter