### PR TITLE
Removed deprecated standalone thread_priority variable 

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -99,7 +99,6 @@ return_type ControllerInterfaceBase::init(
     // no rclcpp::ParameterValue unsigned int specialization
     auto_declare<int>("update_rate", static_cast<int>(params.controller_manager_update_rate));
     auto_declare<bool>("is_async", false);
-    auto_declare<int>("thread_priority", -100);
   }
   catch (const std::exception & e)
   {
@@ -246,17 +245,7 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
   {
     realtime_tools::AsyncFunctionHandlerParams async_params;
     async_params.thread_priority = 50;  // default value
-    const int thread_priority_param =
-      static_cast<int>(get_node()->get_parameter("thread_priority").as_int());
-    if (thread_priority_param >= 0 && thread_priority_param <= 99)
-    {
-      async_params.thread_priority = thread_priority_param;
-      RCLCPP_WARN(
-        get_node()->get_logger(),
-        "The parsed 'thread_priority' parameter will be deprecated and not be functional from "
-        "ROS 2 Lyrical Luth release. Please use the 'async_parameters.thread_priority' parameter "
-        "instead.");
-    }
+
     async_params.initialize(impl_->node_, "async_parameters.");
     if (async_params.scheduling_policy == realtime_tools::AsyncSchedulingPolicy::DETACHED)
     {

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -350,6 +350,7 @@ struct HardwareAsyncParams
 {
   /// Thread priority for the async worker thread
   int thread_priority = 50;
+
   /// Scheduling policy for the async worker thread
   std::string scheduling_policy = "synchronized";
   /// CPU affinity cores for the async worker thread
@@ -359,13 +360,6 @@ struct HardwareAsyncParams
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 struct HardwareInfo
 {
   /// Name of the hardware.
@@ -378,8 +372,7 @@ struct HardwareInfo
   unsigned int rw_rate;
   /// Component is async
   bool is_async;
-  /// Async thread priority
-  [[deprecated("Use async_params instead.")]] int thread_priority;
+
   /// Async Parameters
   HardwareAsyncParams async_params;
   /// Name of the pluginlib plugin of the hardware that will be loaded.
@@ -426,11 +419,6 @@ struct HardwareInfo
    */
   std::unordered_map<std::string, joint_limits::SoftJointLimits> soft_limits;
 };
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
 
 }  // namespace hardware_interface
 #endif  // HARDWARE_INTERFACE__HARDWARE_INFO_HPP_

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -372,7 +372,6 @@ struct HardwareInfo
   unsigned int rw_rate;
   /// Component is async
   bool is_async;
-
   /// Async Parameters
   HardwareAsyncParams async_params;
   /// Name of the pluginlib plugin of the hardware that will be loaded.

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -350,7 +350,6 @@ struct HardwareAsyncParams
 {
   /// Thread priority for the async worker thread
   int thread_priority = 50;
-
   /// Scheduling policy for the async worker thread
   std::string scheduling_policy = "synchronized";
   /// CPU affinity cores for the async worker thread

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -117,16 +117,8 @@ std::string get_attribute_value(
   attr = element_it->FindAttribute(attribute_name);
   if (!attr)
   {
-    const char * name = element_it->Attribute(kNameAttribute);
-    if (name && std::strlen(name) > 0)
-    {
-      throw std::runtime_error(
-        fmt::format(
-          FMT_COMPILE("no attribute '{}' in '{}' tag with name '{}'"), attribute_name, tag_name,
-          name));
-    }
     throw std::runtime_error(
-      fmt::format(FMT_COMPILE("no attribute '{}' in '{}' tag"), attribute_name, tag_name));
+      fmt::format(FMT_COMPILE("no attribute {} in {} tag"), attribute_name, tag_name));
   }
   return ros2_control::strip(element_it->Attribute(attribute_name));
 }
@@ -345,7 +337,7 @@ int parse_thread_priority_attribute(const tinyxml2::XMLElement * elem)
  * \throws std::runtime_error if a component attribute or tag is not found
  */
 std::unordered_map<std::string, std::string> parse_parameters_from_xml(
-  const tinyxml2::XMLElement * params_it, const std::string & context_name)
+  const tinyxml2::XMLElement * params_it)
 {
   std::unordered_map<std::string, std::string> parameters;
   const tinyxml2::XMLAttribute * attr;
@@ -356,10 +348,7 @@ std::unordered_map<std::string, std::string> parse_parameters_from_xml(
     attr = params_it->FindAttribute(kNameAttribute);
     if (!attr)
     {
-      throw std::runtime_error(
-        fmt::format(
-          FMT_COMPILE("no parameter name attribute set in param tag{}"),
-          context_name.empty() ? "" : " for '" + context_name + "'"));
+      throw std::runtime_error("no parameter name attribute set in param tag");
     }
     const std::string parameter_name = ros2_control::strip(params_it->Attribute(kNameAttribute));
     const std::string parameter_value =
@@ -379,7 +368,7 @@ std::unordered_map<std::string, std::string> parse_parameters_from_xml(
  * \throws std::runtime_error if the interfaceType text not set in a tag
  */
 hardware_interface::InterfaceInfo parse_interfaces_from_xml(
-  const tinyxml2::XMLElement * interfaces_it, const std::string & context_name)
+  const tinyxml2::XMLElement * interfaces_it)
 {
   hardware_interface::InterfaceInfo interface;
 
@@ -389,7 +378,7 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
 
   // Optional min/max attributes
   std::unordered_map<std::string, std::string> interface_params =
-    parse_parameters_from_xml(interfaces_it->FirstChildElement(kParamTag), context_name);
+    parse_parameters_from_xml(interfaces_it->FirstChildElement(kParamTag));
   auto interface_param = interface_params.find(kMinTag);
   if (interface_param != interface_params.end())
   {
@@ -425,7 +414,7 @@ hardware_interface::InterfaceInfo parse_interfaces_from_xml(
   const auto * params_it = interfaces_it->FirstChildElement(kParamTag);
   if (params_it)
   {
-    interface.parameters = parse_parameters_from_xml(params_it, context_name);
+    interface.parameters = parse_parameters_from_xml(params_it);
   }
 
   interface.data_type = parse_data_type_attribute(interfaces_it);
@@ -477,7 +466,7 @@ ComponentInfo parse_component_from_xml(const tinyxml2::XMLElement * component_it
   const auto * command_interfaces_it = component_it->FirstChildElement(kCommandInterfaceTag);
   while (command_interfaces_it)
   {
-    InterfaceInfo cmd_info = parse_interfaces_from_xml(command_interfaces_it, component.name);
+    InterfaceInfo cmd_info = parse_interfaces_from_xml(command_interfaces_it);
     cmd_info.enable_limits &= component.enable_limits;
     component.command_interfaces.push_back(cmd_info);
     command_interfaces_it = command_interfaces_it->NextSiblingElement(kCommandInterfaceTag);
@@ -487,7 +476,7 @@ ComponentInfo parse_component_from_xml(const tinyxml2::XMLElement * component_it
   const auto * state_interfaces_it = component_it->FirstChildElement(kStateInterfaceTag);
   while (state_interfaces_it)
   {
-    InterfaceInfo state_info = parse_interfaces_from_xml(state_interfaces_it, component.name);
+    InterfaceInfo state_info = parse_interfaces_from_xml(state_interfaces_it);
     state_info.enable_limits &= component.enable_limits;
     component.state_interfaces.push_back(state_info);
     state_interfaces_it = state_interfaces_it->NextSiblingElement(kStateInterfaceTag);
@@ -497,7 +486,7 @@ ComponentInfo parse_component_from_xml(const tinyxml2::XMLElement * component_it
   const auto * params_it = component_it->FirstChildElement(kParamTag);
   if (params_it)
   {
-    component.parameters = parse_parameters_from_xml(params_it, component.name);
+    component.parameters = parse_parameters_from_xml(params_it);
   }
 
   return component;
@@ -524,8 +513,7 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   const auto * command_interfaces_it = component_it->FirstChildElement(kCommandInterfaceTag);
   while (command_interfaces_it)
   {
-    component.command_interfaces.push_back(
-      parse_interfaces_from_xml(command_interfaces_it, component.name));
+    component.command_interfaces.push_back(parse_interfaces_from_xml(command_interfaces_it));
     command_interfaces_it = command_interfaces_it->NextSiblingElement(kCommandInterfaceTag);
   }
 
@@ -533,8 +521,7 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   const auto * state_interfaces_it = component_it->FirstChildElement(kStateInterfaceTag);
   while (state_interfaces_it)
   {
-    component.state_interfaces.push_back(
-      parse_interfaces_from_xml(state_interfaces_it, component.name));
+    component.state_interfaces.push_back(parse_interfaces_from_xml(state_interfaces_it));
     state_interfaces_it = state_interfaces_it->NextSiblingElement(kStateInterfaceTag);
   }
 
@@ -542,7 +529,7 @@ ComponentInfo parse_complex_component_from_xml(const tinyxml2::XMLElement * comp
   const auto * params_it = component_it->FirstChildElement(kParamTag);
   if (params_it)
   {
-    component.parameters = parse_parameters_from_xml(params_it, component.name);
+    component.parameters = parse_parameters_from_xml(params_it);
   }
 
   return component;
@@ -587,10 +574,7 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
   const auto * type_it = transmission_it->FirstChildElement(kPluginNameTag);
   if (!type_it)
   {
-    throw std::runtime_error(
-      fmt::format(
-        FMT_COMPILE("Missing <plugin> tag of <transmission> element for '{}' in your URDF."),
-        transmission.name));
+    throw std::runtime_error("Missing <plugin> tag of <transmission> element in your URDF.");
   }
   transmission.type = get_text_for_element(type_it, kPluginNameTag);
 
@@ -614,7 +598,7 @@ TransmissionInfo parse_transmission_from_xml(const tinyxml2::XMLElement * transm
   const auto * params_it = transmission_it->FirstChildElement(kParamTag);
   if (params_it)
   {
-    transmission.parameters = parse_parameters_from_xml(params_it, transmission.name);
+    transmission.parameters = parse_parameters_from_xml(params_it);
   }
 
   return transmission;
@@ -694,9 +678,8 @@ HardwareInfo parse_resource_from_xml(
   hardware.type = get_attribute_value(ros2_control_it, kTypeAttribute, kROS2ControlTag);
   hardware.rw_rate = parse_rw_rate_attribute(ros2_control_it);
   hardware.is_async = parse_is_async_attribute(ros2_control_it);
-  hardware.async_params.thread_priority = hardware.is_async
-                                            ? parse_thread_priority_attribute(ros2_control_it)
-                                            : std::numeric_limits<int>::max();
+  hardware.async_params.thread_priority = 50;
+
   // TODO(anyone): remove this line once thread_priority is removed
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -705,7 +688,7 @@ HardwareInfo parse_resource_from_xml(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  hardware.thread_priority = hardware.async_params.thread_priority;
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #else
@@ -722,10 +705,7 @@ HardwareInfo parse_resource_from_xml(
       const auto * type_it = ros2_control_child_it->FirstChildElement(kPluginNameTag);
       if (!type_it)
       {
-        throw std::runtime_error(
-          fmt::format(
-            FMT_COMPILE("Missing <plugin> tag of <hardware> element for '{}' in your URDF."),
-            hardware.name));
+        throw std::runtime_error("Missing <plugin> tag of <hardware> element in your URDF.");
       }
       hardware.hardware_plugin_name =
         get_text_for_element(type_it, std::string("hardware ") + kPluginNameTag);
@@ -737,7 +717,7 @@ HardwareInfo parse_resource_from_xml(
       const auto * params_it = ros2_control_child_it->FirstChildElement(kParamTag);
       if (params_it)
       {
-        hardware.hardware_parameters = parse_parameters_from_xml(params_it, hardware.name);
+        hardware.hardware_parameters = parse_parameters_from_xml(params_it);
       }
     }
     else if (std::string(kPropertiesTag) == ros2_control_child_it->Name())
@@ -769,7 +749,7 @@ HardwareInfo parse_resource_from_xml(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-            hardware.thread_priority = hardware.async_params.thread_priority;
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #else
@@ -1033,8 +1013,7 @@ std::vector<HardwareInfo> parse_control_resources_from_urdf(const std::string & 
 
   if (!ros2_control_it)
   {
-    throw std::runtime_error(
-      fmt::format(FMT_COMPILE("no '{}' tag found in the URDF"), kROS2ControlTag));
+    throw std::runtime_error(fmt::format(FMT_COMPILE("no {} tag"), kROS2ControlTag));
   }
 
   std::vector<HardwareInfo> hardware_info;

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -880,21 +880,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_robot_with_gpio
     hardware_info.hardware_plugin_name, "ros2_control_demo_hardware/RRBotSystemWithGPIOHardware");
 
   ASSERT_FALSE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, std::numeric_limits<int>::max());
   ASSERT_THAT(hardware_info.joints, SizeIs(2));
 
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
@@ -966,21 +951,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_with_size_and_d
   ASSERT_THAT(hardware_info.joints, SizeIs(1));
 
   ASSERT_FALSE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, std::numeric_limits<int>::max());
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   EXPECT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(1));
@@ -1030,21 +1000,6 @@ TEST_F(
 
   ASSERT_THAT(hardware_info.joints, SizeIs(1));
   ASSERT_FALSE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, std::numeric_limits<int>::max());
   EXPECT_EQ(hardware_info.joints[0].name, "joint1");
   EXPECT_EQ(hardware_info.joints[0].type, "joint");
   EXPECT_THAT(hardware_info.joints[0].command_interfaces, SizeIs(2));
@@ -1480,21 +1435,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_async_components)
   ASSERT_THAT(hardware_info.group, IsEmpty());
   ASSERT_THAT(hardware_info.joints, SizeIs(1));
   ASSERT_TRUE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, 30);
   ASSERT_EQ(hardware_info.async_params.scheduling_policy, "detached");
   ASSERT_FALSE(hardware_info.async_params.print_warnings);
   ASSERT_EQ(3u, hardware_info.async_params.cpu_affinity_cores.size());
@@ -1513,21 +1453,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_async_components)
   ASSERT_THAT(hardware_info.joints, IsEmpty());
   ASSERT_THAT(hardware_info.sensors, SizeIs(1));
   ASSERT_TRUE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, 50);
   ASSERT_EQ(hardware_info.async_params.scheduling_policy, "synchronized");
   ASSERT_TRUE(hardware_info.async_params.print_warnings);
   ASSERT_TRUE(hardware_info.async_params.cpu_affinity_cores.empty());
@@ -1554,21 +1479,6 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_async_components)
   EXPECT_EQ(hardware_info.gpios[0].name, "configuration");
   EXPECT_EQ(hardware_info.gpios[0].type, "gpio");
   ASSERT_TRUE(hardware_info.is_async);
-  // TODO(anyone): remove this line once thread_priority is removed
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#else
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  ASSERT_EQ(hardware_info.thread_priority, hardware_info.async_params.thread_priority);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#else
-#pragma GCC diagnostic pop
-#endif
-  ASSERT_EQ(hardware_info.async_params.thread_priority, 70);
   ASSERT_EQ(hardware_info.async_params.scheduling_policy, "synchronized");
   ASSERT_EQ(1u, hardware_info.async_params.cpu_affinity_cores.size());
   ASSERT_THAT(
@@ -1615,16 +1525,6 @@ TEST_F(TestComponentParser, successfully_parse_parameter_empty)
     EXPECT_THAT(hardware_info.limits.at(joint).max_velocity, DoubleNear(0.2, 1e-5));
     EXPECT_THAT(hardware_info.limits.at(joint).max_effort, DoubleNear(0.1, 1e-5));
   }
-}
-
-TEST_F(TestComponentParser, successfully_parse_valid_urdf_async_invalid_thread_priority)
-{
-  std::string urdf_to_test = std::string(ros2_control_test_assets::urdf_head) +
-                             "<ros2_control name='TestActuatorHardware' type='actuator' "
-                             "is_async='true' thread_priority='-30'/>" +
-                             std::string(ros2_control_test_assets::urdf_tail);
-  ;
-  ASSERT_THROW(parse_control_resources_from_urdf(urdf_to_test), std::runtime_error);
 }
 
 TEST_F(TestComponentParser, negative_size_throws_error)

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -753,7 +753,7 @@ const auto hardware_resources_with_disabled_limits =
 
 const auto async_hardware_resources =
   R"(
-  <ros2_control name="TestActuatorHardware" type="actuator" is_async="true" thread_priority="30">
+  <ros2_control name="TestActuatorHardware" type="actuator" is_async="true">
     <properties>
       <async affinity="[2, 4,6]" scheduling_policy="detached" print_warnings="false"/>
     </properties>


### PR DESCRIPTION
## Description
This Pull Request completes the planned removal of the standalone `thread_priority` variable from the `HardwareInfo` struct, as part of the migration to the nested `async_params` structure. 

**Related Issue:** Fixes #3160

### Changes:
* **Core Logic:** Removed deprecated standalone `int thread_priority` from `HardwareInfo`.
* **Parser Updates:** Updated `component_parser.cpp` to remove deprecated `#ifdef` blocks.
* **Controller Base:** Cleaned up `controller_interface_base.cpp` parameter declarations.
* **Test Assets:** Updated `descriptions.hpp` and verified existing tests in `test_component_parser.cpp`.

### Verification:
* Performed a clean build using `colcon build --packages-up-to hardware_interface controller_interface` on the `master` branch.
* Verified that all local tests pass and the pipeline is expected to be green.



Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. Don’t be afraid to request reviews from maintainers.
5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
