### PR TITLE
Fix interface configuration docs

### DIFF
--- a/hardware_interface/doc/hardware_interface_types_userdoc.rst
+++ b/hardware_interface/doc/hardware_interface_types_userdoc.rst
@@ -25,13 +25,12 @@ A generic example which shows the structure is provided below. More specific exa
         <param name="example_param">value</param>
       </hardware>
       <joint name="name_of_the_component">
-        <command_interface name="interface_name">
-          <!-- All of them are optional. `data_type` and `size` are used for GPIOs. Size is length of an array. -->
+        <!-- `data_type` argument is optional (defaults to double). -->
+        <command_interface name="interface_name" data_type="double">
+          <!-- All of them are optional. -->
           <param name="min">-1</param>
           <param name="max">1</param>
           <param name="initial_value">0.0</param>
-          <param name="data_type"></param>
-          <param name="size">5</param>
            <!-- Optional. Added to the key/value storage parameters -->
           <param name="own_param_1">some_value</param>
           <param name="own_param_2">other_value</param>


### PR DESCRIPTION
`data_type` and `size` are XML attributes, not elements. Tested with my hardware, but also see
https://github.com/ros-controls/ros2_control/blob/0301b0a868fed0e0cfef59954c6e37af1b267267/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp#L757-L759

I removed size completely, as we parse and test it but don't use it anywhere (or am I missing something?):

<img width="571" height="277" alt="image" src="https://github.com/user-attachments/assets/8eff905e-9b4a-47fa-b1d6-b4c3fd04c4ad" />
