### PR TITLE
Make configure_controller lifecycle transition strict (no multi-hop)

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -22,6 +22,7 @@ import time
 import warnings
 
 from controller_manager import (
+    cleanup_controller,
     configure_controller,
     list_controllers,
     load_controller,
@@ -133,6 +134,11 @@ def parse_args_advanced(args):
         "--inactive", action="store_true", help="Configure the controller but do not switch it"
     )
     controller_parser.add_argument(
+        "--reconfigure",
+        action="store_true",
+        help="Cleanup and configure the controller again",
+    )
+    controller_parser.add_argument(
         "--controller-ros-args",
         action="append",
         default=None,
@@ -189,6 +195,7 @@ def parse_args_advanced(args):
         c_parser.add_argument("-p", "--param-file", action="append", default=[])
         c_parser.add_argument("--load-only", action="store_true")
         c_parser.add_argument("--inactive", action="store_true")
+        c_parser.add_argument("--reconfigure", action="store_true")
         c_parser.add_argument("--controller-ros-args", action="append", default=None)
 
         c_namespace, c_unknown = c_parser.parse_known_args(controller_args)
@@ -199,6 +206,7 @@ def parse_args_advanced(args):
                 "param_files": c_namespace.param_file,
                 "load_only": c_namespace.load_only,
                 "inactive": c_namespace.inactive,
+                "reconfigure": c_namespace.reconfigure,
                 "controller_ros_args": c_namespace.controller_ros_args,
             }
         )
@@ -235,6 +243,12 @@ def parse_native_args(args):
     parser.add_argument(
         "--inactive",
         help="Load and configure the controller, however do not activate them",
+        action="store_true",
+        required=False,
+    )
+    parser.add_argument(
+        "--reconfigure",
+        help="Cleanup and configure the controller again",
         action="store_true",
         required=False,
     )
@@ -307,6 +321,7 @@ def parse_native_args(args):
                 "param_files": global_namespace_args.param_file,
                 "load_only": global_namespace_args.load_only,
                 "inactive": global_namespace_args.inactive,
+                "reconfigure": global_namespace_args.reconfigure,
                 "controller_ros_args": global_namespace_args.controller_ros_args,
             }
         )
@@ -506,6 +521,19 @@ def main(args=None):
                 logger.info(
                     bcolors.OKBLUE + "Loaded " + bcolors.BOLD + controller_name + bcolors.ENDC
                 )
+                loaded_state = "unconfigured"
+
+            if controller["reconfigure"] and loaded_state not in (None, "unconfigured"):
+                ret = cleanup_controller(
+                    node,
+                    controller_manager_name,
+                    controller_name,
+                    controller_manager_timeout,
+                    service_call_timeout,
+                )
+                if not ret.ok:
+                    logger.error(bcolors.FAIL + "Failed to cleanup controller" + bcolors.ENDC)
+                    return 1
                 loaded_state = "unconfigured"
 
             if not controller["load_only"]:

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -64,13 +64,15 @@ def has_service_names(node, node_name, node_namespace, service_names):
     return all(service in client_names for service in service_names)
 
 
