### PR TITLE
Fix invalid URDF being reported as initialized in ResourceManager (jazzy bp)

### DIFF
--- a/hardware_interface/src/resource_manager.cpp
+++ b/hardware_interface/src/resource_manager.cpp
@@ -1513,7 +1513,7 @@ bool ResourceManager::shutdown_components()
 bool ResourceManager::load_and_initialize_components(
   const std::string & urdf, const unsigned int update_rate)
 {
-  components_are_loaded_and_initialized_ = true;
+  components_are_loaded_and_initialized_ = false;
 
   resource_storage_->robot_description_ = urdf;
   resource_storage_->cm_update_rate_ = update_rate;


### PR DESCRIPTION
**Summary:**

Fixes a pre-existing jazzy bug where `ResourceManager::load_and_initialize_components()` reports a failed initialization as successful when the URDF is invalid.

**Description:**

The flag `components_are_loaded_and_initialized_` was set to true at the start of the function, before `parse_control_resources_from_urdf()`. That parse throws on an invalid URDF, and the exception skips the reset-to-false at the end of the function — so the flag stays true and i`s_resource_manager_initialized()` wrongly returns true. Fix sets the flag to false on entry. It's still set to true after a successful parse, so valid URDFs are unaffected.