### PR TITLE
fix: Remove check for reference_interfaces_ size in export_reference_…

### DIFF
--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -125,20 +125,6 @@ ChainableControllerInterface::export_reference_interfaces()
   exported_reference_interface_names_.clear();
   ordered_exported_reference_interfaces_.clear();
 
-  // BEGIN (Handle export change): for backward compatibility
-  // check if the "reference_interfaces_" variable is resized to number of interfaces
-  if (reference_interfaces_.size() != reference_interfaces.size())
-  {
-    std::string error_msg = fmt::format(
-      FMT_COMPILE(
-        "The internal storage for reference values 'reference_interfaces_' variable has size '{}', "
-        "but it is expected to have the size '{}' equal to the number of exported reference "
-        "interfaces. Please correct and recompile the controller with name '{}' and try again."),
-      reference_interfaces_.size(), reference_interfaces.size(), get_node()->get_name());
-    throw std::runtime_error(error_msg);
-  }
-  // END
-
   // check if the names of the reference interfaces begin with the controller's name
   const auto ref_interface_size = reference_interfaces.size();
   for (auto & interface : reference_interfaces)


### PR DESCRIPTION
### Summary
This pull request removes the check in `export_reference_interfaces` that compared the size of the `reference_interfaces_`   

I might be wrong but it seems to me this check is not necessary. Removing it simplifies the code and avoids redundant runtime errors. All other interface export and validation logic remains unchanged.

For example, in my trapezoidal controller [here](https://github.com/Basiljamal1/trapezoidal_joint_controller/blob/main/src/TrapezoidalJointController.cpp#L256), I previously had to resize the reference interfaces vector solely to satisfy this check, even though it was not functionally necessary. With this change, reference interfaces can be exported regardless of the vector size, simplifying controller implementations. 

Please take a look and provide feedback :pray: 