### PR TITLE
Avoid Windows TRUE/FALSE macro collisions in hardware_interface

### DIFF
--- a/hardware_interface/include/hardware_interface/hardware_info.hpp
+++ b/hardware_interface/include/hardware_interface/hardware_info.hpp
@@ -24,6 +24,14 @@
 
 #include "joint_limits/joint_limits.hpp"
 
+#ifdef TRUE
+#undef TRUE
+#endif
+
+#ifdef FALSE
+#undef FALSE
+#endif
+
 namespace hardware_interface
 {
 /**


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-hardware-interface.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: Windows headers may define TRUE and FALSE macros, which can collide with hardware_interface identifiers; undefining those macros before the declarations keeps the public header consumable on Windows.
