### PR TITLE
Resort members of InterfaceInfo to avoid ABI break

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -47,12 +47,12 @@ struct InterfaceInfo
   std::string data_type = "double";
   /// (Optional) If the handle is an array, the size of the array.
   int size;
-  /// (Optional) enable or disable the limits for the command interfaces
-  bool enable_limits;
   /// (Optional) Key-value pairs of command/stateInterface parameters. This is
   /// useful for drivers that operate on protocols like modbus, where each
   /// interface needs own address(register), datatype, etc.
   std::unordered_map<std::string, std::string> parameters;
+  /// (Optional) enable or disable the limits for the command interfaces
+  bool enable_limits;
 };
 
 /// @brief This structure stores information about a joint that is mimicking another joint


### PR DESCRIPTION
https://github.com/ros-controls/ros2_control/pull/2997#issuecomment-3817264663

`InterfaceInfo` is only passed inside a std::vector (its size does not change when the object changes). But the memory layout of the struct changes and accessing it will break. By moving the new member at the end of the struct, this should not be a problem.