### PR TITLE
Fix `RCLCPP_WARN_ONCE` within handle

### DIFF
--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -25,6 +25,7 @@
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <variant>

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -27,7 +27,6 @@
 #include <shared_mutex>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <variant>
 

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -99,8 +99,7 @@ public:
       {
         throw std::invalid_argument(
           fmt::format(
-            FMT_COMPILE(
-              "Invalid initial value : '{}' parsed for interface : '{}' with type : '{}'"),
+            FMT_COMPILE("Invalid initial value: '{}' parsed for interface: '{}' with type: '{}'"),
             initial_value, handle_name_, data_type_.to_string()));
       }
     }
@@ -114,7 +113,7 @@ public:
       throw std::runtime_error(
         fmt::format(
           FMT_COMPILE(
-            "Invalid data type : '{}' for interface : {}. Supported types are double and bool."),
+            "Invalid data type: '{}' for interface: {}. Supported types are double and bool."),
           data_type, handle_name_));
     }
   }
@@ -223,7 +222,7 @@ public:
           {
             RCLCPP_WARN(
               rclcpp::get_logger(get_name()),
-              "Casting bool to double for interface : %s. Better use get_optional<bool>().",
+              "Casting bool to double for interface: %s. Better use get_optional<bool>().",
               get_name().c_str());
             notified_map[this] = true;
           }
@@ -231,7 +230,7 @@ public:
         default:
           throw std::runtime_error(
             fmt::format(
-              FMT_COMPILE("Data type : '{}' cannot be casted to double for interface : {}"),
+              FMT_COMPILE("Data type: '{}' cannot be casted to double for interface: {}"),
               data_type_.to_string(), get_name()));
       }
     }
@@ -243,7 +242,7 @@ public:
     {
       throw std::runtime_error(
         fmt::format(
-          FMT_COMPILE("Invalid data type : '{}' access for interface : {} expected : '{}'"),
+          FMT_COMPILE("Invalid data type: '{}' access for interface: {} expected: '{}'"),
           get_type_name<T>(), get_name(), data_type_.to_string()));
     }
     // END
@@ -300,7 +299,7 @@ public:
       {
         throw std::runtime_error(
           fmt::format(
-            FMT_COMPILE("Invalid data type : '{}' access for interface : {} expected : '{}'"),
+            FMT_COMPILE("Invalid data type: '{}' access for interface: {} expected: '{}'"),
             get_type_name<T>(), get_name(), data_type_.to_string()));
       }
       value_ = value;

--- a/hardware_interface/include/hardware_interface/handle.hpp
+++ b/hardware_interface/include/hardware_interface/handle.hpp
@@ -208,23 +208,22 @@ public:
     // TODO(saikishor) return value_ if old functionality is removed
     if constexpr (std::is_same_v<T, double>)
     {
-      // TODO(christophfroehlich): replace with RCLCPP_WARN_ONCE once
-      // https://github.com/ros2/rclcpp/issues/2587
-      // is fixed
-      static std::unordered_map<const Handle *, bool> notified_map;
       switch (data_type_)
       {
         case HandleDataType::DOUBLE:
           THROW_ON_NULLPTR(value_ptr_);
           return *value_ptr_;
         case HandleDataType::BOOL:
-          if (notified_map.find(this) == notified_map.end() || !notified_map[this])
+          // TODO(christophfroehlich): replace with RCLCPP_WARN_ONCE once
+          // https://github.com/ros2/rclcpp/issues/2587
+          // is fixed
+          if (!notified_)
           {
             RCLCPP_WARN(
               rclcpp::get_logger(get_name()),
               "Casting bool to double for interface: %s. Better use get_optional<bool>().",
               get_name().c_str());
-            notified_map[this] = true;
+            notified_ = true;
           }
           return static_cast<double>(std::get<bool>(value_));
         default:
@@ -354,6 +353,12 @@ protected:
   double * value_ptr_;
   // END
   mutable std::shared_mutex handle_mutex_;
+
+private:
+  // TODO(christophfroehlich): remove once
+  // https://github.com/ros2/rclcpp/issues/2587
+  // is fixed
+  mutable bool notified_ = false;
 };
 
 class StateInterface : public Handle

--- a/hardware_interface/test/test_handle.cpp
+++ b/hardware_interface/test/test_handle.cpp
@@ -230,6 +230,14 @@ TEST(TestHandle, interface_description_bool_data_type)
   ASSERT_FALSE(handle.get_optional<bool>().value());
   ASSERT_EQ(handle.get_optional(), 0.0);
 
+  info.name = "some_interface";
+  interface_descr = InterfaceDescription(itf_name, info);
+  StateInterface handle2{interface_descr};
+  EXPECT_EQ(handle2.get_name(), itf_name + "/" + "some_interface");
+  ASSERT_TRUE(handle2.set_value(false));
+  ASSERT_FALSE(handle2.get_optional<bool>().value());
+  ASSERT_EQ(handle2.get_optional(), 0.0);
+
   // Test the assertions
   ASSERT_THROW({ std::ignore = handle.set_value(-1.0); }, std::runtime_error);
   ASSERT_THROW({ std::ignore = handle.set_value(0.0); }, std::runtime_error);


### PR DESCRIPTION
RCLCPP_*_ONCE logging macros are global, which means this will be triggered only once for the very first handle hitting this.

Unless https://github.com/ros2/rclcpp/issues/2587 is fixed upstream, we have to deal with it in the application code.

I also added a missing include and reformatted the log strings.