### PR TITLE
feat(ros2controlcli): add lifecycle transition verbs to set_controller_state

### DIFF
--- a/ros2controlcli/ros2controlcli/verb/set_controller_state.py
+++ b/ros2controlcli/ros2controlcli/verb/set_controller_state.py
@@ -17,6 +17,7 @@ from controller_manager import (
     configure_controller,
     list_controllers,
     switch_controllers,
+    unload_controller,
 )
 
 from ros2cli.node.direct import add_arguments
@@ -35,8 +36,20 @@ class SetControllerStateVerb(VerbExtension):
         arg.completer = LoadedControllerNameCompleter()
         arg = parser.add_argument(
             "state",
-            choices=["unconfigured", "inactive", "active"],
-            help="State in which the controller should be changed to",
+            choices=[
+                "unconfigured",
+                "inactive",
+                "active",
+                "configure",
+                "activate",
+                "deactivate",
+                "cleanup",
+                "shutdown",
+            ],
+            help=(
+                "Target state or transition to trigger for the controller. "
+                "Note: 'shutdown' maps to the unload_controller service and removes the controller."
+            ),
         )
         add_controller_mgr_parsers(parser)
 
@@ -102,4 +115,50 @@ class SetControllerStateVerb(VerbExtension):
                     return "Error activating controller, check controller_manager logs"
 
                 print(f"Successfully activated {args.controller_name}")
+                return 0
+
+            if args.state == "configure":
+                response = configure_controller(
+                    node, args.controller_manager, args.controller_name
+                )
+                if not response.ok:
+                    return "Error configuring controller, check controller_manager logs"
+
+                print(f"Successfully configured {args.controller_name}")
+                return 0
+
+            if args.state == "activate":
+                response = switch_controllers(
+                    node, args.controller_manager, [], [args.controller_name], True, True, 5.0
+                )
+                if not response.ok:
+                    return "Error activating controller, check controller_manager logs"
+
+                print(f"Successfully activated {args.controller_name}")
+                return 0
+
+            if args.state == "deactivate":
+                response = switch_controllers(
+                    node, args.controller_manager, [args.controller_name], [], True, True, 5.0
+                )
+                if not response.ok:
+                    return "Error deactivating controller, check controller_manager logs"
+
+                print(f"Successfully deactivated {args.controller_name}")
+                return 0
+
+            if args.state == "cleanup":
+                response = cleanup_controller(node, args.controller_manager, args.controller_name)
+                if not response.ok:
+                    return "Error cleaning up controller, check controller_manager logs"
+
+                print(f"successfully cleaned up {args.controller_name}")
+                return 0
+
+            if args.state == "shutdown":
+                response = unload_controller(node, args.controller_manager, args.controller_name)
+                if not response.ok:
+                    return "Error shutting down controller, check controller_manager logs"
+
+                print(f"Successfully shut down {args.controller_name}")
                 return 0

--- a/ros2controlcli/test/test_set_controller_state.py
+++ b/ros2controlcli/test/test_set_controller_state.py
@@ -1,0 +1,41 @@
+# Copyright 2020 PAL Robotics S.L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import unittest
+from unittest.mock import patch
+
+from ros2controlcli.verb.set_controller_state import SetControllerStateVerb
+
+
+class TestSetControllerStateChoices(unittest.TestCase):
+    def setUp(self):
+        with patch("ros2controlcli.verb.set_controller_state.add_arguments"):
+            self.verb = SetControllerStateVerb()
+            self.parser = argparse.ArgumentParser()
+            self.verb.add_arguments(self.parser, "set_controller_state")
+
+    def test_primary_states_accepted(self):
+        for state in ["unconfigured", "inactive", "active"]:
+            args = self.parser.parse_args(["my_controller", state])
+            self.assertEqual(args.state, state)
+
+    def test_transition_verbs_accepted(self):
+        for state in ["configure", "activate", "deactivate", "cleanup", "shutdown"]:
+            args = self.parser.parse_args(["my_controller", state])
+            self.assertEqual(args.state, state)
+
+    def test_invalid_state_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["my_controller", "running"])


### PR DESCRIPTION

Related to #688

Adds lifecycle transition verbs (`configure`, `activate`, `deactivate`, `cleanup`, `shutdown`)
to `set_controller_state` as additional choices alongside the existing primary state choices
(`unconfigured`, `inactive`, `active`), consistent with `ros2lifecycle`.

Transition verbs call the service directly without pre-checking current state, matching
`ros2lifecycle` behavior.

**Note on `shutdown`**: there is no standalone shutdown service for controllers - **`shutdown`
maps to `unload_controller`**, which internally calls the lifecycle shutdown transition but also
removes the controller. Open to renaming this to `unload` if preferred.

### Is this user-facing behavior change?
Yes - new CLI arguments `configure`, `activate`, `deactivate`, `cleanup`, `shutdown` are
available for `ros2 control set_controller_state`.

cc @christophfroehlich - curious about your thoughts on the `shutdown`/`unload` naming.

