### PR TITLE
[RFC] set initial controller state via configuration

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -147,6 +147,8 @@ public:
    */
   controller_interface::return_type configure_controller(const std::string & controller_name);
 
+  void set_initial_controller_components_state();
+
   /// switch_controller Deactivates some controllers and activates others.
   /**
    * \param[in] activate_controllers is a list of controllers to activate.

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -557,6 +557,7 @@ ControllerManager::ControllerManager(
   if (is_resource_manager_initialized())
   {
     set_initial_hardware_components_state();
+    set_initial_controller_components_state();
     init_services();
   }
 }
@@ -587,6 +588,7 @@ ControllerManager::ControllerManager(
   {
     init_controller_manager();
     set_initial_hardware_components_state();
+    set_initial_controller_components_state();
     init_services();
   }
   else
@@ -802,6 +804,7 @@ void ControllerManager::robot_description_callback(const std_msgs::msg::String &
     "Resource Manager has been successfully initialized. Starting Controller Manager "
     "services...");
 
+  set_initial_controller_components_state();
   init_services();
 }
 
@@ -1832,6 +1835,73 @@ controller_interface::return_type ControllerManager::configure_controller(
   rt_controllers_wrapper_.get_unused_list(guard).clear();
 
   return controller_interface::return_type::OK;
+}
+
+void ControllerManager::set_initial_controller_components_state()
+{
+  // The controller manager is not aware of its own controllers before they are loaded.
+  // We have to search for parameters ending with '.type' and '.initial_state' and assume
+  // that these are controller names.
+
+  constexpr std::string_view suffix = "initial_state";
+
+  const std::vector<std::string> parameter_names = this->list_parameters({}, 2).names;
+
+  std::vector<std::string> controller_names;
+  for (const std::string & name : parameter_names)
+  {
+    if (name.ends_with(".type"))
+    {
+      controller_names.push_back(name.substr(0, name.find('.')));
+    }
+  }
+
+  for (const std::string & controller_name : controller_names)
+  {
+    const std::string param_name = fmt::format(FMT_COMPILE("{}.{}"), controller_name, suffix);
+    if (!has_parameter(param_name))
+    {
+      continue;
+    }
+
+    const std::string target_state = get_parameter(param_name).as_string();
+
+    RCLCPP_DEBUG(
+      get_logger(), "setting '%s' state to: '%s'", controller_name.c_str(), target_state.c_str());
+
+    // controller states and transitions:
+    // UNLOADED -> load -> UNCONFIGURED -> configure -> INACTIVE -> activate -> ACTIVE
+
+    if (target_state == "unconfigured" || target_state == "inactive" || target_state == "active")
+    {
+      if (load_controller(controller_name).get() == nullptr)
+      {
+        RCLCPP_ERROR(get_logger(), "cannot load '%s'", controller_name.c_str());
+        return;
+      }
+    }
+
+    if (target_state == "inactive" || target_state == "active")
+    {
+      if (configure_controller(controller_name) != controller_interface::return_type::OK)
+      {
+        RCLCPP_ERROR(get_logger(), "cannot configure '%s'", controller_name.c_str());
+        return;
+      }
+    }
+
+    if (target_state == "active")
+    {
+      if (
+        switch_controller(
+          {controller_name}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT) !=
+        controller_interface::return_type::OK)
+      {
+        RCLCPP_ERROR(get_logger(), "cannot activate '%s'", controller_name.c_str());
+        return;
+      }
+    }
+  }
 }
 
 void ControllerManager::clear_requests()


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This is a proposal to add a new parameter `initial_state`, next to `type`, that allows the controller manager to set controller states (`unconfigured`, `inactive`, `active`) right after initialisation. The advantage of this is that you can start load, configure, or start controllers immediately, without requiring an external service call.

Example:

Using the configuration
```YAML
controller_manager:
  ros__parameters:
    update_rate: 100

    joint_state_broadcaster:
      type: joint_state_broadcaster/JointStateBroadcaster
      initial_state: active
```
with:
```Python
def generate_launch_description():
    return LaunchDescription([
        Node(
            package="robot_state_publisher",
            executable="robot_state_publisher",
            parameters=[{"robot_description": URDF}],
        ),

        Node(
            package="controller_manager",
            executable="ros2_control_node",
            parameters=["controllers.yaml"],
        ),
    ])
```
starts the controller manager and the controllers almost instantly:
```
$ ros2 control list_controllers 
joint_state_broadcaster joint_state_broadcaster/JointStateBroadcaster  active
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

Controller configuration is not yet implemented. The user-facing change is only the addition of `initial_state`. Configuration parameters would be provided in the same way they are now.

## TODOs

To send us a pull request, please:

- [ ] Fork the repository.
- [ ] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [ ] Commit to your fork using clear commit messages.
- [ ] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
