### PR TITLE
fix: replace broken gdb-refcard link with official sourceware.org source

### DIFF
--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -95,4 +95,4 @@ References
 
 * `ROS 2 and GDB <https://juraph.com/miscellaneous/ros2_and_gdb/>`_
 * `Using GDB to debug a plugin <https://stackoverflow.com/questions/10919832/how-to-use-gdb-to-debug-a-plugin>`_
-* `GDB CLI Tutorial <https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf>`_
+* `GDB CLI Tutorial <https://sourceware.org/gdb/onlinedocs/refcard.pdf>`_


### PR DESCRIPTION
Fixes #3171 — replaced broken link https://users.ece.utexas.edu/~adnan/gdb-refcard.pdf with the official GNU sourceware.org source which is more sustainable and unlikely to break.