### PR TITLE
remove virtual from the add_measurement method

### DIFF
--- a/hardware_interface/include/hardware_interface/types/statistics_types.hpp
+++ b/hardware_interface/include/hardware_interface/types/statistics_types.hpp
@@ -169,7 +169,7 @@ public:
    *
    *  @param item The item that was observed
    */
-  virtual void add_measurement(const double item)
+  void add_measurement(const double item)
   {
     std::lock_guard<DEFAULT_MUTEX> guard{mutex_};
 


### PR DESCRIPTION
Fixes: https://github.com/ros-controls/ros2_control/issues/2556

I don't think the method needs to be virtual, and with this change the warnings shouldn't appear anymore. 