-def is_controller_loaded(
+def get_loaded_controller_state(
     node, controller_manager, controller_name, service_timeout=0.0, call_timeout=10.0
 ):
+    """Return the lifecycle state of the controller, or None if it is not loaded."""
     controllers = list_controllers(
         node, controller_manager, service_timeout, call_timeout
     ).controller
-    return any(c.name == controller_name for c in controllers)
+    match = first_match(controllers, lambda c: c.name == controller_name)
+    return match.state if match else None
 
 
 def parse_args_advanced(args):
@@ -448,13 +450,14 @@ def main(args=None):
         for controller in controllers:
             controller_name = controller["name"]
 
-            if is_controller_loaded(
+            loaded_state = get_loaded_controller_state(
                 node,
                 controller_manager_name,
                 controller_name,
                 controller_manager_timeout,
                 service_call_timeout,
-            ):
+            )
+            if loaded_state is not None:
                 logger.warning(
                     bcolors.WARNING
                     + "Controller already loaded, skipping load_controller"
@@ -503,18 +506,23 @@ def main(args=None):
                 logger.info(
                     bcolors.OKBLUE + "Loaded " + bcolors.BOLD + controller_name + bcolors.ENDC
                 )
+                loaded_state = "unconfigured"
 
             if not controller["load_only"]:
-                ret = configure_controller(
-                    node,
-                    controller_manager_name,
-                    controller_name,
-                    controller_manager_timeout,
-                    service_call_timeout,
-                )
-                if not ret.ok:
-                    logger.error(bcolors.FAIL + "Failed to configure controller" + bcolors.ENDC)
-                    return 1
+                # configure_controller only accepts the unconfigured state
+                if loaded_state == "unconfigured":
+                    ret = configure_controller(
+                        node,
+                        controller_manager_name,
+                        controller_name,
+                        controller_manager_timeout,
+                        service_call_timeout,
+                    )
+                    if not ret.ok:
+                        logger.error(
+                            bcolors.FAIL + "Failed to configure controller" + bcolors.ENDC
+                        )
+                        return 1
 
                 if not controller["inactive"]:
                     if activate_as_group:

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -167,7 +167,7 @@ There are two scripts to interact with controller manager from launch files:
 .. code-block:: console
 
     $ ros2 run controller_manager spawner -h
-    usage: spawner [-h] [-c CONTROLLER_MANAGER] [-p PARAM_FILE] [--load-only] [--inactive] [-u] [--controller-manager-timeout CONTROLLER_MANAGER_TIMEOUT] [--switch-timeout SWITCH_TIMEOUT]
+    usage: spawner [-h] [-c CONTROLLER_MANAGER] [-p PARAM_FILE] [--load-only] [--inactive] [--reconfigure] [-u] [--controller-manager-timeout CONTROLLER_MANAGER_TIMEOUT] [--switch-timeout SWITCH_TIMEOUT]
                [--service-call-timeout SERVICE_CALL_TIMEOUT] [--activate-as-group] [--switch-asap | --no-switch-asap] [--controller-ros-args CONTROLLER_ROS_ARGS]
                controller_names [controller_names ...]
 
@@ -182,6 +182,7 @@ There are two scripts to interact with controller manager from launch files:
                             Controller param file to be loaded into controller node before configure. Pass multiple times to load different files for different controllers or to override the parameters of the same controller.
       --load-only           Only load the controller and leave unconfigured.
       --inactive            Load and configure the controller, however do not activate them
+      --reconfigure         Cleanup and configure the controller again
       -u, --unload-on-kill  Wait until this application is interrupted (SIGINT or SIGTERM) and deactivate/unload controllers
       --controller-manager-timeout CONTROLLER_MANAGER_TIMEOUT
                             Time to wait for the controller manager service to be available
@@ -271,7 +272,7 @@ The ``spawner`` now supports per controller arguments, while parsing the argumen
       -h, --help            Show help
 
     Controller Options:
-    usage: spawner [-p PARAM_FILE] [--load-only] [--inactive] [--controller-ros-args CONTROLLER_ROS_ARGS] controller_name
+    usage: spawner [-p PARAM_FILE] [--load-only] [--inactive] [--reconfigure] [--controller-ros-args CONTROLLER_ROS_ARGS] controller_name
 
     positional arguments:
       controller_name       Name of the controller
@@ -281,6 +282,7 @@ The ``spawner`` now supports per controller arguments, while parsing the argumen
                             Parameter files to load for the controller
       --load-only           Load the controller but do not configure/activate it
       --inactive            Configure the controller but do not switch it
+      --reconfigure         Cleanup and configure the controller again
       --controller-ros-args CONTROLLER_ROS_ARGS
                             ROS arguments to pass to the controller
 

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1615,9 +1615,7 @@ controller_interface::return_type ControllerManager::configure_controller(
   auto controller = found_it->c;
 
   const auto & state = controller->get_lifecycle_state();
-  if (
-    state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE ||
-    state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED)
+  if (state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
   {
     RCLCPP_ERROR(
       get_logger(), "Controller '%s' can not be configured from '%s' state.",
@@ -1625,16 +1623,6 @@ controller_interface::return_type ControllerManager::configure_controller(
     return controller_interface::return_type::ERROR;
   }
 
-  if (state.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE)
-  {
-    RCLCPP_DEBUG(
-      get_logger(), "Controller '%s' is cleaned-up before configuring", controller_name.c_str());
-    if (cleanup_controller(*found_it) != controller_interface::return_type::OK)
-    {
-      return controller_interface::return_type::ERROR;
-    }
-  }
-  // For cases, when the controller ends up in the unconfigured state from any other state
   cleanup_controller_exported_interfaces(*found_it);
 
   try

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1623,6 +1623,7 @@ controller_interface::return_type ControllerManager::configure_controller(
     return controller_interface::return_type::ERROR;
   }
 
+  // Remove any stale exported interfaces from a prior configure cycle before re-configuring.
   cleanup_controller_exported_interfaces(*found_it);
 
   try

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1614,12 +1614,11 @@ controller_interface::return_type ControllerManager::configure_controller(
   }
   auto controller = found_it->c;
 
-  const auto & state = controller->get_lifecycle_state();
-  if (state.id() != lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED)
+  if (!is_controller_unconfigured(*controller))
   {
     RCLCPP_ERROR(
       get_logger(), "Controller '%s' can not be configured from '%s' state.",
-      controller_name.c_str(), state.label().c_str());
+      controller_name.c_str(), controller->get_lifecycle_state().label().c_str());
     return controller_interface::return_type::ERROR;
   }
 

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -211,11 +211,6 @@ CallbackReturn TestController::on_activate(const rclcpp_lifecycle::State & /*pre
 CallbackReturn TestController::on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/)
 {
   verify_internal_lifecycle_id(get_lifecycle_id(), get_lifecycle_state().id());
-  if (simulate_cleanup_failure)
-  {
-    return CallbackReturn::FAILURE;
-  }
-
   if (cleanup_calls)
   {
     (*cleanup_calls)++;

--- a/controller_manager/test/test_controller/test_controller.hpp
+++ b/controller_manager/test/test_controller/test_controller.hpp
@@ -70,7 +70,6 @@ public:
   rclcpp::Service<example_interfaces::srv::SetBool>::SharedPtr service_;
   unsigned int internal_counter = 0;
   double activation_processing_time = 0.0;
-  bool simulate_cleanup_failure = false;
   // Variable where we store when shutdown was called, pointer because the controller
   // is usually destroyed after shutdown
   size_t * cleanup_calls = nullptr;

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -629,6 +629,9 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   rclcpp::Client<controller_manager_msgs::srv::UnloadController>::SharedPtr unload_client =
     srv_node->create_client<controller_manager_msgs::srv::UnloadController>(
       "test_controller_manager/unload_controller");
+  rclcpp::Client<controller_manager_msgs::srv::CleanupController>::SharedPtr cleanup_client =
+    srv_node->create_client<controller_manager_msgs::srv::CleanupController>(
+      "test_controller_manager/cleanup_controller");
 
   auto request = std::make_shared<controller_manager_msgs::srv::ConfigureController::Request>();
   request->name = test_controller::TEST_CONTROLLER_NAME;
@@ -651,9 +654,9 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     test_controller->get_lifecycle_state().id());
 
-  // call configure again and check the state + it shouldn't throw any exception
+  // configure_controller must reject any state other than UNCONFIGURED
   result = call_service_and_wait(*client, request, srv_executor, true);
-  ASSERT_TRUE(result->ok);
+  ASSERT_FALSE(result->ok) << "Controller configured from inactive state: " << request->name;
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
@@ -701,9 +704,9 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     test_chainable_controller->get_lifecycle_state().id());
 
-  // call configure again and check the state + it shouldn't throw any exception
+  // configure_controller must reject any state other than UNCONFIGURED
   result = call_service_and_wait(*client, request, srv_executor, true);
-  ASSERT_TRUE(result->ok);
+  ASSERT_FALSE(result->ok) << "Controller configured from inactive state: " << request->name;
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
     test_chainable_controller::TEST_CONTROLLER_NAME,
@@ -713,6 +716,15 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
+    test_chainable_controller->get_lifecycle_state().id());
+
+  // Cleanup to UNCONFIGURED so the duplicate-interface tests below can attempt configure
+  auto cleanup_request =
+    std::make_shared<controller_manager_msgs::srv::CleanupController::Request>();
+  cleanup_request->name = test_chainable_controller::TEST_CONTROLLER_NAME;
+  ASSERT_TRUE(call_service_and_wait(*cleanup_client, cleanup_request, srv_executor, true)->ok);
+  EXPECT_EQ(
+    lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     test_chainable_controller->get_lifecycle_state().id());
 
   // Now try to configure the chainable controller with duplicated command interfaces

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -238,7 +238,7 @@ TEST_P(TestLoadedControllerParametrized, inactive_controller_cannot_be_cleaned_u
     std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
   size_t cleanup_calls = 0;
   test_controller->cleanup_calls = &cleanup_calls;
-  // Configure from inactive state: controller can no be cleaned-up
+  // Configure from inactive state: rejected because controller is not unconfigured
   test_controller->simulate_cleanup_failure = true;
   EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
   ASSERT_EQ(
@@ -262,15 +262,15 @@ TEST_P(TestLoadedControllerParametrized, inactive_controller_cannot_be_configure
     std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
   size_t cleanup_calls = 0;
   test_controller->cleanup_calls = &cleanup_calls;
-  // Configure from inactive state
+  // Configure from inactive state: rejected because controller is not unconfigured
   test_controller->simulate_cleanup_failure = false;
   {
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::OK);
+    EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
   }
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
-  EXPECT_EQ(1u, cleanup_calls);
+  EXPECT_EQ(0u, cleanup_calls);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -266,7 +266,8 @@ TEST_P(TestLoadedControllerParametrized, inactive_controller_cannot_be_configure
   test_controller->simulate_cleanup_failure = false;
   {
     ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
+    EXPECT_EQ(
+      cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
   }
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());

--- a/controller_manager/test/test_load_controller.cpp
+++ b/controller_manager/test/test_load_controller.cpp
@@ -221,57 +221,21 @@ TEST_P(TestLoadedControllerParametrized, can_not_start_finalized_controller)
     lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED, controller_if->get_lifecycle_state().id());
 }
 
-TEST_P(TestLoadedControllerParametrized, inactive_controller_cannot_be_cleaned_up)
+TEST_P(TestLoadedControllerParametrized, configure_controller_requires_unconfigured_state)
 {
   const auto test_param = GetParam();
 
   EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::OK);
 
   start_test_controller(test_param.strictness);
-
   stop_test_controller(test_param.strictness);
-
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
 
-  std::shared_ptr<test_controller::TestController> test_controller =
-    std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
-  size_t cleanup_calls = 0;
-  test_controller->cleanup_calls = &cleanup_calls;
-  // Configure from inactive state: rejected because controller is not unconfigured
-  test_controller->simulate_cleanup_failure = true;
+  // configure_controller must reject any state other than UNCONFIGURED
   EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
-  EXPECT_EQ(0u, cleanup_calls);
-}
-
-TEST_P(TestLoadedControllerParametrized, inactive_controller_cannot_be_configured)
-{
-  const auto test_param = GetParam();
-
-  EXPECT_EQ(cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::OK);
-
-  start_test_controller(test_param.strictness);
-
-  stop_test_controller(test_param.strictness);
-  ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
-
-  std::shared_ptr<test_controller::TestController> test_controller =
-    std::dynamic_pointer_cast<test_controller::TestController>(controller_if);
-  size_t cleanup_calls = 0;
-  test_controller->cleanup_calls = &cleanup_calls;
-  // Configure from inactive state: rejected because controller is not unconfigured
-  test_controller->simulate_cleanup_failure = false;
-  {
-    ControllerManagerRunner cm_runner(this);
-    EXPECT_EQ(
-      cm_->configure_controller(CONTROLLER_NAME_1), controller_interface::return_type::ERROR);
-  }
-  ASSERT_EQ(
-    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller_if->get_lifecycle_state().id());
-  EXPECT_EQ(0u, cleanup_calls);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -1461,3 +1461,36 @@ TEST_F(TestLoadController, spawner_test_parsing_same_params_file_multiple_times)
   ASSERT_EQ(params_file_info.size(), 1ul);
   ASSERT_EQ(params_file_info[0], fallback_test_file_path);
 }
+
+TEST_F(TestLoadController, spawner_test_reconfigure_controller)
+{
+  cm_->set_parameter(rclcpp::Parameter("ctrl_1.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+
+  ControllerManagerRunner cm_runner(this);
+  EXPECT_EQ(call_spawner("ctrl_1 -c test_controller_manager --inactive"), 0);
+
+  ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
+  auto ctrl_1 = cm_->get_loaded_controllers()[0];
+  ASSERT_EQ(
+    ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  ASSERT_TRUE(ctrl_1.c->command_interface_configuration().names.empty());
+
+  // this parameter is only read in on_configure()
+  ctrl_1.c->get_node()->set_parameter(
+    rclcpp::Parameter("command_interfaces", std::vector<std::string>({"joint1/position"})));
+
+  // not configured again, so the changed parameter is not applied
+  EXPECT_EQ(call_spawner("ctrl_1 -c test_controller_manager --inactive"), 0);
+  EXPECT_EQ(
+    ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_TRUE(ctrl_1.c->command_interface_configuration().names.empty());
+
+  EXPECT_EQ(call_spawner("ctrl_1 -c test_controller_manager --inactive --reconfigure"), 0);
+  EXPECT_EQ(
+    ctrl_1.c->get_lifecycle_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+  EXPECT_THAT(
+    ctrl_1.c->command_interface_configuration().names,
+    std::vector<std::string>({"joint1/position"}));
+
+  cm_->unload_controller("ctrl_1");
+}

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -127,6 +127,13 @@ ChainableControllerInterface
 controller_manager
 ******************
 
+* ``configure_controller`` now performs a single-step lifecycle transition and
+  only accepts controllers in the ``unconfigured`` state (`#3196
+  <https://github.com/ros-controls/ros2_control/pull/3196>`__). Previously an
+  ``inactive`` controller was implicitly cleaned up and then reconfigured. To
+  reconfigure an ``inactive`` controller, call ``cleanup_controller`` first and
+  then ``configure_controller``.
+
 hardware_interface
 ******************
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -24,6 +24,7 @@ controller_manager
 * Added new ``cleanup_controller`` service to the controller manager to allow cleaning up controllers from external clients. (`#2414 <https://github.com/ros-controls/ros2_control/pull/2414>`__)
 * Removed forwarding of the controller manager's ros arguments to the controllers via NodeOptions. (`#3016 <https://github.com/ros-controls/ros2_control/pull/3016>`__)
 * The ``spawner`` now forwards all the parameter files parsed to the spawner node to the spawned controllers. This would support ``allow_substs`` approach. (`#3136 <https://github.com/ros-controls/ros2_control/pull/3136>`__)
+* ``configure_controller`` no longer implicitly cleans up an ``inactive`` controller before configuring; it now strictly requires the ``unconfigured`` state and returns an error otherwise. (`#3196 <https://github.com/ros-controls/ros2_control/pull/3196>`__)
 
 hardware_interface
 ******************

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,7 @@ controller_manager
 * Removed forwarding of the controller manager's ros arguments to the controllers via NodeOptions. (`#3016 <https://github.com/ros-controls/ros2_control/pull/3016>`__)
 * The ``spawner`` now forwards all the parameter files parsed to the spawner node to the spawned controllers. This would support ``allow_substs`` approach. (`#3136 <https://github.com/ros-controls/ros2_control/pull/3136>`__)
 * ``configure_controller`` no longer implicitly cleans up an ``inactive`` controller before configuring; it now strictly requires the ``unconfigured`` state and returns an error otherwise. (`#3196 <https://github.com/ros-controls/ros2_control/pull/3196>`__)
+* The ``spawner`` skips configuring an already configured controller. Use the new ``--reconfigure`` argument to cleanup and configure it again. (`#3196 <https://github.com/ros-controls/ros2_control/pull/3196>`__)
 
 hardware_interface
 ******************

--- a/ros2controlcli/ros2controlcli/verb/load_controller.py
+++ b/ros2controlcli/ros2controlcli/verb/load_controller.py
@@ -54,7 +54,9 @@ class LoadControllerVerb(VerbExtension):
     def main(self, *, args):
         with NodeStrategy(args).direct_node as node:
             controllers = list_controllers(node, args.controller_manager, 20.0).controller
-            if any(c.name == args.controller_name for c in controllers):
+            matched = next((c for c in controllers if c.name == args.controller_name), None)
+            loaded_state = matched.state if matched else None
+            if loaded_state is not None:
                 print(
                     f"{bcolors.WARNING}Controller : {args.controller_name} already loaded, skipping load_controller!{bcolors.ENDC}"
                 )
@@ -86,18 +88,20 @@ class LoadControllerVerb(VerbExtension):
                 print(
                     f"{bcolors.OKBLUE}Successfully loaded controller {args.controller_name}{bcolors.ENDC}"
                 )
+                loaded_state = "unconfigured"
 
             if args.set_state:
 
-                # we in any case configure the controller
-                response = configure_controller(
-                    node, args.controller_manager, args.controller_name
-                )
-                if not response.ok:
-                    print(
-                        f"{bcolors.FAIL}Error configuring controller : {args.controller_name}{bcolors.ENDC}"
+                # configure_controller only accepts the unconfigured state
+                if loaded_state == "unconfigured":
+                    response = configure_controller(
+                        node, args.controller_manager, args.controller_name
                     )
-                    return 1
+                    if not response.ok:
+                        print(
+                            f"{bcolors.FAIL}Error configuring controller : {args.controller_name}{bcolors.ENDC}"
+                        )
+                        return 1
 
                 if args.set_state == "active":
                     response = switch_controllers(


### PR DESCRIPTION
Fix for issue #2916 
As discussed in #2916 and #2414, configure_controller() previously performed a multi-hop transition: if a controller was in Inactive state, it would auto-cleanup before configuring. 
For now cleanup sequence in unload_controller was kept as-is. Altering this would strictly break backward compatibility for service clients (e.g., spawner, orchestrator nodes). 

Changes:                                                                                                                                                                                                       
  - configure_controller(): now only accepts Unconfigured state; any other state returns ERROR                                                                                                                   
  - Removed the implicit auto-cleanup of Inactive controllers                                                                                                                                                    
  - Updated tests to reflect the strict behaviour