### PR TITLE
Cache interface name to avoid failing at the destruction time

### DIFF
--- a/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_command_interface.hpp
@@ -37,7 +37,9 @@ public:
   }
 
   explicit LoanedCommandInterface(CommandInterface::SharedPtr command_interface, Deleter && deleter)
-  : command_interface_(*command_interface), deleter_(std::forward<Deleter>(deleter))
+  : command_interface_(*command_interface),
+    interface_name_(command_interface->get_name()),
+    deleter_(std::forward<Deleter>(deleter))
   {
   }
 
@@ -47,23 +49,23 @@ public:
 
   virtual ~LoanedCommandInterface()
   {
-    auto logger = rclcpp::get_logger(command_interface_.get_name());
+    auto logger = rclcpp::get_logger(interface_name_);
     RCLCPP_WARN_EXPRESSION(
-      rclcpp::get_logger(get_name()),
+      logger,
       (get_value_statistics_.failed_counter > 0 || get_value_statistics_.timeout_counter > 0),
       "LoanedCommandInterface %s has %u (%.4f %%) timeouts and %u (~ %.4f %%) missed calls out of "
       "%u get_value calls",
-      get_name().c_str(), get_value_statistics_.timeout_counter,
+      interface_name_.c_str(), get_value_statistics_.timeout_counter,
       (get_value_statistics_.timeout_counter * 100.0) / get_value_statistics_.total_counter,
       get_value_statistics_.failed_counter,
       (get_value_statistics_.failed_counter * 100.0) / get_value_statistics_.total_counter,
       get_value_statistics_.total_counter);
     RCLCPP_WARN_EXPRESSION(
-      rclcpp::get_logger(get_name()),
+      logger,
       (set_value_statistics_.failed_counter > 0 || set_value_statistics_.timeout_counter > 0),
       "LoanedCommandInterface %s has %u (%.4f %%) timeouts and  %u (~ %.4f %%) missed calls out of "
       "%u set_value calls",
-      get_name().c_str(), set_value_statistics_.timeout_counter,
+      interface_name_.c_str(), set_value_statistics_.timeout_counter,
       (set_value_statistics_.timeout_counter * 100.0) / set_value_statistics_.total_counter,
       set_value_statistics_.failed_counter,
       (set_value_statistics_.failed_counter * 100.0) / set_value_statistics_.total_counter,
@@ -164,6 +166,7 @@ public:
 protected:
   CommandInterface & command_interface_;
   Deleter deleter_;
+  std::string interface_name_;
 
 private:
   struct HandleRTStatistics

--- a/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
+++ b/hardware_interface/include/hardware_interface/loaned_state_interface.hpp
@@ -36,7 +36,9 @@ public:
   }
 
   explicit LoanedStateInterface(StateInterface::ConstSharedPtr state_interface, Deleter && deleter)
-  : state_interface_(*state_interface), deleter_(std::forward<Deleter>(deleter))
+  : state_interface_(*state_interface),
+    interface_name_(state_interface->get_name()),
+    deleter_(std::forward<Deleter>(deleter))
   {
   }
 
@@ -46,13 +48,13 @@ public:
 
   virtual ~LoanedStateInterface()
   {
-    auto logger = rclcpp::get_logger(state_interface_.get_name());
+    auto logger = rclcpp::get_logger(interface_name_);
     RCLCPP_WARN_EXPRESSION(
       logger,
       (get_value_statistics_.failed_counter > 0 || get_value_statistics_.timeout_counter > 0),
       "LoanedStateInterface %s has %u (%.4f %%) timeouts and %u (%.4f %%) missed calls out of %u "
       "get_value calls",
-      state_interface_.get_name().c_str(), get_value_statistics_.timeout_counter,
+      interface_name_.c_str(), get_value_statistics_.timeout_counter,
       (get_value_statistics_.timeout_counter * 100.0) / get_value_statistics_.total_counter,
       get_value_statistics_.failed_counter,
       (get_value_statistics_.failed_counter * 100.0) / get_value_statistics_.total_counter,
@@ -119,6 +121,7 @@ public:
 protected:
   const StateInterface & state_interface_;
   Deleter deleter_;
+  std::string interface_name_;
 
 private:
   struct HandleRTStatistics


### PR DESCRIPTION
This should also fix https://github.com/ros-controls/ros2_control_ci/issues/665 for good