### PR TITLE
Protect controller switching, when switching from nonRT loop

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -697,17 +697,17 @@ private:
     void reset()
     {
       do_switch = false;
-      started = false;
       strictness = 0;
       activate_asap = false;
+      ready_to_switch = false;
     }
 
-    std::atomic_bool do_switch;
-    bool started;
+    std::atomic_bool do_switch{false};
+    std::atomic_bool ready_to_switch{false};
 
     // Switch options
     int strictness;
-    std::atomic_bool activate_asap;
+    std::atomic_bool activate_asap{false};
     std::chrono::nanoseconds timeout;
 
     // conditional variable and mutex to wait for the switch to complete

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1628,6 +1628,7 @@ controller_interface::return_type ControllerManager::configure_controller(
 void ControllerManager::clear_requests()
 {
   switch_params_.do_switch = false;
+  switch_params_.ready_to_switch = false;
   switch_params_.activate_asap = false;
   switch_params_.deactivate_request.clear();
   switch_params_.activate_request.clear();
@@ -2172,6 +2173,7 @@ controller_interface::return_type ControllerManager::switch_controller_cb(
   {
     switch_params_.timeout = timeout.to_chrono<std::chrono::nanoseconds>();
   }
+  switch_params_.ready_to_switch.store(false, std::memory_order_release);
   switch_params_.do_switch = true;
   // wait until switch is finished
   if (switch_params_.activate_asap)
@@ -2192,6 +2194,21 @@ controller_interface::return_type ControllerManager::switch_controller_cb(
   }
   else
   {
+    const auto deadline = std::chrono::steady_clock::now() + switch_params_.timeout;
+    while (!switch_params_.ready_to_switch.load(std::memory_order_acquire))
+    {
+      if (std::chrono::steady_clock::now() >= deadline)
+      {
+        message = fmt::format(
+          FMT_COMPILE("Switch controller timed out after {} seconds!"),
+          static_cast<double>(switch_params_.timeout.count()) / 1e9);
+        RCLCPP_ERROR(get_logger(), "%s", message.c_str());
+        clear_requests();
+        return controller_interface::return_type::ERROR;
+      }
+      // wait for the realtime loop to be ready for switching controllers
+      std::this_thread::yield();
+    }
     RCLCPP_INFO(get_logger(), "Requested controller switch from non-realtime loop");
     // This should work as the realtime thread operation is read-only operation
     manage_switch();
@@ -3350,9 +3367,16 @@ controller_interface::return_type ControllerManager::update(
   resource_manager_->enforce_command_limits(period);
 
   // there are controllers to (de)activate
-  if (switch_params_.do_switch && switch_params_.activate_asap)
+  if (switch_params_.do_switch)
   {
-    manage_switch();
+    if (switch_params_.activate_asap)
+    {
+      manage_switch();
+    }
+    else
+    {
+      switch_params_.ready_to_switch.store(true, std::memory_order_release);
+    }
   }
 
   PUBLISH_ROS2_CONTROL_INTROSPECTION_DATA_ASYNC(hardware_interface::DEFAULT_REGISTRY_KEY);


### PR DESCRIPTION
As per @v-lopez's comment https://github.com/ros-controls/ros2_control/pull/2452#issuecomment-3984882652, it is true that we are not protecting the controller switching properly, there might be a slight chance that the update can be called in paralle to the activate,

The changes allow to prevent such issue