### PR TITLE
hardware_interface: Fix build error with GCC 15

### DIFF
--- a/hardware_interface/include/hardware_interface/lexical_casts.hpp
+++ b/hardware_interface/include/hardware_interface/lexical_casts.hpp
@@ -15,6 +15,7 @@
 #ifndef HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
 #define HARDWARE_INTERFACE__LEXICAL_CASTS_HPP_
 
+#include <cstdint>
 #include <limits>
 #include <regex>
 #include <sstream>


### PR DESCRIPTION
Without this, other packages (e.g. joint_trajectory_controller) fail with errors like the following:
```
In file included from /build/ros2_controllers-release-release-rolling-joint_trajectory_controller-6.4.0-1/include/joint_trajectory_controller/interpolation_methods.hpp:21,
                 from /build/ros2_controllers-release-release-rolling-joint_trajectory_controller-6.4.0-1/include/joint_trajectory_controller/trajectory.hpp:21,
                 from /build/ros2_controllers-release-release-rolling-joint_trajectory_controller-6.4.0-1/src/trajectory.cpp:19:
/build/ros-rolling-hardware-interface-6.4.0-r1/include/hardware_interface/hardware_interface/lexical_casts.hpp:94:8: error: 'uint8_t' does not name a type
   94 | inline uint8_t stoui8(const std::string & s) { return stoui_generic<uint8_t>(s); }
      |        ^~~~~~~
```
