### PR TITLE
Add thread renaming for components

### DIFF
--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -100,6 +100,13 @@ return_type ControllerInterfaceBase::init(
     auto_declare<int>("update_rate", static_cast<int>(params.controller_manager_update_rate));
     auto_declare<bool>("is_async", false);
     auto_declare<int>("thread_priority", -100);
+
+    auto_declare<int>("async_parameters.thread_priority", 50);
+    auto_declare<std::string>("async_parameters.scheduling_policy", "synchronized");
+    auto_declare<std::vector<int64_t>>("async_parameters.cpu_affinity", std::vector<int64_t>());
+    auto_declare<int>("async_parameters.execution_rate", impl_->ctrl_itf_params_.update_rate);
+    auto_declare<bool>("async_parameters.wait_until_initial_trigger", true);
+    auto_declare<bool>("async_parameters.print_warnings", true);
   }
   catch (const std::exception & e)
   {

--- a/controller_interface/src/controller_interface_base.cpp
+++ b/controller_interface/src/controller_interface_base.cpp
@@ -107,6 +107,8 @@ return_type ControllerInterfaceBase::init(
     auto_declare<int>("async_parameters.execution_rate", impl_->ctrl_itf_params_.update_rate);
     auto_declare<bool>("async_parameters.wait_until_initial_trigger", true);
     auto_declare<bool>("async_parameters.print_warnings", true);
+    auto_declare<std::string>("async_parameters.thread_name", "");
+
   }
   catch (const std::exception & e)
   {
@@ -265,6 +267,9 @@ const rclcpp_lifecycle::State & ControllerInterfaceBase::configure()
         "instead.");
     }
     async_params.initialize(impl_->node_, "async_parameters.");
+    if (async_params.thread_name.empty()) {
+      async_params.thread_name = get_node()->get_name();
+    }
     if (async_params.scheduling_policy == realtime_tools::AsyncSchedulingPolicy::DETACHED)
     {
       RCLCPP_ERROR(

--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -358,6 +358,8 @@ struct HardwareAsyncParams
   std::vector<int> cpu_affinity_cores = {};
   /// Whether to print warnings when the async thread doesn't meet its deadline
   bool print_warnings = true;
+  /// Custom name for the async worker thread
+  std::string thread_name = "";
 };
 
 /// This structure stores information about hardware defined in a robot's URDF.

--- a/hardware_interface/src/component_parser.cpp
+++ b/hardware_interface/src/component_parser.cpp
@@ -76,6 +76,7 @@ constexpr const auto kThreadPriorityAttribute = "thread_priority";
 constexpr const auto kAffinityCoresAttribute = "affinity";
 constexpr const auto kSchedulingPolicyAttribute = "scheduling_policy";
 constexpr const auto kPrintWarningsAttribute = "print_warnings";
+constexpr const auto kThreadNameAttribute = "thread_name";
 
 }  // namespace
 
@@ -765,6 +766,11 @@ HardwareInfo parse_resource_from_xml(
           {
             hardware.async_params.scheduling_policy =
               to_lower_case(get_attribute_value(async_it, kSchedulingPolicyAttribute, kAsyncTag));
+          }
+          if (async_it->FindAttribute(kThreadNameAttribute))
+          {
+            hardware.async_params.thread_name =
+              get_attribute_value(async_it, kThreadNameAttribute, kAsyncTag);
           }
           if (async_it->FindAttribute(kThreadPriorityAttribute))
           {

--- a/hardware_interface/src/hardware_component_interface.cpp
+++ b/hardware_interface/src/hardware_component_interface.cpp
@@ -81,6 +81,11 @@ CallbackReturn HardwareComponentInterface::init(
     async_thread_params.logger = get_logger();
     async_thread_params.exec_rate = params.hardware_info.rw_rate;
     async_thread_params.print_warnings = info_.async_params.print_warnings;
+    if (!info_.async_params.thread_name.empty()) {
+      async_thread_params.thread_name = info_.async_params.thread_name;
+    } else {
+      async_thread_params.thread_name = info_.name;
+    }
     RCLCPP_INFO(
       get_logger(), "Starting async handler with scheduler priority: %d and policy : %s",
       info_.async_params.thread_priority,


### PR DESCRIPTION
## Description

#### Note: Requires fix https://github.com/ros-controls/ros2_control/pull/3481 to be merged, so we can use async parameters on controllers properly.
#### Note: Requires [this PR on `realtime_tools` to be merged as well](https://github.com/ros-controls/realtime_tools/pull/550)

I was working on distributing ros2 control processing on different cores, and It was nice to rename the threads spawned by `async_function_handler`, as we can see them more easily in `top` output.

In this PR, by default we rename the thread spawned to the component name,  truncated to 15 chars. Alternatively, we can give the thing a name we want.

#### Demo:
<img width="1556" height="214" alt="image" src="https://github.com/user-attachments/assets/02a51dee-b5d4-4095-ba91-9e262bfb8bc4" />

These are the configs for controllers/hardware and the output they produce:

This config for controllers
```yaml
example_controller:
  ros__parameters:
      type: joint_trajectory_controller/JointTrajectoryController
      is_async: true
      async_parameters:
        scheduling_policy: detached
        thread_priority: 70
        cpu_affinity: [2, 3]
        thread_name: ros_ctrl_jtc
```
gives these logs:
```
[INFO] [1784294876.480348261] [controller_manager]: Configuring controller: 'example_controller'
[INFO] [1784294876.480464686] [controller_manager]: Linked async controller 'example_controller' update() to follow async hardware 'maurob_cell_robot' read().
[INFO] [1784294876.480486086] [example_controller]: Starting async handler with scheduler priority: 70
[INFO] [1784294876.480578392] [AsyncFunctionHandler]: Thread name: ros_ctrl_jtc
[INFO] [1784294876.480659950] [example_controller]: No specific joint names are used for command interfaces. Using 'joints' parameter.
[WARN] [1784294876.480661020] [AsyncFunctionHandler]: Async worker thread is successfully pinned to the requested CPU cores! 
```
And this config for hardware:
```xml
<async 
            scheduling_policy="${scheduling_policy}" 
            print_warnings="true" 
            affinity="[2,3]" 
            thread_priority="70"
            thread_name="ros_hw_kuka"
        />
```
gives these logs:
```
[INFO] [1784294875.544887049] [controller_manager]: Initialize hardware 'my_kuka_robot'
[INFO] [1784294875.544901150] [controller_manager.hardware_component.system.my_kuka_robot]: Starting async handler with scheduler priority: 70 and policy : detached
[INFO] [1784294875.545115477] [controller_manager.hardware_component.system.my_kuka_robot]: Thread name: ros_hw_kuka
[WARN] [1784294875.545272045] [controller_manager.hardware_component.system.my_kuka_robot]: Async worker thread is successfully pinned to the requested CPU cores!
[INFO] [1784294875.548283067] [controller_manager]: Successful initialization of hardware 'my_kuka_robot' 
```

### Is this user-facing behavior change?

yes, if you muddle around with threads and real-time stuff

### Did you use Generative AI?

nah