### PR TITLE
[Spawner] Fix failing makedirs on multiple spawners at startup

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -182,7 +182,10 @@ def main(args=None):
         ros_home = os.getenv("ROS_HOME", os.path.join(os.path.expanduser("~"), ".ros"))
         ros_control_lock_dir = os.path.join(ros_home, "locks")
         if not os.path.exists(ros_control_lock_dir):
-            os.makedirs(ros_control_lock_dir)
+            try:
+                os.makedirs(ros_control_lock_dir)
+            except FileExistsError:
+                pass
         lock = FileLock(f"{ros_control_lock_dir}/ros2-control-controller-spawner.lock")
         max_retries = 5
         retry_delay = 3  # seconds


### PR DESCRIPTION
This is related to the bug reported to me by @christophfroehlich 

```
1: [spawner-5] Traceback (most recent call last):
1: [spawner-5]   File "/workspaces/ros2_rolling_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 185, in main
1: [spawner-5]     os.makedirs(ros_control_lock_dir)
1: [spawner-5]   File "<frozen os>", line 225, in makedirs
1: [spawner-5] FileExistsError: [Errno 17] File exists: '/home/vscode/.ros/locks'
1: [spawner-5] 
1: [spawner-5] During handling of the above exception, another exception occurred:
1: [spawner-5] 
1: [spawner-5] Traceback (most recent call last):
1: [spawner-5]   File "/workspaces/ros2_rolling_ws/install/controller_manager/lib/controller_manager/spawner", line 33, in <module>
1: [spawner-5]     sys.exit(load_entry_point('controller-manager==5.7.0', 'console_scripts', 'spawner')())
1: [spawner-5]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1: [spawner-5]   File "/workspaces/ros2_rolling_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 399, in main
1: [spawner-5]     if lock.is_locked:
1: [spawner-5]        ^^^^
1: [spawner-5] UnboundLocalError: cannot access local variable 'lock' where it is not associated with a value
```