### PR TITLE
Handle NaNs properly in the joint limiters

### DIFF
--- a/joint_limits/src/joint_limits_helpers.cpp
+++ b/joint_limits/src/joint_limits_helpers.cpp
@@ -75,23 +75,23 @@ void verify_actual_position_within_limits(
 void update_prev_command(
   const JointControlInterfacesData & desired, JointControlInterfacesData & prev_command)
 {
-  if (desired.has_position())
+  if (desired.has_position() && !std::isnan(desired.position.value()))
   {
     prev_command.position = desired.position;
   }
-  if (desired.has_velocity())
+  if (desired.has_velocity() && !std::isnan(desired.velocity.value()))
   {
     prev_command.velocity = desired.velocity;
   }
-  if (desired.has_effort())
+  if (desired.has_effort() && !std::isnan(desired.effort.value()))
   {
     prev_command.effort = desired.effort;
   }
-  if (desired.has_acceleration())
+  if (desired.has_acceleration() && !std::isnan(desired.acceleration.value()))
   {
     prev_command.acceleration = desired.acceleration;
   }
-  if (desired.has_jerk())
+  if (desired.has_jerk() && !std::isnan(desired.jerk.value()))
   {
     prev_command.jerk = desired.jerk;
   }

--- a/joint_limits/src/joint_range_limiter.cpp
+++ b/joint_limits/src/joint_range_limiter.cpp
@@ -63,24 +63,58 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
   {
     if (desired.has_position())
     {
-      prev_command_.position = actual.has_position() ? actual.position : desired.position;
+      if (actual.has_position())
+      {
+        prev_command_.position = actual.position;
+      }
+      else if (!std::isnan(desired.position.value()))
+      {
+        prev_command_.position = desired.position;
+      }
     }
     if (desired.has_velocity())
     {
-      prev_command_.velocity = actual.has_velocity() ? actual.velocity : desired.velocity;
+      if (actual.has_velocity())
+      {
+        prev_command_.velocity = actual.velocity;
+      }
+      else if (!std::isnan(desired.velocity.value()))
+      {
+        prev_command_.velocity = desired.velocity;
+      }
     }
     if (desired.has_effort())
     {
-      prev_command_.effort = actual.has_effort() ? actual.effort : desired.effort;
+      if (actual.has_effort())
+      {
+        prev_command_.effort = actual.effort;
+      }
+      else if (!std::isnan(desired.effort.value()))
+      {
+        prev_command_.effort = desired.effort;
+      }
     }
     if (desired.has_acceleration())
     {
-      prev_command_.acceleration =
-        actual.has_acceleration() ? actual.acceleration : desired.acceleration;
+      if (actual.has_acceleration())
+      {
+        prev_command_.acceleration = actual.acceleration;
+      }
+      else if (!std::isnan(desired.acceleration.value()))
+      {
+        prev_command_.acceleration = desired.acceleration;
+      }
     }
     if (desired.has_jerk())
     {
-      prev_command_.jerk = actual.has_jerk() ? actual.jerk : desired.jerk;
+      if (actual.has_jerk())
+      {
+        prev_command_.jerk = actual.jerk;
+      }
+      else if (!std::isnan(desired.jerk.value()))
+      {
+        prev_command_.jerk = desired.jerk;
+      }
     }
     if (actual.has_data())
     {
@@ -92,7 +126,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
     }
   }
 
-  if (desired.has_position())
+  if (desired.has_position() && !std::isnan(desired.position.value()))
   {
     const auto limits = compute_position_limits(
       joint_name, joint_limits, actual.velocity, actual.position, prev_command_.position,
@@ -101,7 +135,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
     desired.position = std::clamp(desired.position.value(), limits.lower_limit, limits.upper_limit);
   }
 
-  if (desired.has_velocity())
+  if (desired.has_velocity() && !std::isnan(desired.velocity.value()))
   {
     const auto limits = compute_velocity_limits(
       joint_name, joint_limits, desired.velocity.value(), actual.position, prev_command_.velocity,
@@ -112,7 +146,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
     desired.velocity = std::clamp(desired.velocity.value(), limits.lower_limit, limits.upper_limit);
   }
 
-  if (desired.has_effort())
+  if (desired.has_effort() && !std::isnan(desired.effort.value()))
   {
     const auto limits =
       compute_effort_limits(joint_limits, actual.position, actual.velocity, dt_seconds);
@@ -121,7 +155,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
     desired.effort = std::clamp(desired.effort.value(), limits.lower_limit, limits.upper_limit);
   }
 
-  if (desired.has_acceleration())
+  if (desired.has_acceleration() && !std::isnan(desired.acceleration.value()))
   {
     const auto limits =
       compute_acceleration_limits(joint_limits, desired.acceleration.value(), actual.velocity);
@@ -132,7 +166,7 @@ bool JointSaturationLimiter<JointControlInterfacesData>::on_enforce(
       std::clamp(desired.acceleration.value(), limits.lower_limit, limits.upper_limit);
   }
 
-  if (desired.has_jerk())
+  if (desired.has_jerk() && !std::isnan(desired.jerk.value()))
   {
     limits_enforced =
       is_limited(desired.jerk.value(), -joint_limits.max_jerk, joint_limits.max_jerk) ||

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -49,24 +49,58 @@ bool JointSoftLimiter::on_enforce(
   {
     if (desired.has_position())
     {
-      prev_command_.position = actual.has_position() ? actual.position : desired.position;
+      if (actual.has_position())
+      {
+        prev_command_.position = actual.position;
+      }
+      else if (!std::isnan(desired.position.value()))
+      {
+        prev_command_.position = desired.position;
+      }
     }
     if (desired.has_velocity())
     {
-      prev_command_.velocity = actual.has_velocity() ? actual.velocity : desired.velocity;
+      if (actual.has_velocity())
+      {
+        prev_command_.velocity = actual.velocity;
+      }
+      else if (!std::isnan(desired.velocity.value()))
+      {
+        prev_command_.velocity = desired.velocity;
+      }
     }
     if (desired.has_effort())
     {
-      prev_command_.effort = actual.has_effort() ? actual.effort : desired.effort;
+      if (actual.has_effort())
+      {
+        prev_command_.effort = actual.effort;
+      }
+      else if (!std::isnan(desired.effort.value()))
+      {
+        prev_command_.effort = desired.effort;
+      }
     }
     if (desired.has_acceleration())
     {
-      prev_command_.acceleration =
-        actual.has_acceleration() ? actual.acceleration : desired.acceleration;
+      if (actual.has_acceleration())
+      {
+        prev_command_.acceleration = actual.acceleration;
+      }
+      else if (!std::isnan(desired.acceleration.value()))
+      {
+        prev_command_.acceleration = desired.acceleration;
+      }
     }
     if (desired.has_jerk())
     {
-      prev_command_.jerk = actual.has_jerk() ? actual.jerk : desired.jerk;
+      if (actual.has_jerk())
+      {
+        prev_command_.jerk = actual.jerk;
+      }
+      else if (!std::isnan(desired.jerk.value()))
+      {
+        prev_command_.jerk = desired.jerk;
+      }
     }
     if (actual.has_data())
     {
@@ -132,7 +166,7 @@ bool JointSoftLimiter::on_enforce(
     }
   }
 
-  if (desired.has_position())
+  if (desired.has_position() && !std::isnan(desired.position.value()))
   {
     const auto position_limits = compute_position_limits(
       joint_name, hard_limits, actual.velocity, actual.position, prev_command_.position,
@@ -170,7 +204,7 @@ bool JointSoftLimiter::on_enforce(
     desired.position = std::clamp(desired.position.value(), pos_low, pos_high);
   }
 
-  if (desired.has_velocity())
+  if (desired.has_velocity() && !std::isnan(desired.velocity.value()))
   {
     const auto velocity_limits = compute_velocity_limits(
       joint_name, hard_limits, desired.velocity.value(), actual.position, prev_command_.velocity,
@@ -192,7 +226,7 @@ bool JointSoftLimiter::on_enforce(
     desired.velocity = std::clamp(desired.velocity.value(), soft_min_vel, soft_max_vel);
   }
 
-  if (desired.has_effort())
+  if (desired.has_effort() && !std::isnan(desired.effort.value()))
   {
     const auto effort_limits =
       compute_effort_limits(hard_limits, actual.position, actual.velocity, dt_seconds);
@@ -221,7 +255,7 @@ bool JointSoftLimiter::on_enforce(
     desired.effort = std::clamp(desired.effort.value(), soft_min_eff, soft_max_eff);
   }
 
-  if (desired.has_acceleration())
+  if (desired.has_acceleration() && !std::isnan(desired.acceleration.value()))
   {
     const auto limits =
       compute_acceleration_limits(hard_limits, desired.acceleration.value(), actual.velocity);
@@ -232,33 +266,12 @@ bool JointSoftLimiter::on_enforce(
       std::clamp(desired.acceleration.value(), limits.lower_limit, limits.upper_limit);
   }
 
-  if (desired.has_jerk())
+  if (desired.has_jerk() && !std::isnan(desired.jerk.value()))
   {
     limits_enforced =
       is_limited(desired.jerk.value(), -hard_limits.max_jerk, hard_limits.max_jerk) ||
       limits_enforced;
     desired.jerk = std::clamp(desired.jerk.value(), -hard_limits.max_jerk, hard_limits.max_jerk);
-  }
-
-  if (desired.has_position() && !std::isfinite(desired.position.value()) && actual.has_position())
-  {
-    desired.position = actual.position;
-    limits_enforced = true;
-  }
-  if (desired.has_velocity() && !std::isfinite(desired.velocity.value()))
-  {
-    desired.velocity = 0.0;
-    limits_enforced = true;
-  }
-  if (desired.has_acceleration() && !std::isfinite(desired.acceleration.value()))
-  {
-    desired.acceleration = 0.0;
-    limits_enforced = true;
-  }
-  if (desired.has_jerk() && !std::isfinite(desired.jerk.value()))
-  {
-    desired.jerk = 0.0;
-    limits_enforced = true;
   }
 
   update_prev_command(desired, prev_command_);

--- a/joint_limits/test/test_joint_range_limiter.cpp
+++ b/joint_limits/test/test_joint_range_limiter.cpp
@@ -737,7 +737,8 @@ TEST_F(JointSaturationLimiterTest, when_command_is_nan_expect_no_limiting)
   actual_state_.velocity = 0.0;
   desired_state_ = {};
   desired_state_.position = 0.0;
-  ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
+  ASSERT_FALSE(
+    joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
 
   desired_state_.position = nan;
   EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // NaN, no change

--- a/joint_limits/test/test_joint_range_limiter.cpp
+++ b/joint_limits/test/test_joint_range_limiter.cpp
@@ -672,6 +672,82 @@ TEST_F(JointSaturationLimiterTest, check_all_desired_references_limiting)
   test_limit_enforcing(5.0, 0.5, 6.0, 2.0, 1.0, 0.5, 5.0, 0.0, 0.5, 0.5, true);
 }
 
+TEST_F(JointSaturationLimiterTest, when_command_is_nan_expect_no_limiting)
+{
+  SetupNode("joint_saturation_limiter");
+  ASSERT_TRUE(Load());
+
+  joint_limits::JointLimits limits;
+  limits.has_position_limits = true;
+  limits.min_position = -M_PI;
+  limits.max_position = M_PI;
+  limits.has_velocity_limits = true;
+  limits.max_velocity = 1.0;
+  limits.has_acceleration_limits = true;
+  limits.max_acceleration = 0.5;
+  limits.has_effort_limits = true;
+  limits.max_effort = 200.0;
+  limits.has_jerk_limits = true;
+  limits.max_jerk = 2.0;
+  ASSERT_TRUE(Init(limits));
+  ASSERT_TRUE(Configure());
+
+  rclcpp::Duration period(1, 0);  // 1 second
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+
+  // NaN position must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.position = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.position.value()));
+
+  // NaN velocity must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.velocity = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.velocity.value()));
+
+  // NaN effort must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.effort = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.effort.value()));
+
+  // NaN acceleration must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.acceleration = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.acceleration.value()));
+
+  // NaN jerk must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.jerk = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.jerk.value()));
+
+  // NaN must not corrupt prev_command_ — a subsequent finite command must still be limited.
+  ASSERT_TRUE(Init(limits));
+  actual_state_ = {};
+  actual_state_.position = 0.0;
+  actual_state_.velocity = 0.0;
+  desired_state_ = {};
+  desired_state_.position = 0.0;
+  ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
+
+  desired_state_.position = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // NaN, no change
+
+  desired_state_.position = M_PI * 2.0;  // well outside position limits
+  EXPECT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isfinite(desired_state_.position.value()));
+  EXPECT_LE(desired_state_.position.value(), limits.max_position);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -1167,7 +1167,8 @@ TEST_F(JointSoftLimiterTest, when_command_is_nan_expect_no_limiting)
   actual_state_.velocity = 0.0;
   desired_state_ = {};
   desired_state_.position = 0.0;
-  ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
+  ASSERT_FALSE(
+    joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
 
   desired_state_.position = nan;
   EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // NaN, no change

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -1101,6 +1101,83 @@ TEST_F(JointSoftLimiterTest, check_all_desired_references_limiting)
   test_limit_enforcing(5.0, 0.5, 6.0, 2.0, 1.0, 0.5, 5.0, 0.0, 0.5, 0.5, true);
 }
 
+TEST_F(JointSoftLimiterTest, when_command_is_nan_expect_no_limiting)
+{
+  SetupNode("joint_saturation_limiter");
+  ASSERT_TRUE(Load());
+
+  joint_limits::JointLimits limits;
+  limits.has_position_limits = true;
+  limits.min_position = -M_PI;
+  limits.max_position = M_PI;
+  limits.has_velocity_limits = true;
+  limits.max_velocity = 1.0;
+  limits.has_acceleration_limits = true;
+  limits.max_acceleration = 0.5;
+  limits.has_effort_limits = true;
+  limits.max_effort = 200.0;
+  limits.has_jerk_limits = true;
+  limits.max_jerk = 2.0;
+  joint_limits::SoftJointLimits soft_limits;
+  ASSERT_TRUE(Init(limits, soft_limits));
+  ASSERT_TRUE(Configure());
+
+  rclcpp::Duration period(1, 0);  // 1 second
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+
+  // NaN position must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.position = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.position.value()));
+
+  // NaN velocity must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.velocity = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.velocity.value()));
+
+  // NaN effort must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.effort = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.effort.value()));
+
+  // NaN acceleration must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.acceleration = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.acceleration.value()));
+
+  // NaN jerk must pass through unchanged
+  desired_state_ = {};
+  actual_state_ = {};
+  desired_state_.jerk = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isnan(desired_state_.jerk.value()));
+
+  // NaN must not corrupt prev_command_ — a subsequent finite command must still be limited.
+  ASSERT_TRUE(Init(limits, soft_limits));
+  actual_state_ = {};
+  actual_state_.position = 0.0;
+  actual_state_.velocity = 0.0;
+  desired_state_ = {};
+  desired_state_.position = 0.0;
+  ASSERT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // seed prev_command
+
+  desired_state_.position = nan;
+  EXPECT_FALSE(joint_limiter_->enforce(actual_state_, desired_state_, period));  // NaN, no change
+
+  desired_state_.position = M_PI * 2.0;  // well outside position limits
+  EXPECT_TRUE(joint_limiter_->enforce(actual_state_, desired_state_, period));
+  EXPECT_TRUE(std::isfinite(desired_state_.position.value()));
+  EXPECT_LE(desired_state_.position.value(), limits.max_position);
+}
+
 int main(int argc, char ** argv)
 {
   ::testing::InitGoogleMock(&argc, argv);


### PR DESCRIPTION
## Description

In our case, a controller was setting NaNs to the command interface and then the limiters are overriding these NaNs with a different value. Until we saw the logs, we aren't sure what was happening. I think if the interfaces are set to NaN, then simply ignore the limiting and leave it to NaNs. I think this behaviour is right and easier to debug


### Is this user-facing behavior change?

YES, sending NaNs will give you NaNs instead of the valid value. 

### Did you use Generative AI?

NO

@ros-controls/ros_control can we backport this to jazzy and kilted?