### PR TITLE
Win-CI: Build also the tests, but don't run them

### DIFF
--- a/.github/workflows/rolling-semi-binary-build-win.yml
+++ b/.github/workflows/rolling-semi-binary-build-win.yml
@@ -30,4 +30,3 @@ jobs:
       ros_distro: rolling
       pixi_dependencies: typeguard jinja2 boost compilers
       ninja_packages: rsl
-      target_cmake_args: -DBUILD_TESTING=OFF


### PR DESCRIPTION
there is no colcon test step in the workflow.

I changed this to be default, because some repos have headers not being build-tested otherwise.