### PR TITLE
fix(controller_manager): forward controller params as NodeOptions parameter overrides (backport #3497)

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -2712,6 +2712,28 @@ rclcpp::NodeOptions ControllerManager::determine_controller_node_options(
     node_options_arguments.push_back(parameters_file);
   }
 
+  // Forward controller-specific parameters from CM to the controller node as
+  // parameter overrides.  In Humble, rclcpp::LifecycleNode does not process
+  // --params-file from NodeOptions arguments (ros2_control #3497).  The spawner
+  // already stores these params on the CM node; we read them back and inject
+  // them directly into NodeOptions so they reach the controller.
+  const std::string prefix = controller.info.name + ".";
+  const auto prefixed_params = this->list_parameters({prefix}, 1).names;
+  for (const auto & full_name : prefixed_params)
+  {
+    const std::string param_name = full_name.substr(prefix.length());
+    if (param_name.empty() || param_name == "type" || param_name == "params_file")
+    {
+      continue;
+    }
+    rclcpp::Parameter param;
+    if (this->get_parameter(full_name, param))
+    {
+      controller_node_options.parameter_overrides().push_back(
+        rclcpp::Parameter(param_name, param.get_parameter_value()));
+    }
+  }
+
   // ensure controller's `use_sim_time` parameter matches controller_manager's
   const rclcpp::Parameter use_sim_time = this->get_parameter("use_sim_time");
   if (use_sim_time.as_bool())


### PR DESCRIPTION
## Problem

In Humble, `rclcpp::LifecycleNode` does not process `--params-file` from `NodeOptions` arguments during construction. This means controllers (e.g., `JointTrajectoryController`) that rely on parameters loaded via `--params-file` (like `joints`, `command_interfaces`, `state_interfaces`) start with empty read-only parameters and fail to configure.

**Reproduction details**: ros2_control#3497

## Root Cause

`determine_controller_node_options()` appends `--params-file <path>` to `NodeOptions::arguments()`, expecting the LifecycleNode constructor to pick them up. But in Humble rclcpp, the LifecycleNode constructor does not process `--params-file` from NodeOptions arguments — only launch-level arguments work.

## Fix

The spawner already calls `set_controller_parameters_from_param_files()` on load, which stores the controller's parameters (from the YAML) on the CM node with a `controller_name.` prefix. Instead of forwarding `--params-file` arguments, we read these stored parameters back from the CM node, strip the prefix, and inject them as `NodeOptions::parameter_overrides()` — which `LifecycleNode` does apply during construction.

```cpp
const std::string prefix = controller.info.name + ".";
const auto prefixed_params = this->list_parameters({prefix}, 1).names;
for (const auto & full_name : prefixed_params)
{
  const std::string param_name = full_name.substr(prefix.length());
  if (param_name.empty() || param_name == "type" || param_name == "params_file")
  {
    continue;
  }
  rclcpp::Parameter param;
  if (this->get_parameter(full_name, param))
  {
    controller_node_options.parameter_overrides().push_back(
      rclcpp::Parameter(param_name, param.get_parameter_value()));
  }
}
```

## Testing

- Build: `colcon build --packages-up-to controller_manager` passes
- Integration: tested on real robot hardware (RealMan RM65 arm) — JTC configures successfully with correct `joints`, `command_interfaces`, and `state_interfaces` parameters
- Backwards compatible: existing `--params-file` arguments are still appended (for setups where they work); the new parameter overrides are additive

Fixes #3497