### PR TITLE
Add tests for GPIO parsing behavior in component_parser

### DIFF
--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -81,6 +81,33 @@ TEST_F(TestComponentParser, missing_attribute_throws_error)
   ASSERT_THROW(parse_control_resources_from_urdf(broken_urdf_string), std::runtime_error);
 }
 
+TEST_F(TestComponentParser, gpio_missing_interface_throws_error)
+{
+  const std::string broken_urdf = std::string(ros2_control_test_assets::urdf_head) +
+                                  R"(
+      <ros2_control name="TestSystem" type="system">
+        <hardware>
+          <plugin>mock_components/GenericSystem</plugin>
+        </hardware>
+
+        <joint name="joint1">
+          <command_interface name="position"/>
+          <state_interface name="position"/>
+        </joint>
+
+        <gpio name="gpio_name">
+          <state_interface name="does_not_exist"/>
+        </gpio>
+      </ros2_control>
+    )" + ros2_control_test_assets::urdf_tail;
+
+  // NOTE:
+  // GPIO interfaces are not strictly validated against hardware interface
+  // existence during URDF parsing (unlike joints and sensors).
+  // This test documents current behavior.
+  ASSERT_NO_THROW(parse_control_resources_from_urdf(broken_urdf));
+}
+
 TEST_F(TestComponentParser, parameter_missing_name_throws_error)
 {
   const std::string broken_urdf_string =


### PR DESCRIPTION
## Summary

This PR adds test coverage for GPIO tag parsing in `component_parser`.

Specifically, it introduces a test case where a GPIO interface is declared in the URDF but does not correspond to a hardware interface.

## Details

While working on this, I observed that unlike joints and sensors, GPIO interfaces are not strictly validated against hardware interface existence during URDF parsing. The added test documents this behavior and ensures it is explicitly covered.

This improves test coverage and clarifies expected behavior for GPIO parsing. Happy to extend this further if stricter validation for GPIO interfaces is desired.

## Testing

- Built and tested locally using:
  - `colcon build --packages-select hardware_interface`
  - `colcon test --packages-select hardware_interface`
  - `pre-commit run --all-files`
- All tests pass

## Related Issue

Closes #976