### PR TITLE
Add missing controller async parameter declarations

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -99,9 +99,6 @@ return_type ControllerInterfaceBase::init(
     // no rclcpp::ParameterValue unsigned int specialization
     auto_declare<int>("update_rate", static_cast<int>(params.controller_manager_update_rate));
     auto_declare<bool>("is_async", false);
-
-    realtime_tools::AsyncFunctionHandlerParams::declare(
-      impl_->node_, "async_parameters.", impl_->ctrl_itf_params_.update_rate);
   }
   catch (const std::exception & e)
   {

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -99,7 +99,6 @@ return_type ControllerInterfaceBase::init(
     // no rclcpp::ParameterValue unsigned int specialization
     auto_declare<int>("update_rate", static_cast<int>(params.controller_manager_update_rate));
     auto_declare<bool>("is_async", false);
-    auto_declare<int>("thread_priority", -100);
 
     realtime_tools::AsyncFunctionHandlerParams::declare(
       impl_->node_, "async_parameters.", impl_->ctrl_itf_params_.update_rate);

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -101,12 +101,8 @@ return_type ControllerInterfaceBase::init(
     auto_declare<bool>("is_async", false);
     auto_declare<int>("thread_priority", -100);
 
-    auto_declare<int>("async_parameters.thread_priority", 50);
-    auto_declare<std::string>("async_parameters.scheduling_policy", "synchronized");
-    auto_declare<std::vector<int64_t>>("async_parameters.cpu_affinity", std::vector<int64_t>());
-    auto_declare<int>("async_parameters.execution_rate", impl_->ctrl_itf_params_.update_rate);
-    auto_declare<bool>("async_parameters.wait_until_initial_trigger", true);
-    auto_declare<bool>("async_parameters.print_warnings", true);
+    realtime_tools::AsyncFunctionHandlerParams::declare(
+      impl_->node_, "async_parameters.", impl_->ctrl_itf_params_.update_rate);
   }
   catch (const std::exception & e)
   {

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -100,6 +100,13 @@ return_type ControllerInterfaceBase::init(
     auto_declare<int>("update_rate", static_cast<int>(params.controller_manager_update_rate));
     auto_declare<bool>("is_async", false);
     auto_declare<int>("thread_priority", -100);
+
+    auto_declare<int>("async_parameters.thread_priority", 50);
+    auto_declare<std::string>("async_parameters.scheduling_policy", "synchronized");
+    auto_declare<std::vector<int64_t>>("async_parameters.cpu_affinity", std::vector<int64_t>());
+    auto_declare<int>("async_parameters.execution_rate", impl_->ctrl_itf_params_.update_rate);
+    auto_declare<bool>("async_parameters.wait_until_initial_trigger", true);
+    auto_declare<bool>("async_parameters.print_warnings", true);
   }
   catch (const std::exception & e)
   {

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -248,6 +248,7 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
   {
     realtime_tools::AsyncFunctionHandlerParams async_params;
     async_params.thread_priority = 50;  // default value
+    async_params.exec_rate = impl_->ctrl_itf_params_.update_rate;
     const int thread_priority_param =
       static_cast<int>(get_node()->get_parameter("thread_priority").as_int());
     if (thread_priority_param >= 0 && thread_priority_param <= 99)


### PR DESCRIPTION
## Description

Setting `async_parameters` key in controller config does not apply `cpu_affinity` or `thread_priority` config, as per [the documentation](https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/running_controllers_asynchronously.html#examples)

This config:
```yaml
example_controller:
  ros__parameters:
      type: joint_trajectory_controller/JointTrajectoryController
      is_async: true
      async_parameters:
        scheduling_policy: detached
        thread_priority: 70
        cpu_affinity: [2, 3]
```
Results in these logs:
```
[INFO] [1784294876.480348261] [controller_manager]: Configuring controller: 'example_controller'
[INFO] [1784294876.480486086] [example_controller]: Starting async handler with scheduler priority: 50   # <-- this is default!
[INFO] [1784294876.480659950] [example_controller]: No specific joint names are used for command interfaces. Using 'joints' parameter.
```

When this is expected:
```
[INFO] [1784294876.480348261] [controller_manager]: Configuring controller: 'example_controller'
[INFO] [1784294876.480486086] [example_controller]: Starting async handler with scheduler priority: 70
[INFO] [1784294876.480659950] [example_controller]: No specific joint names are used for command interfaces. Using 'joints' parameter.
[WARN] [1784294876.480661020] [AsyncFunctionHandler]: Async worker thread is successfully pinned to the requested CPU cores! 
```

## Solution:

Declare the parameters in question automatically, [here](https://github.com/ros-controls/ros2_control/blob/e4ebcc352d9aeb69969308428b051bdd3105b88f/controller_interface/src/controller_interface_base.cpp#L99-L102)

Not sure why this is not declared automatically. Probably at some point rclcpp does not automatically declare parameters set for nodes, so these configs get ignored.

And no one seemed to be pinning async controllers to any of the cores :smile: 

### Is this user-facing behavior change?

yep, now when you put the parameters described [in the docs](https://control.ros.org/rolling/doc/ros2_control/controller_manager/doc/running_controllers_asynchronously.html#examples), they actually get applied.

### Did you use Generative AI?

Nah