### PR TITLE
hardware_interface: fix C++20 structured-binding capture in lambda (fixes #2574)

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1003,8 +1003,10 @@ public:
   {
     if (interface)
     {
-      for (auto & [hw_name, limiters] : joint_limiters_interface_)
+      for (auto & entry : joint_limiters_interface_)
       {
+        auto & limiters = entry.second;
+
         // If the prefix is a joint name, then bind the limiter to the command interface
         if (limiters.find(interface->get_prefix_name()) != limiters.end())
         {


### PR DESCRIPTION
Remove the `-Wc++20-extensions` warning triggered by capturing a structured binding in a lambda.

ROS 2 still targets C++17 only (REP-2000). Capturing structured bindings directly is a C++20 extension, so we avoid it by using `.second` explicitly instead. The unused first element (hw_name / entry.first) is omitted to avoid the separate -Wunused-variable warning/error.

No functional change.

Fixes #2574

Tested locally:
- `colcon build --packages-select hardware_interface`
- `colcon test --packages-select hardware_interface` - all tests pass 