### PR TITLE
Update migration guide (and fix format)

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -8,14 +8,27 @@ This list summarizes important changes between Jazzy (previous) and Kilted (curr
 
 controller_interface
 ********************
+
 * ``get_ordered_interfaces`` now throws if the size of the output vector does not match the size of the input names vector (`#2528 <https://github.com/ros-controls/ros2_control/pull/2528>`__).
+* ``controller_interface::init()`` has been deprecated, use the ``init(const controller_interface::ControllerInterfaceParams & params)`` method instead. (`#2390 <https://github.com/ros-controls/ros2_control/pull/2390>`__).
+  For example, the following code:
+
+  .. code-block:: cpp
+
+    controller_interface::ControllerInterfaceParams params;
+    params.controller_name = "controller_name";
+    params.robot_description = "";
+    params.update_rate = 50;
+    params.node_namespace = "";
+    params.node_options = controller.define_custom_node_options();
+    controller.init(params);
 
 controller_manager
 ******************
 
 * The spawner now supports two new arguments ``--switch-asap`` and ``--no-switch-asap`` to control the behaviour of the spawner when switching controllers to be in realtime loop (or) non-realtime loop.
-   By default, it is set to ``--no-switch-asap`` because when activating multiple controllers at same time might affect the realtime loop performance (`#2452 <https://github.com/ros-controls/ros2_control/pull/2453>`_)
-   If it is needed to switch controllers in realtime loop, then the argument ``--switch-asap`` need to be parsed to the spawner.
+  By default, it is set to ``--no-switch-asap`` because when activating multiple controllers at same time might affect the realtime loop performance (`#2452 <https://github.com/ros-controls/ros2_control/pull/2453>`_).
+  If it is needed to switch controllers in realtime loop, then the argument ``--switch-asap`` need to be parsed to the spawner.
 
 hardware_interface
 ******************


### PR DESCRIPTION
#2390 was missing its migration note.