### PR TITLE
Readd migration notes

### DIFF
--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -55,3 +55,10 @@ hardware_interface
   have been changed from passing a ``const HardwareInfo &`` to passing a ``const
   HardwareComponentParams &`` (`#2323 <https://github.com/ros-controls/ros2_control/pull/2323>`_,
   `#2589 <https://github.com/ros-controls/ros2_control/pull/2589>`__).
+
+* The ``get_value`` of LoanedStateInterface and LoanedCommandInterface is now accessed using ``get_optional`` method. The value will be returned as an ``std::optional<T>``. (`#2061 <https://github.com/ros-controls/ros2_control/pull/2061>`_).
+    This change was made to better handle cases where the interface value may not be accessible due to a concurrent access from other threads in the system.
+
+* The ``double get_value()`` of standard StateInterface and CommandInterface is now accessed using  ``get_optional`` or ``bool get_value(T & value, bool wait_for_lock)`` method. The value will be returned as an ``std::optional<T>`` when using ``get_optional`` (`#2831 <https://github.com/ros-controls/ros2_control/pull/2831>`_).
+    Likewise, the ``set_value`` method has been updated to ``bool set_value(const T & value, bool wait_for_lock)`` and return value is to indicate success or failure of the operation (`#2831 <https://github.com/ros-controls/ros2_control/pull/2831>`_).
+    You can use the return values of these methods to handle cases where the interface value may not be accessible due to a concurrent access from other threads in the system. You can set the ``wait_for_lock`` parameter to ``true`` to block until the lock is acquired, however, this is not real-time safe and should be used with caution in real-time contexts.


### PR DESCRIPTION
They were added with the deprecation, but after branching for kilted they are not there anymore when we actually removed it with #2589.