### PR TITLE
Fix the out of bound access of the std::vector in ChainableController

### DIFF
--- a/controller_interface/src/chainable_controller_interface.cpp
+++ b/controller_interface/src/chainable_controller_interface.cpp
@@ -50,6 +50,13 @@ return_type ChainableControllerInterface::update(
 std::vector<hardware_interface::StateInterface::ConstSharedPtr>
 ChainableControllerInterface::export_state_interfaces()
 {
+  // Reset internal state before calling the export methods so that stale names from a previous
+  // configure cycle (e.g. after a failed activation that skipped on_cleanup) do not cause the
+  // default on_export_state_interfaces() to generate ghost interfaces.
+  exported_state_interfaces_.clear();
+  exported_state_interface_names_.clear();
+  ordered_exported_state_interfaces_.clear();
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   auto state_interfaces = on_export_state_interfaces();
@@ -60,9 +67,6 @@ ChainableControllerInterface::export_state_interfaces()
   ordered_exported_state_interfaces_.reserve(
     state_interfaces.size() + state_interfaces_list.size());
   exported_state_interface_names_.reserve(state_interfaces.size() + state_interfaces_list.size());
-  exported_state_interfaces_.clear();
-  exported_state_interface_names_.clear();
-  ordered_exported_state_interfaces_.clear();
 
   // check if the names of the controller state interfaces begin with the controller's name
   for (const auto & interface : state_interfaces)
@@ -160,6 +164,13 @@ ChainableControllerInterface::export_state_interfaces()
 std::vector<hardware_interface::CommandInterface::SharedPtr>
 ChainableControllerInterface::export_reference_interfaces()
 {
+  // Reset internal state before calling the export methods so that stale names from a previous
+  // configure cycle (e.g. after a failed activation that skipped on_cleanup) do not cause the
+  // default on_export_reference_interfaces() to generate ghost interfaces.
+  exported_reference_interfaces_.clear();
+  exported_reference_interface_names_.clear();
+  ordered_exported_reference_interfaces_.clear();
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   auto reference_interfaces = on_export_reference_interfaces();
@@ -172,9 +183,6 @@ ChainableControllerInterface::export_reference_interfaces()
     reference_interfaces.size() + reference_interfaces_list.size());
   ordered_exported_reference_interfaces_.reserve(
     reference_interfaces.size() + reference_interfaces_list.size());
-  exported_reference_interfaces_.clear();
-  exported_reference_interface_names_.clear();
-  ordered_exported_reference_interfaces_.clear();
 
   // BEGIN (Handle export change): for backward compatibility
   // check if the "reference_interfaces_" variable is resized to number of interfaces

--- a/controller_interface/test/test_imu_sensor.cpp
+++ b/controller_interface/test/test_imu_sensor.cpp
@@ -54,7 +54,7 @@ TEST_F(IMUSensorTest, validate_all)
   auto orientation_z = std::make_shared<hardware_interface::StateInterface>(
     sensor_name_, imu_interface_names_[2], &orientation_values_[2]);
   auto orientation_w = std::make_shared<hardware_interface::StateInterface>(
-    sensor_name_, imu_interface_names_[3], &orientation_values_[4]);
+    sensor_name_, imu_interface_names_[3], &orientation_values_[3]);
 
   // assign values to angular velocity
   auto angular_velocity_x = std::make_shared<hardware_interface::StateInterface>(

--- a/controller_manager/test/test_controller/test_controller.cpp
+++ b/controller_manager/test/test_controller/test_controller.cpp
@@ -190,7 +190,10 @@ CallbackReturn TestController::on_activate(const rclcpp_lifecycle::State & /*pre
   {
     throw std::runtime_error("Exception from TestController::on_activate() as requested.");
   }
-  if (external_commands_for_testing_.empty())
+  // Resize to match the actual number of claimed command interfaces. Using names.size() in
+  // set_command_interface_configuration() gives the wrong count for ALL (0 names), REGEX (pattern
+  // count != match count), and INDIVIDUAL_BEST_EFFORT (some names may not exist).
+  if (external_commands_for_testing_.size() != command_interfaces_.size())
   {
     external_commands_for_testing_.resize(command_interfaces_.size(), 0.0);
   }

--- a/controller_manager/test/test_hardware_spawner.cpp
+++ b/controller_manager/test/test_hardware_spawner.cpp
@@ -209,7 +209,7 @@ TEST_F(TestHardwareSpawnerWithoutRobotDescription, spawner_with_later_load_of_ro
 {
   // Delay sending robot description
   robot_description_sending_timer_ = cm_->create_wall_timer(
-    std::chrono::milliseconds(2500),
+    std::chrono::milliseconds(4000),
     [&]()
     {
       RCLCPP_INFO(

--- a/controller_manager/test/test_hardware_spawner.cpp
+++ b/controller_manager/test/test_hardware_spawner.cpp
@@ -209,7 +209,13 @@ TEST_F(TestHardwareSpawnerWithoutRobotDescription, spawner_with_later_load_of_ro
 {
   // Delay sending robot description
   robot_description_sending_timer_ = cm_->create_wall_timer(
-    std::chrono::milliseconds(2500), [&]() { pass_robot_description_to_cm_and_rm(); });
+    std::chrono::milliseconds(2500),
+    [&]()
+    {
+      RCLCPP_INFO(
+        cm_->get_logger(), "Passing robot description to controller manager and resource manager");
+      pass_robot_description_to_cm_and_rm();
+    });
 
   EXPECT_EQ(
     call_spawner(


### PR DESCRIPTION
The bug is in both export_state_interfaces() and export_reference_interfaces() in chainable_controller_interface.cpp.                       
                                                                                                                                                                         
  Root cause: The default on_export_reference_interfaces() (old API backward compatibility) uses exported_reference_interface_names_ to generate interfaces. However,    
  these names are only cleared AFTER the call, so on the second configure (after a failed activation that bypassed on_cleanup), the stale names from the first configure 
  cause ghost interfaces to be created. This doubles ordered_exported_reference_interfaces_.size() to 2, while (*msg)->data only has 1 element → out-of-bounds access at 
  (*msg)->data[1].                                                                                                                                                       
                                                                                                                                                                         
  The fix is to clear the internal state vectors before calling on_export_reference_interfaces() / on_export_state_interfaces(), so the default (old API) implementations
   see an empty name list and return zero ghost interfaces.
                                                                      

<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #3283

### Is this user-facing behavior change?
No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Claude




