### PR TITLE
Add RangeSensor unit coverage

### DIFF
--- a/controller_interface/CMakeLists.txt
+++ b/controller_interface/CMakeLists.txt
@@ -102,6 +102,13 @@ if(BUILD_TESTING)
     ${sensor_msgs_TARGETS}
   )
 
+  ament_add_gmock(test_range_sensor test/test_range_sensor.cpp)
+  target_link_libraries(test_range_sensor
+    controller_interface
+    hardware_interface::hardware_interface
+    ${sensor_msgs_TARGETS}
+  )
+
   # Semantic component command interface tests
 
   ament_add_gmock(test_semantic_component_command_interface

--- a/controller_interface/include/semantic_components/range_sensor.hpp
+++ b/controller_interface/include/semantic_components/range_sensor.hpp
@@ -41,7 +41,7 @@ public:
     const auto data = state_interfaces_[0].get().get_optional();
     if (data.has_value())
     {
-      return data.value();
+      return static_cast<float>(data.value());
     }
     return std::numeric_limits<float>::quiet_NaN();
   }

--- a/controller_interface/test/test_range_sensor.cpp
+++ b/controller_interface/test/test_range_sensor.cpp
@@ -50,7 +50,7 @@ public:
 
   std::unique_lock<std::shared_mutex> lock_for_test()
   {
-    return std::unique_lock<std::shared_mutex>(handle_mutex_);
+    return std::unique_lock<std::shared_mutex>(get_mutex());
   }
 };
 
@@ -95,7 +95,8 @@ TEST(RangeSensorTest, reports_nan_when_value_lock_is_unavailable)
 
   ASSERT_TRUE(range_sensor.assign_loaned_state_interfaces(state_interfaces));
 
-  const auto exclusive_lock = range_state->lock_for_test();
+  auto exclusive_lock = range_state->lock_for_test();
+  ASSERT_TRUE(exclusive_lock.owns_lock());
 
   EXPECT_TRUE(std::isnan(range_sensor.get_range()));
 

--- a/controller_interface/test/test_range_sensor.cpp
+++ b/controller_interface/test/test_range_sensor.cpp
@@ -1,0 +1,105 @@
+// Copyright 2026 Dennis Lanov
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+#include "semantic_components/range_sensor.hpp"
+#include "sensor_msgs/msg/range.hpp"
+
+using hardware_interface::LoanedStateInterface;
+using hardware_interface::StateInterface;
+using testing::ElementsAre;
+
+namespace
+{
+constexpr char SENSOR_NAME[] = "test_range_sensor";
+constexpr char RANGE_INTERFACE[] = "range";
+}  // namespace
+
+class TestableRangeSensor : public semantic_components::RangeSensor
+{
+public:
+  using RangeSensor::RangeSensor;
+
+  std::size_t assigned_interface_count() const { return state_interfaces_.size(); }
+};
+
+class LockableStateInterface : public StateInterface
+{
+public:
+  using StateInterface::StateInterface;
+
+  std::unique_lock<std::shared_mutex> lock_for_test()
+  {
+    return std::unique_lock<std::shared_mutex>(handle_mutex_);
+  }
+};
+
+TEST(RangeSensorTest, reports_range_value_and_message)
+{
+  TestableRangeSensor range_sensor(SENSOR_NAME);
+
+  EXPECT_THAT(
+    range_sensor.get_state_interface_names(),
+    ElementsAre(std::string(SENSOR_NAME) + "/" + RANGE_INTERFACE));
+
+  double range_value = 1.25;
+  auto range_state =
+    std::make_shared<LockableStateInterface>(SENSOR_NAME, RANGE_INTERFACE, &range_value);
+
+  std::vector<LoanedStateInterface> state_interfaces;
+  state_interfaces.emplace_back(range_state);
+
+  ASSERT_TRUE(range_sensor.assign_loaned_state_interfaces(state_interfaces));
+  ASSERT_EQ(range_sensor.assigned_interface_count(), 1u);
+
+  EXPECT_FLOAT_EQ(range_sensor.get_range(), static_cast<float>(range_value));
+
+  sensor_msgs::msg::Range message;
+  ASSERT_TRUE(range_sensor.get_values_as_message(message));
+  EXPECT_FLOAT_EQ(message.range, static_cast<float>(range_value));
+
+  range_sensor.release_interfaces();
+  EXPECT_EQ(range_sensor.assigned_interface_count(), 0u);
+}
+
+TEST(RangeSensorTest, reports_nan_when_value_lock_is_unavailable)
+{
+  TestableRangeSensor range_sensor(SENSOR_NAME);
+
+  double range_value = 1.25;
+  auto range_state =
+    std::make_shared<LockableStateInterface>(SENSOR_NAME, RANGE_INTERFACE, &range_value);
+
+  std::vector<LoanedStateInterface> state_interfaces;
+  state_interfaces.emplace_back(range_state);
+
+  ASSERT_TRUE(range_sensor.assign_loaned_state_interfaces(state_interfaces));
+
+  const auto exclusive_lock = range_state->lock_for_test();
+
+  EXPECT_TRUE(std::isnan(range_sensor.get_range()));
+
+  sensor_msgs::msg::Range message;
+  ASSERT_TRUE(range_sensor.get_values_as_message(message));
+  EXPECT_TRUE(std::isnan(message.range));
+}


### PR DESCRIPTION
## Summary

- add focused unit coverage for the `RangeSensor` semantic component
- verify interface naming, range retrieval, message population, interface release, and unavailable-value handling
- make the conversion from the state interface's `double` value to the message's `float` value explicit

## Testing

- `pre-commit run --files controller_interface/CMakeLists.txt controller_interface/include/semantic_components/range_sensor.hpp controller_interface/test/test_range_sensor.cpp`
- `ctest --test-dir ~/github/ros2_control_ws/build_range_sensor/controller_interface --tests-regex '^test_range_sensor$' --output-on-failure`

Fixes #2496
