### PR TITLE
Use proper hardware component logger for async components

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -108,9 +108,7 @@ public:
   CallbackReturn init(const hardware_interface::HardwareComponentParams & params)
   {
     clock_ = params.clock;
-    auto logger_copy = params.logger;
-    logger_ = logger_copy.get_child(
-      "hardware_component." + params.hardware_info.type + "." + params.hardware_info.name);
+    logger_ = params.logger;
     info_ = params.hardware_info;
     if (params.hardware_info.is_async)
     {

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -250,7 +250,9 @@ public:
     hardware_interface::HardwareComponentParams component_params;
     component_params.hardware_info = params.hardware_info;
     component_params.clock = rm_clock_;
-    component_params.logger = rm_logger_;
+    component_params.logger = rm_logger_.get_child(
+      fmt::format(
+        "hardware_component.{}.{}", params.hardware_info.type, params.hardware_info.name));
     component_params.executor = params.executor;
     component_params.node_namespace = params.node_namespace;
     RCLCPP_INFO(


### PR DESCRIPTION
We are using a wrong logger in async components
