### PR TITLE
[Spawner] Fix exception of time.sleep in spawner

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -539,7 +539,12 @@ def main(args=None):
         # Without this, a signal delivered while rclpy's C extension returns to
         # Python can raise a second KeyboardInterrupt inside the except block,
         # skipping the deactivate/unload calls and leaving controllers loaded.
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        # The try/except guards against coverage's trace function raising a
+        # second KeyboardInterrupt during the signal.signal() call itself.
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (KeyboardInterrupt, Exception):
+            pass
         if unload_on_kill:
             logger.info("KeyboardInterrupt successfully captured!")
 


### PR DESCRIPTION
I could reproduce the issue running it locally 100 times, and then I added the current fix and it is good to go

```
ist : ['ctrl_3', 'ctrl_2']!
[INFO] [1773487499.633128193] [spawner_ctrl_3]: Waiting until interrupt to unload controllers
Traceback (most recent call last):
  File "/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 535, in main
    time.sleep(1)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/lib/python3/dist-packages/coverage/__main__.py", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 970, in main
    status = CoverageScript().command_line(argv)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 681, in command_line
    return self.do_run(options, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/cmdline.py", line 858, in do_run
    runner.run()
  File "/usr/lib/python3/dist-packages/coverage/execfile.py", line 211, in run
    exec(code, main_mod.__dict__)
  File "/home/user/ros2_control_ws/install/controller_manager/lib/controller_manager/spawner", line 33, in <module>
    sys.exit(load_entry_point('controller-manager==6.4.0', 'console_scripts', 'spawner')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/ros2_control_ws/install/controller_manager/lib/python3.12/site-packages/controller_manager/spawner.py", line 542, in main
    signal.signal(signal.SIGINT, signal.SIG_IGN)
  File "/usr/lib/python3.12/signal.py", line 56, in signal
    @_wraps(_signal.signal)
    
  File "/usr/lib/python3/dist-packages/coverage/control.py", line 394, in _should_trace
    disp = self._inorout.should_trace(filename, frame)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/inorout.py", line 347, in should_trace
    canonical = canonical_filename(filename)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/files.py", line 85, in canonical_filename
    cf = abs_file(cf)
         ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/coverage/files.py", line 156, in abs_file
    return actual_path(os.path.abspath(os.path.realpath(path)))
                                       ^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 432, in realpath
  File "<frozen posixpath>", line 476, in _joinrealpath
KeyboardInterrupt
/home/user/ros2_control_ws/src/ros2_control/controller_manager/test/test_advanced_spawner.cpp:494: Failure
Expected equality of these values:
  cm_->get_loaded_controllers().size()
    Which is: 2
  0ul
    Which is: 0

Stack trace (most recent call last):
#17   Object "", at 0xffffffffffffffff, in 
#16   Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c12ec64, in _start
#15   Source "../csu/libc-start.c", line 360, in __libc_start_main_impl [0x74cd6c87828a]
#14   Source "../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main [0x74cd6c8781c9]
#13   Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c17e8ba, in main
#12   Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c17e8d2, in RUN_ALL_TESTS()
#11   Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1a40d8, in testing::UnitTest::Run()
#10   Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1bc022, in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
#9    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1c3d05, in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
#8    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1a5ca5, in testing::internal::UnitTestImpl::RunAllTests()
#7    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c194b21, in testing::TestSuite::Run()
#6    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1940a8, in testing::TestInfo::Run()
#5    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1934d7, in testing::Test::Run()
#4    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1baac6, in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
#3    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1c29f8, in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
#2    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c13bb8d, in TestLoadController_advanced_spawner_unload_on_kill_activate_as_group_Test::TestBody()
#1    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c18a141, in testing::internal::AssertHelper::operator=(testing::Message const&) const
#0    Object "/home/user/ros2_control_ws/build/controller_manager/test_advanced_spawner", at 0x569f4c1a3dfb, in testing::UnitTest::AddTestPartResult(testing::TestPartResult::Type, char const*, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
Trace/breakpoint trap (Signal sent by the kernel 0 0)
Trace/breakpoint trap (core dumped)

```