### PR TITLE
Unload controller upon sigterm

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -108,7 +108,7 @@ def parse_args_advanced(args):
         "-u",
         "--unload-on-kill",
         action="store_true",
-        help="Deactivate the active controllers and unload them on kill",
+        help="Deactivate the active controllers and unload them on SIGINT or SIGTERM",
     )
     global_parser.add_argument("-h", "--help", action="store_true", help="Show help")
 
@@ -239,7 +239,7 @@ def parse_native_args(args):
     parser.add_argument(
         "-u",
         "--unload-on-kill",
-        help="Wait until this application is interrupted and unload controller",
+        help="Wait until this application is interrupted (SIGINT or SIGTERM) and deactivate/unload controllers",
         action="store_true",
     )
     parser.add_argument(
@@ -358,6 +358,13 @@ def main(args=None):
     activate_as_group = global_args.activate_as_group
     unload_on_kill = global_args.unload_on_kill
     node = None
+    lock = None
+
+    def _on_shutdown_signal(signum, frame):
+        raise KeyboardInterrupt()
+
+    signal.signal(signal.SIGINT, _on_shutdown_signal)
+    signal.signal(signal.SIGTERM, _on_shutdown_signal)
 
     if spawner_ros_params_files:
         for controller in controllers:
@@ -574,6 +581,7 @@ def main(args=None):
         # second KeyboardInterrupt during the signal.signal() call itself.
         try:
             signal.signal(signal.SIGINT, signal.SIG_IGN)
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
         except (KeyboardInterrupt, Exception):
             pass
         if unload_on_kill:
@@ -632,7 +640,7 @@ def main(args=None):
     finally:
         if node:
             node.destroy_node()
-        if lock.is_locked:
+        if lock is not None and lock.is_locked:
             lock.release()
         rclpy.shutdown()
 

--- a/controller_manager/doc/userdoc.rst
+++ b/controller_manager/doc/userdoc.rst
@@ -182,7 +182,7 @@ There are two scripts to interact with controller manager from launch files:
                             Controller param file to be loaded into controller node before configure. Pass multiple times to load different files for different controllers or to override the parameters of the same controller.
       --load-only           Only load the controller and leave unconfigured.
       --inactive            Load and configure the controller, however do not activate them
-      -u, --unload-on-kill  Wait until this application is interrupted and unload controller
+      -u, --unload-on-kill  Wait until this application is interrupted (SIGINT or SIGTERM) and deactivate/unload controllers
       --controller-manager-timeout CONTROLLER_MANAGER_TIMEOUT
                             Time to wait for the controller manager service to be available
       --switch-timeout SWITCH_TIMEOUT
@@ -267,7 +267,7 @@ The ``spawner`` now supports per controller arguments, while parsing the argumen
       --activate-as-group   Activate controllers as a group
       --switch-asap, --no-switch-asap
                             Switch controllers as soon as possible
-      -u, --unload-on-kill  Deactivate the active controllers and unload them on kill
+      -u, --unload-on-kill  Deactivate the active controllers and unload them on SIGINT or SIGTERM
       -h, --help            Show help
 
     Controller Options:

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -605,6 +605,25 @@ TEST_F(TestLoadController, unload_on_kill_activate_as_group)
   ASSERT_EQ(cm_->get_loaded_controllers().size(), 0ul);
 }
 
+TEST_F(TestLoadController, unload_on_kill_with_sigterm)
+{
+  // When a launch file shuts down because a required sibling process crashes,
+  // it sends SIGINT and escalates to SIGTERM, --unload-on-kill must still
+  // deactivate and unload the controller when SIGTERM is delivered.
+  ControllerManagerRunner cm_runner(this);
+  cm_->set_parameter(rclcpp::Parameter("ctrl_3.type", test_controller::TEST_CONTROLLER_CLASS_NAME));
+  std::stringstream ss;
+  ss << "timeout --signal=TERM 5 "
+     << std::string(coveragepy_script) +
+          " $(ros2 pkg prefix controller_manager)/lib/controller_manager/spawner "
+     << "ctrl_3 -c test_controller_manager --unload-on-kill";
+
+  EXPECT_NE(std::system(ss.str().c_str()), 0)
+    << "timeout should have killed spawner and returned non 0 code";
+
+  ASSERT_EQ(cm_->get_loaded_controllers().size(), 0ul);
+}
+
 TEST_F(TestLoadController, spawner_test_to_check_parameter_overriding)
 {
   const std::string main_test_file_path =


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

```
pal@kangaroo-8c:~$ ros2 launch pal_policy_deployer kang_mjlab_policy_deployer.launch.py 
[INFO] [launch]: All log files can be found below /home/pal/.ros/log/2026-06-22-15-45-19-800466-kangaroo-8c-109236
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [kang_mjlab_node-1]: process started with pid [109262]
[INFO] [spawner-2]: process started with pid [109264]
[kang_mjlab_node-1] /home/pal/deployed_ws/pal_policy_inferer/lib/pal_policy_inferer/kang_mjlab_node: error while loading shared libraries: libonnxruntime.so.1.18.0: cannot open shared object file: No such file or directory
[ERROR] [kang_mjlab_node-1]: process has died [pid 109262, exit code 127, cmd '/home/pal/deployed_ws/pal_policy_inferer/lib/pal_policy_inferer/kang_mjlab_node --ros-args -r __node:=pal_policy_deployer --params-file /tmp/launch_params_eo_uajah -r /subscriber_controller/desired_state:=/rl_impedance_controller/reference'].
[INFO] [launch.user]: [pal_policy_deployer] policy node exited; shutting down the launch (controller will be unloaded).
[INFO] [launch]: process[kang_mjlab_node-1] was required: shutting down launched system
[INFO] [spawner-2]: sending signal 'SIGINT' to process[spawner-2]
[spawner-2] 1782143120.281697 [93]    spawner: wlan0: optional interface was not found.
[spawner-2] [INFO] [1782143120.443201124] [spawner_rl_impedance_controller]: Setting controller param "params_file" to "['/home/pal/deployed_ws/pal_policy_deployer/share/pal_policy_deployer/config/kangaroo_rl_controller.yaml']" for rl_impedance_controller
[spawner-2] [INFO] [1782143120.455259470] [spawner_rl_impedance_controller]: Setting controller param "type" to "pid_controller/PidController" for rl_impedance_controller
[spawner-2] [INFO] [1782143120.524388154] [spawner_rl_impedance_controller]: Loaded rl_impedance_controller
[spawner-2] [INFO] [1782143120.545013178] [spawner_rl_impedance_controller]: Configured and activated rl_impedance_controller
[spawner-2] [INFO] [1782143120.545542444] [spawner_rl_impedance_controller]: Waiting until interrupt to unload controllers
[ERROR] [spawner-2]: process[spawner-2] failed to terminate '5' seconds after receiving 'SIGINT', escalating to 'SIGTERM'
[INFO] [spawner-2]: sending signal 'SIGTERM' to process[spawner-2]
[ERROR] [spawner-2]: process has died [pid 109264, exit code -15, cmd '/opt/pal/alum/lib/controller_manager/spawner rl_impedance_controller --controller-manager controller_manager --param-file /home/pal/deployed_ws/pal_policy_deployer/share/pal_policy_deployer/config/kangaroo_rl_controller.yaml --unload-on-kill --ros-args'].

```

When there is a SIGTERM, I expected my controller to be killed when the child process of the launch dies, this wasn't the case here. It is needed for the safety of the robot, to not to leave it in torque/current control with older commands

Fixes # (issue)

### Is this user-facing behavior change?

NO

### Did you use Generative AI?

NO

