### PR TITLE
Remove hardcoded default update rate

### DIFF
--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -67,7 +67,7 @@ public:
    * \param[in] activate_all boolean argument indicating if all resources should be immediately
    * activated. Currently used only in tests.
    * \param[in] update_rate Update rate of the controller manager to calculate calling frequency
-   * of async components.
+   * of async components. Must be non-zero, otherwise load_and_initialize_components will fail.
    * \param[in] clock_interface reference to the clock interface of the CM node for getting time
    * used for triggering async components and different read/write component rates.
    * \param[in] logger_interface reference to the logger interface of the CM node for logging.
@@ -88,7 +88,7 @@ public:
    * \param[in] activate_all boolean argument indicating if all resources should be immediately
    * activated. Currently used only in tests.
    * \param[in] update_rate Update rate of the controller manager to calculate calling frequency
-   * of async components.
+   * of async components. Must be non-zero, otherwise load_and_initialize_components will fail.
    * \param[in] clock reference to the clock of the CM node for getting time used for triggering
    * async components and different read/write component rates.
    * \param[in] logger logger of the CM node for logging.

--- a/hardware_interface/include/hardware_interface/resource_manager.hpp
+++ b/hardware_interface/include/hardware_interface/resource_manager.hpp
@@ -76,7 +76,7 @@ public:
     const std::string & urdf,
     rclcpp::node_interfaces::NodeClockInterface::SharedPtr clock_interface,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr logger_interface,
-    bool activate_all = false, const unsigned int update_rate = 100);
+    bool activate_all = false, const unsigned int update_rate = 0);
 
   /// Constructor for the Resource Manager.
   /**
@@ -95,7 +95,7 @@ public:
    */
   explicit ResourceManager(
     const std::string & urdf, rclcpp::Clock::SharedPtr clock, rclcpp::Logger logger,
-    bool activate_all = false, const unsigned int update_rate = 100);
+    bool activate_all = false, const unsigned int update_rate = 0);
 
   /// Constructor for the Resource Manager.
   /**
@@ -587,7 +587,7 @@ private:
   // aforementioned constructors.
   hardware_interface::ResourceManagerParams constructParams(
     rclcpp::Clock::SharedPtr clock, rclcpp::Logger logger, const std::string & urdf = std::string(),
-    bool activate_all = false, unsigned int update_rate = 100);
+    bool activate_all = false, unsigned int update_rate = 0);
 
   std::unordered_map<std::string, bool> claimed_command_interface_map_;
 

--- a/hardware_interface/include/hardware_interface/types/resource_manager_params.hpp
+++ b/hardware_interface/include/hardware_interface/types/resource_manager_params.hpp
@@ -94,8 +94,10 @@ struct ResourceManagerParams
    * @brief The update rate (in Hz) of the ControllerManager.
    * This can be used by ResourceManager to configure asynchronous hardware components
    * or for other timing considerations.
+   * @note Must be set to a non-zero value before calling load_and_initialize_components,
+   * otherwise initialization will fail.
    */
-  unsigned int update_rate = 100;
+  unsigned int update_rate = 0;
 
   /**
    * @brief If true, the ResourceManager will catch exceptions thrown during the different

--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1433,7 +1433,7 @@ public:
 
   // Update rate of the controller manager, and the clock interface of its node
   // Used by async components.
-  unsigned int cm_update_rate_ = 100;
+  unsigned int cm_update_rate_ = 0;
 };
 
 ResourceManager::ResourceManager(
@@ -1525,6 +1525,16 @@ bool ResourceManager::shutdown_components()
 bool ResourceManager::load_and_initialize_components(
   const hardware_interface::ResourceManagerParams & params)
 {
+  components_are_loaded_and_initialized_ = true;
+
+  if (params.update_rate == 0)
+  {
+    RCLCPP_ERROR(
+      params.logger, "update_rate is not set or is zero - cannot initialize hardware components.");
+    components_are_loaded_and_initialized_ = false;
+    return false;
+  }
+
   resource_storage_->robot_description_ = params.robot_description;
   resource_storage_->cm_update_rate_ = params.update_rate;
   params_.robot_description = params.robot_description;

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -220,6 +220,18 @@ TEST_F(ResourceManagerTest, no_load_and_initialize_components_function_called)
   ASSERT_FALSE(rm.are_components_initialized());
 }
 
+TEST_F(ResourceManagerTest, expect_load_and_initialize_to_fail_when_update_rate_is_zero)
+{
+  TestableResourceManager rm(node_);
+  hardware_interface::ResourceManagerParams rm_params;
+  rm_params.robot_description = ros2_control_test_assets::minimal_robot_urdf;
+  rm_params.clock = node_.get_clock();
+  rm_params.logger = node_.get_logger();
+  rm_params.update_rate = 0;
+  ASSERT_FALSE(rm.load_and_initialize_components(rm_params));
+  ASSERT_FALSE(rm.are_components_initialized());
+}
+
 TEST_F(
   ResourceManagerTest, expect_load_and_initialize_to_fail_when_a_hw_component_plugin_does_not_exist)
 {

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -1502,6 +1502,7 @@ TEST_F(ResourceManagerTest, hardware_nodes_are_added_to_mock_executor_on_load)
   params.clock = node_.get_clock();
   params.logger = node_.get_logger();
   params.executor = mock_executor;
+  params.update_rate = 100;
   TestableResourceManager rm(params);
   auto to_lower = [](const std::string & s)
   {

--- a/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
+++ b/hardware_interface_testing/test/test_resource_manager_prepare_perform_switch.cpp
@@ -555,6 +555,7 @@ public:
     params.logger = node_.get_logger();
     params.clock = node_.get_clock();
     params.robot_description = command_mode_urdf;
+    params.update_rate = 100;
     rm_ = std::make_unique<TestableResourceManager>(params);
     ASSERT_EQ(1u, rm_->actuator_components_size());
     ASSERT_EQ(1u, rm_->system_components_size());


### PR DESCRIPTION
## Description
The update_rate in ResourceManagerParams and cm_update_rate_ in ResourceStorage were hardcoded to 100 Hz as defaults. This caused simulators that override load_and_initialize_components or construct ResourceManager without explicitly setting the rate to silently run at the wrong frequency with no error. This PR changes the default to 0 as a sentinel value and adds an explicit validation in load_and_initialize_components that logs an error and returns false if update_rate is not set. Two tests that constructed ResourceManagerParams without setting update_rate are also fixed to explicitly pass 100.

Fixes #1575 