### PR TITLE
Add joint names as std::string to mimic struct

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -55,7 +55,9 @@ struct InterfaceInfo
 /// @brief This structure stores information about a joint that is mimicking another joint
 struct MimicJoint
 {
+  std::string joint_name;
   std::size_t joint_index;
+  std::string mimicked_joint_name;
   std::size_t mimicked_joint_index;
   double multiplier = 1.0;
   double offset = 0.0;

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -994,7 +994,9 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
         };
 
         MimicJoint mimic_joint;
+        mimic_joint.joint_name = joint.name;
         mimic_joint.joint_index = i;
+        mimic_joint.mimicked_joint_name = urdf_joint->mimic->joint_name;
         mimic_joint.mimicked_joint_index = find_joint(urdf_joint->mimic->joint_name);
         mimic_joint.multiplier = urdf_joint->mimic->multiplier;
         mimic_joint.offset = urdf_joint->mimic->offset;

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -1569,7 +1569,9 @@ TEST_F(TestComponentParser, gripper_mimic_true_valid_config)
   EXPECT_DOUBLE_EQ(hw_info[0].mimic_joints[0].multiplier, 2.0);
   EXPECT_DOUBLE_EQ(hw_info[0].mimic_joints[0].offset, 1.0);
   EXPECT_EQ(hw_info[0].mimic_joints[0].mimicked_joint_index, 0);
+  EXPECT_EQ(hw_info[0].mimic_joints[0].mimicked_joint_name, "right_finger_joint");
   EXPECT_EQ(hw_info[0].mimic_joints[0].joint_index, 1);
+  EXPECT_EQ(hw_info[0].mimic_joints[0].joint_name, "left_finger_joint");
   // when not set, rw_rate should be 0
   EXPECT_EQ(hw_info[0].rw_rate, 0u);
 }
@@ -1587,7 +1589,9 @@ TEST_F(TestComponentParser, gripper_no_mimic_valid_config)
   EXPECT_DOUBLE_EQ(hw_info[0].mimic_joints[0].multiplier, 2.0);
   EXPECT_DOUBLE_EQ(hw_info[0].mimic_joints[0].offset, 1.0);
   EXPECT_EQ(hw_info[0].mimic_joints[0].mimicked_joint_index, 0);
+  EXPECT_EQ(hw_info[0].mimic_joints[0].mimicked_joint_name, "right_finger_joint");
   EXPECT_EQ(hw_info[0].mimic_joints[0].joint_index, 1);
+  EXPECT_EQ(hw_info[0].mimic_joints[0].joint_name, "left_finger_joint");
   // when not set, rw_rate should be 0
   EXPECT_EQ(hw_info[0].rw_rate, 0u);
 }


### PR DESCRIPTION
In the handles and API for the hardware components we use vector of joint names and also unordered maps with joint names keys.
While I was working on https://github.com/ros-controls/ros2_control/pull/2571 I found it helpful to have also the string names in the mimic struct, instead of the indices only.