### PR TITLE
fix: add update_rate upper bound validation to prevent narrowing overflow

### DIFF
--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -31,6 +31,7 @@ endforeach()
 
 generate_parameter_library(controller_manager_parameters
   src/controller_manager_parameters.yaml
+  include/controller_manager/validate_controller_manager_parameters.hpp
 )
 
 add_library(controller_manager SHARED

--- a/controller_manager/include/controller_manager/validate_controller_manager_parameters.hpp
+++ b/controller_manager/include/controller_manager/validate_controller_manager_parameters.hpp
@@ -1,0 +1,41 @@
+// Copyright 2026 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTROLLER_MANAGER__VALIDATE_CONTROLLER_MANAGER_PARAMETERS_HPP_
+#define CONTROLLER_MANAGER__VALIDATE_CONTROLLER_MANAGER_PARAMETERS_HPP_
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include "rclcpp/parameter.hpp"
+#include "rsl/parameter_validators.hpp"
+
+namespace controller_manager
+{
+inline tl::expected<void, std::string> fits_update_rate_storage(const rclcpp::Parameter & parameter)
+{
+  const auto update_rate = parameter.as_int();
+  const auto max_update_rate = static_cast<std::uint64_t>(std::numeric_limits<unsigned int>::max());
+
+  if (update_rate > 0 && static_cast<std::uint64_t>(update_rate) > max_update_rate)
+  {
+    return tl::make_unexpected("must be less than or equal to " + std::to_string(max_update_rate));
+  }
+
+  return {};
+}
+}  // namespace controller_manager
+
+#endif  // CONTROLLER_MANAGER__VALIDATE_CONTROLLER_MANAGER_PARAMETERS_HPP_

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -743,7 +743,7 @@ void ControllerManager::initialize_parameters()
     RCLCPP_ERROR(
       this->get_logger(),
       "Exception thrown while initializing controller manager parameters: %s \n", e.what());
-    throw e;
+    throw;
   }
 }
 

--- a/controller_manager/src/controller_manager_parameters.yaml
+++ b/controller_manager/src/controller_manager_parameters.yaml
@@ -3,7 +3,11 @@ controller_manager:
     type: int,
     default_value: 100,
     read_only: true,
-    description: "The frequency of controller manager's real-time update loop. This loop reads states from hardware, updates controllers and writes commands to hardware."
+    description: "The frequency of controller manager's real-time update loop. This loop reads states from hardware, updates controllers and writes commands to hardware.",
+    validation: {
+      gt<>: 0,
+      "controller_manager::fits_update_rate_storage": null,
+    }
   }
 
   enforce_command_limits: {

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,6 +28,47 @@
 
 using ::testing::_;
 using ::testing::Return;
+
+class TestControllerManagerUpdateRateParameter : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase() { rclcpp::init(0, nullptr); }
+
+  static void TearDownTestCase() { rclcpp::shutdown(); }
+
+  void expect_update_rate_rejected(const std::int64_t update_rate)
+  {
+    auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    auto node_options = controller_manager::get_cm_node_options();
+    node_options.parameter_overrides({rclcpp::Parameter("update_rate", update_rate)});
+
+    EXPECT_THROW(
+      std::make_shared<controller_manager::ControllerManager>(
+        executor, ros2_control_test_assets::minimal_robot_urdf, true, TEST_CM_NAME, "",
+        node_options),
+      rclcpp::exceptions::InvalidParameterValueException);
+  }
+};
+
+TEST_F(TestControllerManagerUpdateRateParameter, rejects_zero) { expect_update_rate_rejected(0); }
+
+TEST_F(TestControllerManagerUpdateRateParameter, rejects_negative_value)
+{
+  expect_update_rate_rejected(-1);
+}
+
+TEST_F(TestControllerManagerUpdateRateParameter, rejects_value_that_overflows_storage)
+{
+  const auto max_update_rate = static_cast<std::uint64_t>(std::numeric_limits<unsigned int>::max());
+  const auto max_parameter_value =
+    static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  if (max_update_rate >= max_parameter_value)
+  {
+    GTEST_SKIP() << "The update-rate parameter cannot represent a value larger than unsigned int";
+  }
+
+  expect_update_rate_rejected(static_cast<std::int64_t>(max_update_rate + 1));
+}
 
 class TestControllerManagerWithStrictness
 : public ControllerManagerFixture<controller_manager::ControllerManager>,


### PR DESCRIPTION
Fixes #3469.

**Bug**: ROS params are 64-bit, but update_rate is stored as unsigned int (32-bit). A value > UINT_MAX passes the `gt<>: 0` lower-bound check but narrows to 0 after `static_cast`, causing modulo-by-zero UB.

**Fix**: Adds a custom validator `fits_update_rate_storage` that rejects values exceeding `unsigned int` max, combined with `gt<>: 0` for a complete [1, UINT_MAX] range. Also fixes a `throw e` (slicing) to `throw;`.

**Changes**:
- New `validate_controller_manager_parameters.hpp` with `fits_update_rate_storage` validator
- Added validation block to `controller_manager_parameters.yaml` (gt<>: 0 + fits_update_rate_storage)
- 3 new tests: rejects_zero, rejects_negative_value, rejects_value_that_overflows_storage
- Fix `throw e` → `throw;` in controller_manager.cpp

Discovered during review of #3454.