### PR TITLE
[Simulation] Catch exceptions of sleep_until context

### DIFF
--- a/controller_manager/src/ros2_control_node.cpp
+++ b/controller_manager/src/ros2_control_node.cpp
@@ -150,7 +150,17 @@ int main(int argc, char ** argv)
         // wait until we hit the end of the period
         if (use_sim_time)
         {
-          cm->get_clock()->sleep_until(current_time + period);
+          try
+          {
+            cm->get_clock()->sleep_until(current_time + period);
+          }
+          catch (const std::runtime_error & e)
+          {
+            RCLCPP_ERROR(
+              cm->get_logger(),
+              "sleep_until failed with error: %s. Exiting control loop and aborting....", e.what());
+            break;
+          }
         }
         else
         {


### PR DESCRIPTION
I've observed this in mujoco_ros2_control this one, so It it better to handle this here