### PR TITLE
Fix LNK2005 in joint*limiter

### DIFF
--- a/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
+++ b/joint_limits/include/joint_limits/joint_saturation_limiter.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 
+#include "joint_limits/data_structures.hpp"
 #include "joint_limits/joint_limiter_interface.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
@@ -43,7 +44,7 @@ public:
   /** \brief Destructor */
   virtual ~JointSaturationLimiter();
 
-  bool on_init() override { return true; }
+  bool on_init() override;
 
   bool on_configure(const JointLimitsStateDataType & current_joint_states) override
   {
@@ -99,6 +100,15 @@ template <typename JointLimitsStateDataType>
 JointSaturationLimiter<JointLimitsStateDataType>::~JointSaturationLimiter()
 {
 }
+
+template <typename JointLimitsStateDataType>
+bool JointSaturationLimiter<JointLimitsStateDataType>::on_init()
+{
+  return true;
+}
+
+template <>
+bool JointSaturationLimiter<JointControlInterfacesData>::on_init();
 
 }  // namespace joint_limits
 


### PR DESCRIPTION
## Description
Since recently, windows builds fail
https://github.com/ros-controls/ros2_control/actions/runs/24822532815/job/72650396213?pr=3244
https://github.com/ros-controls/ros2_controllers/actions/runs/24820333962/job/72643437410

` joint_soft_limiter.obj : error LNK2005: "public: virtual bool __cdecl joint_limits::JointSaturationLimiter<struct joint_limits::JointControlInterfacesData>::on_init(void)" (?on_init@?$JointSaturationLimiter@UJointControlInterfacesData@joint_limits@@@joint_limits@@UEAA_NXZ) already defined in joint_range_limiter.obj [C:\upstream_ws\build\joint_limits\joint_saturation_limiter.vcxproj]`

### Is this user-facing behavior change?
no

### Did you use Generative AI?

GPT 5.3 Codex
