### PR TITLE
Re-add the removed on_init method of HardwareInfo

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -138,6 +138,15 @@ public:
 
   /// Initialization of the hardware interface from data parsed from the robot's URDF.
   /**
+   * \param[in] hardware_info structure with data from URDF.
+   * \returns CallbackReturn::SUCCESS if required data are provided and can be parsed.
+   * \returns CallbackReturn::ERROR if any error happens or data are missing.
+   */
+  [[deprecated("Use on_init(const HardwareComponentInterfaceParams & params) instead.")]]
+  virtual CallbackReturn on_init(const HardwareInfo & hardware_info);
+
+  /// Initialization of the hardware interface from data parsed from the robot's URDF.
+  /**
    * \param[in] params  A struct of type hardware_interface::HardwareComponentInterfaceParams
    * containing all necessary parameters for initializing this specific hardware component,
    * specifically its HardwareInfo, and a weak_ptr to the executor.

--- a/hardware_interface/src/hardware_component_interface.cpp
+++ b/hardware_interface/src/hardware_component_interface.cpp
@@ -247,10 +247,9 @@ return_type HardwareComponentInterface::update_hardware_status_message(
   return return_type::OK;
 }
 
-CallbackReturn HardwareComponentInterface::on_init(
-  const hardware_interface::HardwareComponentInterfaceParams & params)
+CallbackReturn HardwareComponentInterface::on_init(const HardwareInfo & hardware_info)
 {
-  info_ = params.hardware_info;
+  info_ = hardware_info;
   if (info_.type == "actuator")
   {
     parse_state_interface_descriptions(info_.joints, joint_state_interfaces_);
@@ -270,6 +269,16 @@ CallbackReturn HardwareComponentInterface::on_init(
     parse_command_interface_descriptions(info_.gpios, gpio_command_interfaces_);
   }
   return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn HardwareComponentInterface::on_init(
+  const hardware_interface::HardwareComponentInterfaceParams & params)
+{
+  // This is done for backward compatibility with the old on_init method.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return on_init(params.hardware_info);
+#pragma GCC diagnostic pop
 }
 
 rclcpp::NodeOptions HardwareComponentInterface::define_custom_node_options() const


### PR DESCRIPTION
When fixing the conflicts one of the old deprecated method got removed in the kilted branch. This should fix it