### PR TITLE
Remove deprecation warning for jazzy

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -254,8 +254,8 @@ struct HardwareInfo
   unsigned int rw_rate;
   /// Component is async
   bool is_async;
-  /// Async thread priority
-  [[deprecated("Use async_params instead.")]] int thread_priority;
+  /// [[deprecated("Use async_params instead.")]] Async thread priority
+  int thread_priority;
   /// Async Parameters
   HardwareAsyncParams async_params;
   /// Name of the pluginlib plugin of the hardware that will be loaded.


### PR DESCRIPTION
Introduced with #2600, better to remove the deprecation warning like we did on kilted #2605