### PR TITLE
Fix `-Wreturn-local-addr` compiler warning

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -194,12 +194,10 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
     async_params.initialize(node_, "async_parameters.");
     if (async_params.scheduling_policy == realtime_tools::AsyncSchedulingPolicy::DETACHED)
     {
-      const rclcpp_lifecycle::State unconfigured_state(
-        lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured");
       RCLCPP_ERROR(
         get_node()->get_logger(),
         "The controllers are not supported to run asynchronously in detached mode!");
-      return unconfigured_state;
+      return get_node()->get_current_state();
     }
     RCLCPP_INFO(
       get_node()->get_logger(), "Starting async handler with scheduler priority: %d",


### PR DESCRIPTION
Fixes
```

--- stderr: controller_interface                                  
/workspaces/ros2_rolling_ws/src/ros2_control/controller_interface/src/controller_interface_base.cpp: In member function ‘const rclcpp_lifecycle::State& controller_interface::ControllerInterfaceBase::configure()’:
/workspaces/ros2_rolling_ws/src/ros2_control/controller_interface/src/controller_interface_base.cpp:202:14: warning: reference to local variable ‘unconfigured_state’ returned [-Wreturn-local-addr]
  202 |       return unconfigured_state;
      |              ^~~~~~~~~~~~~~~~~~
/workspaces/ros2_rolling_ws/src/ros2_control/controller_interface/src/controller_interface_base.cpp:197:37: note: declared here
  197 |       const rclcpp_lifecycle::State unconfigured_state(
      |                                     ^~~~~~~~~~~~~~~~~~
---
```