### PR TITLE
Improve warning if spawner cannot acquire filelock

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -214,11 +214,10 @@ def main(args=None):
             return 1
 
         # print only once when the lock is finally acquired, but with info level if it failed once
-        if (
-            not logger.debug(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
-            and hit_timeout
-        ):
+        if hit_timeout:
             logger.info(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
+        else:
+            logger.debug(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
 
         node = Node(spawner_node_name)
         logger = node.get_logger()


### PR DESCRIPTION
Error logs in the CI are like
```
2026-01-20T03:49:35.9124785Z     [spawner-5] [WARN] [1768880313.776779189] [ros2_control_controller_spawner_fts_broadcaster]: Attempt 2 failed. Retrying in 3 seconds...
2026-01-20T03:49:35.9125179Z     [spawner-3] [WARN] [1768880313.776965745] [ros2_control_controller_spawner_joint_state_broadcaster]: Attempt 2 failed. Retrying in 3 seconds...
```
without any notice that the filelock is the problem here, not the service calls.