### PR TITLE
Create spawner logger before lock-result is logged

### DIFF
--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -379,12 +379,15 @@ def main(args=None):
                 if not os.path.isfile(param_file):
                     raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
 
-    # Use the first controller name for the logger/lock
+    # Use the first controller name for the node/lock
     first_controller_name = controllers[0]["name"]
-    logger = rclpy.logging.get_logger("ros2_control_controller_spawner_" + first_controller_name)
+    spawner_node_name = "spawner_" + first_controller_name
+    # Fallback logger in case node creation fails; replaced by node.get_logger() below
+    logger = rclpy.logging.get_logger("spawner")
 
     try:
-        spawner_node_name = "spawner_" + first_controller_name
+        node = Node(spawner_node_name)
+        logger = node.get_logger()
         # Get the environment variable $ROS_HOME or default to ~/.ros
         ros_home = os.getenv("ROS_HOME", os.path.join(os.path.expanduser("~"), ".ros"))
         ros_control_lock_dir = os.path.join(ros_home, "locks")
@@ -425,9 +428,6 @@ def main(args=None):
             logger.info(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
         else:
             logger.debug(bcolors.OKGREEN + "Spawner lock acquired!" + bcolors.ENDC)
-
-        node = Node(spawner_node_name)
-        logger = node.get_logger()
 
         spawner_namespace = node.get_namespace()
 

--- a/controller_manager/controller_manager/spawner.py
+++ b/controller_manager/controller_manager/spawner.py
@@ -379,15 +379,12 @@ def main(args=None):
                 if not os.path.isfile(param_file):
                     raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), param_file)
 
-    # Use the first controller name for the node/lock
+    # Use the first controller name for the logger/lock
     first_controller_name = controllers[0]["name"]
-    spawner_node_name = "spawner_" + first_controller_name
-    # Fallback logger in case node creation fails; replaced by node.get_logger() below
-    logger = rclpy.logging.get_logger("spawner")
+    logger = rclpy.logging.get_logger("ros2_control_controller_spawner_" + first_controller_name)
 
     try:
-        node = Node(spawner_node_name)
-        logger = node.get_logger()
+        spawner_node_name = "spawner_" + first_controller_name
         # Get the environment variable $ROS_HOME or default to ~/.ros
         ros_home = os.getenv("ROS_HOME", os.path.join(os.path.expanduser("~"), ".ros"))
         ros_control_lock_dir = os.path.join(ros_home, "locks")
@@ -422,6 +419,13 @@ def main(args=None):
                 bcolors.FAIL + "Failed to acquire lock after multiple attempts." + bcolors.ENDC
             )
             return 1
+
+        # Create the node once the lock is acquired, so that all subsequent log
+        # messages are published to /rosout with the node's actual (possibly
+        # remapped) name. The node is created after the lock to keep node
+        # creation serialized between concurrent spawners.
+        node = Node(spawner_node_name)
+        logger = node.get_logger()
 
         # print only once when the lock is finally acquired, but with info level if it failed once
         if hit_timeout:


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

The spawner's logger was created from a hardcoded name
(`"ros2_control_controller_spawner_" + first_controller_name`) before the
Node existed. Since /rosout attribution is based on the node's actual name,
any log message emitted before `node.get_logger()` was assigned — including
all the file-lock acquisition messages (waiting, timeout retries, failures) —
never reached /rosout when the node name was remapped at launch.

This PR creates the Node before the lock-acquisition loop and obtains the
logger from it via `node.get_logger()`, so the logger always reflects the
node's actual (possibly remapped) name.

A fallback `rclpy.logging.get_logger("spawner")` is kept before the `try:`
block to preserve the logger-scope guarantee from #2382: the exception
handlers and `finally:` block reference `logger`, which must exist even if
Node creation itself raises.

Some history: the Node was originally created before this logic; #2202 moved
it inside the try block when introducing the file lock, and #2382 then
hoisted a hardcoded logger out of the try block to fix a scope issue. This
PR effectively restores the original ordering while keeping both the lock
behavior and the scope guarantee.

Verified the mechanism with a minimal rclpy script on ROS 2 Humble: a logger
obtained from `rclpy.logging.get_logger("<hardcoded>")` does not appear in
/rosout, while `node.get_logger()` messages appear with the node's remapped
name. `unspawner.py` already uses `node.get_logger()` throughout and is not
affected.

Fixes #3446

### Is this user-facing behavior change?

Yes, in a minor way: spawner log messages now appear in /rosout under the
node's actual (possibly remapped) name instead of the previous hardcoded
logger name `ros2_control_controller_spawner_<first_controller_name>`.
Anyone filtering /rosout by the old logger name would need to filter by the
node name instead.

### Did you use Generative AI?

Yes — I used Claude (Anthropic) as a guide while working on this PR: it
helped me navigate the contribution workflow, review the git history of
spawner.py, and draft this description. The fix itself follows the approach
suggested in the issue, and I made and tested the code changes myself.

### Additional Information

Relying on CI for the C++ integration tests (test_spawner_unspawner.cpp
etc.) on the target distros — I'm on ROS 2 Humble locally, so I verified
the rclpy logger mechanism directly rather than building the full stack.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
