### PR TITLE
Fix the CPU affinity of the ros2_control_node (#2509)

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -45,7 +45,7 @@ int main(int argc, char ** argv)
   auto cm = std::make_shared<controller_manager::ControllerManager>(executor, manager_node_name);
 
   const bool use_sim_time = cm->get_parameter_or("use_sim_time", false);
-  
+
   const bool has_realtime = realtime_tools::has_realtime_kernel();
   const bool lock_memory = cm->get_parameter_or<bool>("lock_memory", has_realtime);
   if (lock_memory)


### PR DESCRIPTION
# Changes
- Moves the thread affinity settings into control loop thread. This is a cherry-pick of @saikishor's commit to `humble`
(cherry picked from commit 94e610af911e43eb4c6a4797321fe51cc7f36bd6)