### PR TITLE
Fix the CPU affinity of the ros2_control_node

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -70,29 +70,6 @@ int main(int argc, char ** argv)
     }
   }
 
-  rclcpp::Parameter cpu_affinity_param;
-  if (cm->get_parameter("cpu_affinity", cpu_affinity_param))
-  {
-    std::vector<int> cpus = {};
-    if (cpu_affinity_param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
-    {
-      cpus = {static_cast<int>(cpu_affinity_param.as_int())};
-    }
-    else if (cpu_affinity_param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY)
-    {
-      const auto cpu_affinity_param_array = cpu_affinity_param.as_integer_array();
-      std::for_each(
-        cpu_affinity_param_array.begin(), cpu_affinity_param_array.end(),
-        [&cpus](int cpu) { cpus.push_back(static_cast<int>(cpu)); });
-    }
-    const auto affinity_result = realtime_tools::set_current_thread_affinity(cpus);
-    if (!affinity_result.first)
-    {
-      RCLCPP_WARN(
-        cm->get_logger(), "Unable to set the CPU affinity : '%s'", affinity_result.second.c_str());
-    }
-  }
-
   // wait for the clock to be available
   cm->get_clock()->wait_until_started();
   cm->get_clock()->sleep_for(rclcpp::Duration::from_seconds(1.0 / cm->get_update_rate()));
@@ -106,6 +83,30 @@ int main(int argc, char ** argv)
   std::thread cm_thread(
     [cm, thread_priority, use_sim_time]()
     {
+      rclcpp::Parameter cpu_affinity_param;
+      if (cm->get_parameter("cpu_affinity", cpu_affinity_param))
+      {
+        std::vector<int> cpus = {};
+        if (cpu_affinity_param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+        {
+          cpus = {static_cast<int>(cpu_affinity_param.as_int())};
+        }
+        else if (cpu_affinity_param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY)
+        {
+          const auto cpu_affinity_param_array = cpu_affinity_param.as_integer_array();
+          std::for_each(
+            cpu_affinity_param_array.begin(), cpu_affinity_param_array.end(),
+            [&cpus](int cpu) { cpus.push_back(static_cast<int>(cpu)); });
+        }
+        const auto affinity_result = realtime_tools::set_current_thread_affinity(cpus);
+        if (!affinity_result.first)
+        {
+          RCLCPP_WARN(
+            cm->get_logger(), "Unable to set the CPU affinity : '%s'",
+            affinity_result.second.c_str());
+        }
+      }
+
       if (!realtime_tools::configure_sched_fifo(thread_priority))
       {
         RCLCPP_WARN(


### PR DESCRIPTION
If we set the CPU affinity to the controller_manager, with the current setup the non-RT things also run on the same CPU and time to time the RT node is being blocked for sometimes for some reasons. 

Changing it to only RT loop fixes the current issue

Without the fix:

```
    PID     TID PSR %CPU %MEM CLS RTPRIO PRI
  21006   21006   6  0.0  1.3 TS       -  19
  21006   21019   6  0.0  1.3 TS       -  19
  21006   21020   2  0.0  1.3 TS       -  19
  21006   21021   2  0.0  1.3 TS       -  19
  21006   21022   7  0.0  1.3 TS       -  19
  21006   21023   6  0.0  1.3 TS       -  19
  21006   21024   3  0.0  1.3 TS       -  19
  21006   21025   6  0.0  1.3 TS       -  19
  21006   21026   1  0.0  1.3 TS       -  19
  21006   21027   0  1.4  1.3 TS       -  19
  21006   21028   3  1.5  1.3 TS       -  19
  21006   21029   6 14.7  1.3 FF      50  90
  21006   21030   6  0.0  1.3 TS       -  19
  21006   21031   6  0.0  1.3 TS       -  19
  21006   21032   6  0.0  1.3 TS       -  19
  21006   21033   6  0.0  1.3 TS       -  19
  21006   21034   6  0.0  1.3 TS       -  19
  21006   21035   6  0.0  1.3 TS       -  19
  21006   21036   6  0.0  1.3 TS       -  19
  21006   21037   4 16.4  1.3 FF      70 110
  21006   21042   6  0.7  1.3 FF      50  90
  21006   21048   6  0.0  1.3 TS       -  19
  21006   21052   6  3.2  1.3 TS       -  19
  21006   21053   6  4.2  1.3 TS       -  19
  21006   21054   6  3.2  1.3 TS       -  19
  21006   21055   6  0.0  1.3 TS       -  19
  21006   21056   6  1.2  1.3 TS       -  19
  21006   21057   6  0.2  1.3 TS       -  19
  21006   21058   6  0.2  1.3 TS       -  19
  21006   21059   6  0.2  1.3 TS       -  19
  21006   21060   6  0.2  1.3 TS       -  19
  21006   21061   6  0.2  1.3 TS       -  19
  21006   21062   6  0.2  1.3 TS       -  19
  21006   21063   6  0.2  1.3 TS       -  19
  21006   21064   6  0.2  1.3 TS       -  19
  21006   21688   6  0.1  1.3 TS       -  19
  21006   21689   6  0.9  1.3 TS       -  19
  21006   21697   6  0.0  1.3 TS       -  19
  21006   21717   6  0.0  1.3 TS       -  19
  21006   21726   6  0.0  1.3 TS       -  19
  21006   21734   6  0.0  1.3 TS       -  19
  21006   21735   6  0.8  1.3 TS       -  19
  21006   21744   6  0.0  1.3 TS       -  19
  21006   21779   6  0.0  1.3 TS       -  19
```


With the current fix: (All threads are running on different cores, except the RT with thread priorities)
```
    PID     TID PSR %CPU %MEM CLS RTPRIO PRI
  15006   15006   6  0.0  1.3 TS       -  19
  15006   15019   6  0.0  1.3 TS       -  19
  15006   15020   2  0.0  1.3 TS       -  19
  15006   15021   2  0.0  1.3 TS       -  19
  15006   15022   7  0.0  1.3 TS       -  19
  15006   15023   6  0.0  1.3 TS       -  19
  15006   15024   3  0.0  1.3 TS       -  19
  15006   15025   6  0.0  1.3 TS       -  19
  15006   15026   1  0.0  1.3 TS       -  19
  15006   15027   0  1.2  1.3 TS       -  19
  15006   15028   3  1.2  1.3 TS       -  19
  15006   15029   6 14.7  1.3 FF      50  90
  15006   15030   5  0.0  1.3 TS       -  19
  15006   15031   3  0.0  1.3 TS       -  19
  15006   15032   0  0.0  1.3 TS       -  19
  15006   15033   2  0.0  1.3 TS       -  19
  15006   15034   1  0.0  1.3 TS       -  19
  15006   15035   5  0.0  1.3 TS       -  19
  15006   15036   6  0.0  1.3 TS       -  19
  15006   15037   4 16.4  1.3 FF      70 110
  15006   15042   1  0.7  1.3 FF      50  90
  15006   15048   0  0.0  1.3 TS       -  19
  15006   15052   3  3.2  1.3 TS       -  19
  15006   15053   4  4.2  1.3 TS       -  19
  15006   15054   0  3.2  1.3 TS       -  19
  15006   15055   0  0.0  1.3 TS       -  19
  15006   15056   6  1.2  1.3 TS       -  19
  15006   15057   4  0.2  1.3 TS       -  19
  15006   15058   6  0.2  1.3 TS       -  19
  15006   15059   7  0.2  1.3 TS       -  19
  15006   15060   4  0.2  1.3 TS       -  19
  15006   15061   0  0.2  1.3 TS       -  19
  15006   15062   7  0.2  1.3 TS       -  19
  15006   15063   4  0.2  1.3 TS       -  19
  15006   15064   3  0.2  1.3 TS       -  19
  15006   15688   0  0.1  1.3 TS       -  19
  15006   15689   1  0.9  1.3 TS       -  19
  15006   15697   7  0.0  1.3 TS       -  19
  15006   15717   2  0.0  1.3 TS       -  19
  15006   15726   7  0.0  1.3 TS       -  19
  15006   15734   7  0.0  1.3 TS       -  19
  15006   15735   0  0.8  1.3 TS       -  19
  15006   15744   0  0.0  1.3 TS       -  19
  15006   15779   2  0.0  1.3 TS       -  19
```
