### PR TITLE
Bump C++ version to C++20

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(controller_interface SHARED
   src/controller_interface.cpp
   src/chainable_controller_interface.cpp
 )
-target_compile_features(controller_interface PUBLIC cxx_std_17)
 target_include_directories(controller_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/controller_interface>

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -36,7 +36,6 @@ generate_parameter_library(controller_manager_parameters
 add_library(controller_manager SHARED
   src/controller_manager.cpp
 )
-target_compile_features(controller_manager PUBLIC cxx_std_17)
 target_include_directories(controller_manager PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/controller_manager>

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -34,7 +34,6 @@ add_library(hardware_interface SHARED
   src/hardware_component_interface.cpp
   src/lexical_casts.cpp
 )
-target_compile_features(hardware_interface PUBLIC cxx_std_17)
 target_include_directories(hardware_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/hardware_interface>
@@ -58,7 +57,6 @@ target_link_libraries(hardware_interface PUBLIC
 add_library(mock_components SHARED
   src/mock_components/generic_system.cpp
 )
-target_compile_features(mock_components PUBLIC cxx_std_17)
 target_include_directories(mock_components PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/hardware_interface>

--- a/joint_limits/CMakeLists.txt
+++ b/joint_limits/CMakeLists.txt
@@ -23,7 +23,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
 endforeach()
 
 add_library(joint_limits INTERFACE)
-target_compile_features(joint_limits INTERFACE cxx_std_17)
 target_include_directories(joint_limits INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
@@ -38,7 +37,6 @@ target_link_libraries(joint_limits INTERFACE
 add_library(joint_limiter_interface SHARED
   src/joint_limiter_interface.cpp
 )
-target_compile_features(joint_limiter_interface PUBLIC cxx_std_17)
 target_include_directories(joint_limiter_interface PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
@@ -51,7 +49,6 @@ target_link_libraries(joint_limiter_interface PUBLIC
 add_library(joint_limits_helpers SHARED
   src/joint_limits_helpers.cpp
 )
-target_compile_features(joint_limits_helpers PUBLIC cxx_std_17)
 target_include_directories(joint_limits_helpers PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>
@@ -63,7 +60,6 @@ add_library(joint_saturation_limiter SHARED
   src/joint_range_limiter.cpp
   src/joint_soft_limiter.cpp
 )
-target_compile_features(joint_saturation_limiter PUBLIC cxx_std_17)
 target_include_directories(joint_saturation_limiter PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/joint_limits>

--- a/ros2_control.rolling.repos
+++ b/ros2_control.rolling.repos
@@ -10,4 +10,4 @@ repositories:
   ros2_control_cmake:
     type: git
     url: https://github.com/ros-controls/ros2_control_cmake.git
-    version: c++20
+    version: master

--- a/ros2_control.rolling.repos
+++ b/ros2_control.rolling.repos
@@ -10,4 +10,4 @@ repositories:
   ros2_control_cmake:
     type: git
     url: https://github.com/ros-controls/ros2_control_cmake.git
-    version: master
+    version: c++20

--- a/ros2_control_test_assets/CMakeLists.txt
+++ b/ros2_control_test_assets/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.16)
 project(ros2_control_test_assets LANGUAGES CXX)
 
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
+
 find_package(ament_cmake REQUIRED)
 
 add_library(ros2_control_test_assets INTERFACE)
-target_compile_features(ros2_control_test_assets INTERFACE cxx_std_17)
 target_include_directories(ros2_control_test_assets INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/ros2_control_test_assets>

--- a/ros2_control_test_assets/package.xml
+++ b/ros2_control_test_assets/package.xml
@@ -11,6 +11,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros2_control_cmake</build_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

https://discourse.openrobotics.org/t/ros-2-lyrical-c-version/52551

I tested this build without https://github.com/ros-controls/ros2_control/pull/3244
```
colcon build --packages-up-to hardware_interface --cmake-clean-cache --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
colcon test --packages-select hardware_interface
```
and it fails, which means that the correct c++20 version is used and the behavior change would have been reflected by our CI build.

Needs https://github.com/ros-controls/ros2_control_cmake/pull/28


### Is this user-facing behavior change?
hopefully not

### Did you use Generative AI?
no
