### PR TITLE
Use tinyxml2 package instead of deprecated tinyxml2_vendor

### DIFF
--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -14,7 +14,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rcutils
   realtime_tools
   TinyXML2
-  tinyxml2_vendor
   joint_limits
   urdf
   pal_statistics
@@ -50,7 +49,6 @@ target_link_libraries(hardware_interface PUBLIC
                       rcpputils::rcpputils
                       ${joint_limits_TARGETS}
                       ${TinyXML2_LIBRARIES}
-                      ${tinyxml2_vendor_LIBRARIES}
                       ${pal_statistics_LIBRARIES}
                       ${control_msgs_TARGETS}
                       ${lifecycle_msgs_TARGETS}

--- a/hardware_interface/package.xml
+++ b/hardware_interface/package.xml
@@ -23,7 +23,7 @@
   <depend>rcpputils</depend>
   <depend>realtime_tools</depend>
   <depend>sdformat_urdf</depend>
-  <depend>tinyxml2_vendor</depend>
+  <depend>tinyxml2</depend>
   <depend>urdf</depend>
   <depend>fmt</depend>
 


### PR DESCRIPTION
See https://github.com/ros2/tinyxml2_vendor/commit/f2fc760a8d1f9d4676ce5e50818e4ffbca3bdaee