### PR TITLE
Add read_only attribute to JointInfo and ActuatorInfo

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -110,6 +110,7 @@ struct JointInfo
   std::vector<std::string> state_interfaces;
   std::vector<std::string> command_interfaces;
   std::string role;
+  bool read_only = false;
   double mechanical_reduction = 1.0;
   double offset = 0.0;
 };
@@ -121,6 +122,7 @@ struct ActuatorInfo
   std::vector<std::string> state_interfaces;
   std::vector<std::string> command_interfaces;
   std::string role;
+  bool read_only = false;
   double mechanical_reduction = 1.0;
   double offset = 0.0;
 };

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -110,9 +110,9 @@ struct JointInfo
   std::vector<std::string> state_interfaces;
   std::vector<std::string> command_interfaces;
   std::string role;
-  bool read_only = false;
   double mechanical_reduction = 1.0;
   double offset = 0.0;
+  bool read_only = false;
 };
 
 /// Contains semantic info about a given actuator loaded from URDF for a transmission
@@ -122,9 +122,9 @@ struct ActuatorInfo
   std::vector<std::string> state_interfaces;
   std::vector<std::string> command_interfaces;
   std::string role;
-  bool read_only = false;
   double mechanical_reduction = 1.0;
   double offset = 0.0;
+  bool read_only = false;
 };
 
 /// Contains semantic info about a given transmission loaded from URDF

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -682,7 +682,7 @@ void auto_fill_transmission_interfaces(HardwareInfo & hardware)
       transmission.actuators.push_back(
         ActuatorInfo{
           "actuator1", transmission.joints[0].state_interfaces,
-          transmission.joints[0].command_interfaces, "actuator1", false, 1.0, 0.0});
+          transmission.joints[0].command_interfaces, "actuator1", 1.0, 0.0, false});
     }
   }
 }

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -67,6 +67,7 @@ constexpr const auto kSizeAttribute = "size";
 constexpr const auto kNameAttribute = "name";
 constexpr const auto kTypeAttribute = "type";
 constexpr const auto kRoleAttribute = "role";
+constexpr const auto kReadOnlyAttribute = "read_only";
 constexpr const auto kReductionAttribute = "mechanical_reduction";
 constexpr const auto kOffsetAttribute = "offset";
 constexpr const auto kReadWriteRateAttribute = "rw_rate";
@@ -554,6 +555,9 @@ JointInfo parse_transmission_joint_from_xml(const tinyxml2::XMLElement * element
   JointInfo joint_info;
   joint_info.name = get_attribute_value(element_it, kNameAttribute, element_it->Name());
   joint_info.role = get_attribute_value(element_it, kRoleAttribute, element_it->Name());
+  const auto * read_only_attr = element_it->FindAttribute(kReadOnlyAttribute);
+  joint_info.read_only =
+    read_only_attr ? parse_bool(ros2_control::strip(read_only_attr->Value())) : false;
   joint_info.mechanical_reduction =
     get_parameter_value_or(element_it->FirstChildElement(), kReductionAttribute, 1.0);
   joint_info.offset =
@@ -566,6 +570,9 @@ ActuatorInfo parse_transmission_actuator_from_xml(const tinyxml2::XMLElement * e
   ActuatorInfo actuator_info;
   actuator_info.name = get_attribute_value(element_it, kNameAttribute, element_it->Name());
   actuator_info.role = get_attribute_value(element_it, kRoleAttribute, element_it->Name());
+  const auto * read_only_attr = element_it->FindAttribute(kReadOnlyAttribute);
+  actuator_info.read_only =
+    read_only_attr ? parse_bool(ros2_control::strip(read_only_attr->Value())) : false;
   actuator_info.mechanical_reduction =
     get_parameter_value_or(element_it->FirstChildElement(), kReductionAttribute, 1.0);
   actuator_info.offset =
@@ -675,7 +682,7 @@ void auto_fill_transmission_interfaces(HardwareInfo & hardware)
       transmission.actuators.push_back(
         ActuatorInfo{
           "actuator1", transmission.joints[0].state_interfaces,
-          transmission.joints[0].command_interfaces, "actuator1", 1.0, 0.0});
+          transmission.joints[0].command_interfaces, "actuator1", false, 1.0, 0.0});
     }
   }
 }

--- a/hardware_interface/test/test_component_parser.cpp
+++ b/hardware_interface/test/test_component_parser.cpp
@@ -734,16 +734,20 @@ TEST_F(TestComponentParser, successfully_parse_valid_urdf_system_multi_joints_tr
   EXPECT_EQ(hardware_info.transmissions[0].joints[0].role, "joint1");
   EXPECT_EQ(hardware_info.transmissions[0].joints[0].mechanical_reduction, 10.0);
   EXPECT_EQ(hardware_info.transmissions[0].joints[0].offset, 0.5);
+  EXPECT_FALSE(hardware_info.transmissions[0].joints[0].read_only);
   EXPECT_EQ(hardware_info.transmissions[0].joints[1].name, "joint2");
   EXPECT_EQ(hardware_info.transmissions[0].joints[1].role, "joint2");
   EXPECT_EQ(hardware_info.transmissions[0].joints[1].mechanical_reduction, 50.0);
   EXPECT_EQ(hardware_info.transmissions[0].joints[1].offset, 0.0);
+  EXPECT_FALSE(hardware_info.transmissions[0].joints[1].read_only);
 
   ASSERT_THAT(hardware_info.transmissions[0].actuators, SizeIs(2));
   EXPECT_EQ(hardware_info.transmissions[0].actuators[0].name, "joint1_motor");
   EXPECT_EQ(hardware_info.transmissions[0].actuators[0].role, "actuator1");
+  EXPECT_TRUE(hardware_info.transmissions[0].actuators[0].read_only);
   EXPECT_EQ(hardware_info.transmissions[0].actuators[1].name, "joint2_motor");
   EXPECT_EQ(hardware_info.transmissions[0].actuators[1].role, "actuator2");
+  EXPECT_FALSE(hardware_info.transmissions[0].actuators[1].read_only);
 }
 
 TEST_F(TestComponentParser, successfully_parse_valid_urdf_sensor_only)

--- a/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/components_urdfs.hpp
@@ -352,13 +352,13 @@ const auto valid_urdf_ros2_control_system_multi_joints_transmission =
     </joint>
     <transmission name="transmission1">
       <plugin>transmission_interface/DifferentialTransmission</plugin>
-      <actuator name="joint1_motor" role="actuator1"/>
+      <actuator name="joint1_motor" role="actuator1" read_only="true"/>
       <actuator name="joint2_motor" role="actuator2"/>
       <joint name="joint1" role="joint1">
         <mechanical_reduction>10</mechanical_reduction>
         <offset>0.5</offset>
       </joint>
-      <joint name="joint2" role="joint2">
+      <joint name="joint2" role="joint2" read_only="false">
         <mechanical_reduction>50</mechanical_reduction>
       </joint>
     </transmission>


### PR DESCRIPTION
## Description

On our kangaroo, one of the transmission has to read data from an actuator, to initialize the other 2 joints, and when we add logic into our custom system, it is affecting our prepare and perform command switch interface logic. Having a way to be able to set that a specific actuator is read_only, that way the lower level can handle the complex behaviour

Fixes # (issue)

### Is this user-facing behavior change?

NO

### Did you use Generative AI?
NO

