### PR TITLE
Fix C++20 behavior changes of `std::from_chars`

### DIFF
--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -29,14 +29,19 @@ namespace hardware_interface
 {
 namespace impl
 {
-template <typename T>
-std::optional<T> parse_floating_point_from_chars(const std::string & s)
+template <typename FloatingPointType>
+std::optional<FloatingPointType> parse_floating_point_with_from_chars(const std::string & s)
 {
   const char * begin = s.data();
-  const char * end = begin + s.size();
+  const char * end = s.data() + s.size();
 
-  // std::from_chars for floating-point values does not accept a leading '+'.
-  if (begin != end && *begin == '+')
+  if (begin == end)
+  {
+    return std::nullopt;
+  }
+
+  // std::from_chars for floating-point does not accept a leading '+' sign.
+  if (*begin == '+')
   {
     ++begin;
     if (begin == end)
@@ -45,9 +50,11 @@ std::optional<T> parse_floating_point_from_chars(const std::string & s)
     }
   }
 
-  T result_value;
+  FloatingPointType result_value;
   const auto parse_result = std::from_chars(begin, end, result_value);
-  if (parse_result.ec == std::errc() && parse_result.ptr == end && std::isfinite(result_value))
+  if (
+    parse_result.ec == std::errc() && parse_result.ptr == end &&
+    std::isfinite(static_cast<double>(result_value)))
   {
     return result_value;
   }
@@ -70,7 +77,8 @@ std::optional<double> stod(const std::string & s)
   }
   return result;
 #else
-  return parse_floating_point_from_chars<double>(s);
+  // Impl with std::from_chars
+  return parse_floating_point_with_from_chars<double>(s);
 #endif
 }
 
@@ -89,7 +97,8 @@ std::optional<float> stof(const std::string & s)
   }
   return result;
 #else
-  return parse_floating_point_from_chars<float>(s);
+  // Impl with std::from_chars
+  return parse_floating_point_with_from_chars<float>(s);
 #endif
 }
 

--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -29,6 +29,32 @@ namespace hardware_interface
 {
 namespace impl
 {
+template <typename T>
+std::optional<T> parse_floating_point_from_chars(const std::string & s)
+{
+  const char * begin = s.data();
+  const char * end = begin + s.size();
+
+  // std::from_chars for floating-point values does not accept a leading '+'.
+  if (begin != end && *begin == '+')
+  {
+    ++begin;
+    if (begin == end)
+    {
+      return std::nullopt;
+    }
+  }
+
+  T result_value;
+  const auto parse_result = std::from_chars(begin, end, result_value);
+  if (parse_result.ec == std::errc() && parse_result.ptr == end && std::isfinite(result_value))
+  {
+    return result_value;
+  }
+
+  return std::nullopt;
+}
+
 std::optional<double> stod(const std::string & s)
 {
 #if __cplusplus < 202002L
@@ -44,14 +70,7 @@ std::optional<double> stod(const std::string & s)
   }
   return result;
 #else
-  // Impl with std::from_chars
-  double result_value;
-  const auto parse_result = std::from_chars(s.data(), s.data() + s.size(), result_value);
-  if (parse_result.ec == std::errc())
-  {
-    return result_value;
-  }
-  return std::nullopt;
+  return parse_floating_point_from_chars<double>(s);
 #endif
 }
 
@@ -70,14 +89,7 @@ std::optional<float> stof(const std::string & s)
   }
   return result;
 #else
-  // Impl with std::from_chars
-  float result_value;
-  const auto parse_result = std::from_chars(s.data(), s.data() + s.size(), result_value);
-  if (parse_result.ec == std::errc())
-  {
-    return result_value;
-  }
-  return std::nullopt;
+  return parse_floating_point_from_chars<float>(s);
 #endif
 }
 


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
It seems that there is a behavior change in C++20, fixes #3240

This is not reflected in our PR CI jobs, but I was able to reproduce it locally with 
```
colcon build --packages-up-to hardware_interface --cmake-clean-cache --cmake-args -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=RelWithDebInfo
colcon test --packages-select hardware_interface
```
and this PR fixes the test failures.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

GPT 5.3 codex