### PR TITLE
Fix Windows build: add missing <unordered_set> include in resource_manager

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
## Description

Attempt at fixing CI-reported error on Windows.

`resource_manager.cpp` uses `std::unordered_set` but never includes `<unordered_set>`. MSVC fails (`error C2039`) while GCC/Clang resolve it transitively. Adds the missing include. 

### Is this user-facing behavior change?

No.

### Did you use Generative AI?
Claude Opus 4.8