### PR TITLE
Use stream parsing for hardware_interface floats on Apple

### DIFF
--- a/hardware_interface/src/lexical_casts.cpp
+++ b/hardware_interface/src/lexical_casts.cpp
@@ -64,7 +64,7 @@ std::optional<FloatingPointType> parse_floating_point_with_from_chars(const std:
 
 std::optional<double> stod(const std::string & s)
 {
-#if __cplusplus < 202002L
+#if __cplusplus < 202002L || defined(__APPLE__)
   // convert from string using no locale
   // Impl with std::istringstream
   std::istringstream stream(s);
@@ -84,7 +84,7 @@ std::optional<double> stod(const std::string & s)
 
 std::optional<float> stof(const std::string & s)
 {
-#if __cplusplus < 202002L
+#if __cplusplus < 202002L || defined(__APPLE__)
   // convert from string using no locale
   // Impl with std::istringstream
   std::istringstream stream(s);


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-hardware-interface.osx.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: Apple toolchains can still lack complete floating-point std::from_chars support; using the existing stream fallback there keeps lexical_casts.cpp buildable while preserving the from_chars path elsewhere.
