### PR TITLE
Add default read() implementation to HardwareComponentInterface

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_component_interface.hpp
@@ -261,7 +261,7 @@ public:
    * \param[in] period The measured time taken by the last control loop iteration
    * \return return_type::OK if the read was successful, return_type::ERROR otherwise.
    */
-  virtual return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) = 0;
+  virtual return_type read(const rclcpp::Time & time, const rclcpp::Duration & period);
 
   /// Triggers the write method synchronously or asynchronously depending on the HardwareInfo
   /**

--- a/hardware_interface/include/hardware_interface/sensor_interface.hpp
+++ b/hardware_interface/include/hardware_interface/sensor_interface.hpp
@@ -56,6 +56,8 @@ class SensorInterface : public HardwareComponentInterface
 public:
   std::vector<CommandInterface::SharedPtr> on_export_command_interfaces() override { return {}; }
 
+  virtual return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) = 0;
+
   return_type write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) final
   {
     return return_type::OK;

--- a/hardware_interface/src/hardware_component_interface.cpp
+++ b/hardware_interface/src/hardware_component_interface.cpp
@@ -481,6 +481,12 @@ HardwareComponentCycleStatus HardwareComponentInterface::trigger_write(
   return status;
 }
 
+return_type HardwareComponentInterface::read(
+  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+{
+  return return_type::OK;
+}
+
 return_type HardwareComponentInterface::write(
   const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
 {


### PR DESCRIPTION
Fixes #2734.

## Problem

`HardwareComponentInterface::write` has a default implementation returning `return_type::OK`, but `HardwareComponentInterface::read` is purely virtual. This forces `ActuatorInterface` implementors to write a no-op `read()` even when their hardware has no feedback sensors — while `SensorInterface` implementors never need to write a no-op `write()` (it's handled by `SensorInterface::write` final).

## Fix

Three-file change:

- **`hardware_component_interface.hpp`**: Remove `= 0` from `read` declaration (mirrors `write`)
- **`hardware_component_interface.cpp`**: Add default `read` implementation returning `return_type::OK` (mirrors the existing `write` default)
- **`sensor_interface.hpp`**: Re-declare `read` as pure virtual (`= 0`) to preserve the requirement that `SensorInterface` implementors must provide a real read — since reading state is the entire purpose of a sensor

## Result

- `ActuatorInterface` implementors no longer need a no-op `read()` when their hardware has no feedback
- `SensorInterface` implementors still get a compile error if they forget to implement `read`
- `SystemInterface` behavior unchanged (users should still implement `read` for full hardware drivers)