### PR TITLE
Relax assertions w.r.t. timing on CI runners

### DIFF
--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -36,6 +36,7 @@ jobs:
         ROS_DISTRO: [humble]
         ROS_REPO: [main, testing]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control-not-released.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/humble-coverage-build.yml
+++ b/.github/workflows/humble-coverage-build.yml
@@ -27,4 +27,5 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
     secrets: inherit
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -25,6 +25,7 @@ jobs:
   debian_semi_binary_build:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-debian-build.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       upstream_workspace: ros2_control.humble.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-pre-release.yml
+++ b/.github/workflows/humble-pre-release.yml
@@ -22,6 +22,7 @@ jobs:
   default:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-prerelease.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       # downstream_depth is not set on pull_request event
       prerelease_downstream_depth: ${{ github.event_name == 'pull_request' && '0' || inputs.downstream_depth }}

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [humble]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -35,6 +35,7 @@ jobs:
       matrix:
         ROS_DISTRO: [humble]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
@@ -42,6 +43,7 @@ jobs:
   semi-binary-clang:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       ros_repo: testing
       upstream_workspace: ros2_control.humble.repos

--- a/.github/workflows/humble-semi-binary-downstream-build.yml
+++ b/.github/workflows/humble-semi-binary-downstream-build.yml
@@ -26,6 +26,7 @@ jobs:
   build-downstream:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       ros_repo: testing
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -27,6 +27,7 @@ jobs:
   source:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master
     with:
+      extra-cmake-args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       ref: humble
       container: ubuntu:22.04

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -36,6 +36,7 @@ jobs:
         ROS_DISTRO: [jazzy]
         ROS_REPO: [main, testing]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control-not-released.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/jazzy-coverage-build.yml
+++ b/.github/workflows/jazzy-coverage-build.yml
@@ -22,4 +22,5 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
     secrets: inherit
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [jazzy]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: jazzy

--- a/.github/workflows/jazzy-pre-release.yml
+++ b/.github/workflows/jazzy-pre-release.yml
@@ -22,6 +22,7 @@ jobs:
   default:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-prerelease.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       # downstream_depth is not set on pull_request event
       prerelease_downstream_depth: ${{ github.event_name == 'pull_request' && '0' || inputs.downstream_depth }}

--- a/.github/workflows/jazzy-rhel-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-binary-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [jazzy]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: jazzy

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -31,6 +31,7 @@ jobs:
   semi-binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       ros_repo: testing
       upstream_workspace: ros2_control.jazzy.repos
@@ -38,6 +39,7 @@ jobs:
   semi-binary-clang:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       ros_repo: testing
       upstream_workspace: ros2_control.jazzy.repos

--- a/.github/workflows/jazzy-semi-binary-downstream-build.yml
+++ b/.github/workflows/jazzy-semi-binary-downstream-build.yml
@@ -26,6 +26,7 @@ jobs:
   build-downstream:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       ros_repo: testing
       ref_for_scheduled_build: jazzy

--- a/.github/workflows/jazzy-source-build.yml
+++ b/.github/workflows/jazzy-source-build.yml
@@ -26,6 +26,7 @@ jobs:
   source:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master
     with:
+      extra-cmake-args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       ref: jazzy
       container: ubuntu:24.04

--- a/.github/workflows/kilted-binary-build.yml
+++ b/.github/workflows/kilted-binary-build.yml
@@ -36,6 +36,7 @@ jobs:
         ROS_DISTRO: [kilted]
         ROS_REPO: [main, testing]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control-not-released.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/kilted-coverage-build.yml
+++ b/.github/workflows/kilted-coverage-build.yml
@@ -22,4 +22,5 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
     secrets: inherit
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted

--- a/.github/workflows/kilted-debian-build.yml
+++ b/.github/workflows/kilted-debian-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [kilted]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-pre-release.yml
+++ b/.github/workflows/kilted-pre-release.yml
@@ -22,6 +22,7 @@ jobs:
   default:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-prerelease.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       # downstream_depth is not set on pull_request event
       prerelease_downstream_depth: ${{ github.event_name == 'pull_request' && '0' || inputs.downstream_depth }}

--- a/.github/workflows/kilted-rhel-binary-build.yml
+++ b/.github/workflows/kilted-rhel-binary-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [kilted]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-semi-binary-build.yml
+++ b/.github/workflows/kilted-semi-binary-build.yml
@@ -31,6 +31,7 @@ jobs:
   semi-binary:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       ros_repo: testing
       upstream_workspace: ros2_control.kilted.repos
@@ -38,6 +39,7 @@ jobs:
   semi-binary-clang:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       ros_repo: testing
       upstream_workspace: ros2_control.kilted.repos

--- a/.github/workflows/kilted-semi-binary-downstream-build.yml
+++ b/.github/workflows/kilted-semi-binary-downstream-build.yml
@@ -26,6 +26,7 @@ jobs:
   build-downstream:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       ros_repo: testing
       ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-source-build.yml
+++ b/.github/workflows/kilted-source-build.yml
@@ -27,6 +27,7 @@ jobs:
   source:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master
     with:
+      extra-cmake-args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       ref: kilted
       container: ubuntu:24.04

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -40,6 +40,7 @@ jobs:
           - ROS_DISTRO: rolling
             ROS_REPO: main
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}
       upstream_workspace: ros2_control-not-released.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/rolling-compatibility-humble-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-humble-binary-build.yml
@@ -28,6 +28,7 @@ jobs:
   build-on-humble:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: humble
       ros_repo: testing
       upstream_workspace: ros2_control.rolling.repos

--- a/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-jazzy-binary-build.yml
@@ -28,6 +28,7 @@ jobs:
   build-on-jazzy:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: jazzy
       ros_repo: testing
       upstream_workspace: ros2_control.rolling.repos

--- a/.github/workflows/rolling-compatibility-kilted-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-kilted-binary-build.yml
@@ -28,6 +28,7 @@ jobs:
   build-on-kilted:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: kilted
       ros_repo: testing
       upstream_workspace: ros2_control.rolling.repos

--- a/.github/workflows/rolling-compatibility-lyrical-binary-build.yml
+++ b/.github/workflows/rolling-compatibility-lyrical-binary-build.yml
@@ -28,6 +28,7 @@ jobs:
   build-on-lyrical:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: lyrical
       ros_repo: testing
       upstream_workspace: ros2_control.rolling.repos

--- a/.github/workflows/rolling-coverage-build.yml
+++ b/.github/workflows/rolling-coverage-build.yml
@@ -27,4 +27,5 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master
     secrets: inherit
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: rolling

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         ROS_DISTRO: [lyrical, rolling]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-pre-release.yml
+++ b/.github/workflows/rolling-pre-release.yml
@@ -27,6 +27,7 @@ jobs:
 
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-prerelease.yml@master
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       # downstream_depth is not set on pull_request event
       prerelease_downstream_depth: ${{ github.event_name == 'pull_request' && '0' || inputs.downstream_depth }}

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         ROS_DISTRO: [lyrical, rolling]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         ROS_DISTRO: [lyrical, rolling]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos
@@ -47,6 +48,7 @@ jobs:
       matrix:
         ROS_DISTRO: [rolling]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       upstream_workspace: ros2_control.${{ matrix.ROS_DISTRO }}.repos

--- a/.github/workflows/rolling-semi-binary-downstream-build.yml
+++ b/.github/workflows/rolling-semi-binary-downstream-build.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         ROS_DISTRO: [lyrical, rolling]
     with:
+      target_cmake_args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: testing
       ref_for_scheduled_build: master

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         ROS_DISTRO: [lyrical, rolling]
     with:
+      extra-cmake-args: -DROS2_CONTROL_STRICT_TIMING_TESTS=OFF
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ref: master
       container: ubuntu:26.04

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -67,6 +67,10 @@ if(BUILD_TESTING)
   find_package(ros2_control_test_assets REQUIRED)
   find_package(example_interfaces REQUIRED)
 
+  option(ROS2_CONTROL_STRICT_TIMING_TESTS
+    "Use strict timing-sensitive assertions in ros2_control tests. Turn ON for RT-capable local validation."
+    OFF)
+
   # Plugin Libraries that are built and installed for use in testing
   add_library(test_controller SHARED test/test_controller/test_controller.cpp)
   target_link_libraries(test_controller PUBLIC
@@ -112,6 +116,9 @@ if(BUILD_TESTING)
     test_chainable_controller
     ros2_control_test_assets::ros2_control_test_assets
   )
+  target_compile_definitions(
+    test_controller_manager
+    PRIVATE ROS2_CONTROL_STRICT_TIMING_TESTS=$<BOOL:${ROS2_CONTROL_STRICT_TIMING_TESTS}>)
 
   ament_add_gmock(test_controller_manager_with_namespace
     test/test_controller_manager_with_namespace.cpp

--- a/controller_manager/CMakeLists.txt
+++ b/controller_manager/CMakeLists.txt
@@ -69,7 +69,7 @@ if(BUILD_TESTING)
 
   option(ROS2_CONTROL_STRICT_TIMING_TESTS
     "Use strict timing-sensitive assertions in ros2_control tests. Turn ON for RT-capable local validation."
-    OFF)
+    ON)
 
   # Plugin Libraries that are built and installed for use in testing
   add_library(test_controller SHARED test/test_controller/test_controller.cpp)

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -27,6 +27,34 @@
 using ::testing::_;
 using ::testing::Return;
 
+namespace
+{
+#if ROS2_CONTROL_STRICT_TIMING_TESTS
+constexpr bool kStrictTimingTests = true;
+#else
+constexpr bool kStrictTimingTests = false;
+#endif
+
+constexpr double kRelaxedTimingLowerBoundFactor = 0.9;
+constexpr double kRelaxedTimingUpperBoundFactor = 1.1;
+constexpr double kRelaxedExecutionTimeUpperBoundFactor = 2.5;
+
+double timing_lower_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingLowerBoundFactor;
+}
+
+double timing_upper_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingUpperBoundFactor;
+}
+
+double execution_time_upper_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedExecutionTimeUpperBoundFactor;
+}
+}  // namespace
+
 class TestControllerManagerWithStrictness
 : public ControllerManagerFixture<controller_manager::ControllerManager>,
   public testing::WithParamInterface<Strictness>
@@ -729,8 +757,21 @@ TEST_P(TestControllerManagerWithStrictness, async_controller_lifecycle_at_cm_rat
 
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     EXPECT_EQ(controller_interface::return_type::OK, switch_future.get());
-    EXPECT_EQ(last_internal_counter + 1, test_controller->internal_counter)
-      << "Controller is stopped at the end of update, it should finish it's active cycle";
+    if (
+      !kStrictTimingTests &&
+      test_param.strictness == controller_manager_msgs::srv::SwitchController::Request::BEST_EFFORT)
+    {
+      EXPECT_THAT(
+        test_controller->internal_counter,
+        testing::AllOf(testing::Ge(last_internal_counter), testing::Le(last_internal_counter + 1u)))
+        << "In relaxed mode, BEST_EFFORT allows scheduler jitter while stopping async "
+           "controllers.";
+    }
+    else
+    {
+      EXPECT_EQ(last_internal_counter + 1, test_controller->internal_counter)
+        << "Controller is stopped at the end of update, it should finish it's active cycle";
+    }
   }
 
   EXPECT_EQ(
@@ -912,7 +953,9 @@ TEST_P(TestControllerManagerWithUpdateRates, per_controller_equal_and_higher_upd
     // [cm_update_rate, 2*cm_update_rate)
     EXPECT_THAT(
       test_controller->update_period_.seconds(),
-      testing::AllOf(testing::Ge(0.65 / cm_update_rate), testing::Lt((1.6 / cm_update_rate))));
+      testing::AllOf(
+        testing::Ge(timing_lower_bound(0.65 / cm_update_rate)),
+        testing::Lt(timing_upper_bound(1.6 / cm_update_rate))));
     ASSERT_EQ(
       test_controller->internal_counter,
       cm_->get_loaded_controllers()[0].execution_time_statistics->get_count());
@@ -923,15 +966,18 @@ TEST_P(TestControllerManagerWithUpdateRates, per_controller_equal_and_higher_upd
     EXPECT_THAT(
       cm_->get_loaded_controllers()[0].periodicity_statistics->get_average(),
       testing::AllOf(
-        testing::Ge(0.9 * cm_->get_update_rate()), testing::Lt((1.05 * cm_->get_update_rate()))));
+        testing::Ge(timing_lower_bound(0.9 * cm_->get_update_rate())),
+        testing::Lt(timing_upper_bound(1.05 * cm_->get_update_rate()))));
     EXPECT_THAT(
       cm_->get_loaded_controllers()[0].periodicity_statistics->get_min(),
       testing::AllOf(
-        testing::Ge(0.5 * cm_->get_update_rate()), testing::Lt((1.2 * cm_->get_update_rate()))));
+        testing::Ge(timing_lower_bound(0.5 * cm_->get_update_rate())),
+        testing::Lt(timing_upper_bound(1.2 * cm_->get_update_rate()))));
     EXPECT_THAT(
       cm_->get_loaded_controllers()[0].periodicity_statistics->get_max(),
       testing::AllOf(
-        testing::Ge(0.75 * cm_->get_update_rate()), testing::Lt((2.0 * cm_->get_update_rate()))));
+        testing::Ge(timing_lower_bound(0.75 * cm_->get_update_rate())),
+        testing::Lt(timing_upper_bound(2.0 * cm_->get_update_rate()))));
     loop_rate.sleep();
   }
   // if we do 2 times of the controller_manager update rate, the internal counter should be
@@ -1058,8 +1104,8 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
       EXPECT_THAT(
         test_controller->update_period_.seconds(),
         testing::AllOf(
-          testing::Gt(0.65 * exp_controller_period),
-          testing::Lt((1.2 * exp_controller_period) + PERIOD.seconds())))
+          testing::Gt(timing_lower_bound(0.65 * exp_controller_period)),
+          testing::Lt(timing_upper_bound((1.2 * exp_controller_period) + PERIOD.seconds()))))
         << "update_counter: " << update_counter
         << " desired controller period: " << controller_period
         << " expected controller period: " << exp_controller_period
@@ -1101,16 +1147,22 @@ TEST_P(TestControllerUpdateRates, check_the_controller_update_rate)
         << "The first update is not counted in periodicity statistics";
       EXPECT_THAT(
         cm_->get_loaded_controllers()[0].periodicity_statistics->get_average(),
-        testing::AllOf(testing::Ge(0.9 * exp_periodicity), testing::Lt((1.05 * exp_periodicity))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.9 * exp_periodicity)),
+          testing::Lt(timing_upper_bound(1.05 * exp_periodicity))));
       EXPECT_THAT(
         cm_->get_loaded_controllers()[0].periodicity_statistics->get_min(),
-        testing::AllOf(testing::Ge(0.5 * exp_periodicity), testing::Lt((1.2 * exp_periodicity))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.5 * exp_periodicity)),
+          testing::Lt(timing_upper_bound(1.2 * exp_periodicity))));
       EXPECT_THAT(
         cm_->get_loaded_controllers()[0].periodicity_statistics->get_max(),
-        testing::AllOf(testing::Ge(0.75 * exp_periodicity), testing::Lt((2.0 * exp_periodicity))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.75 * exp_periodicity)),
+          testing::Lt(timing_upper_bound(2.0 * exp_periodicity))));
       EXPECT_LT(
         cm_->get_loaded_controllers()[0].execution_time_statistics->get_average(),
-        50.0);  // 50 microseconds
+        execution_time_upper_bound(50.0));  // 50 microseconds in strict mode
     }
   }
 }

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -39,17 +39,17 @@ constexpr double kRelaxedTimingLowerBoundFactor = 0.9;
 constexpr double kRelaxedTimingUpperBoundFactor = 1.1;
 constexpr double kRelaxedExecutionTimeUpperBoundFactor = 2.5;
 
-double timing_lower_bound(const double strict_value)
+double timing_lower_bound(double strict_value)
 {
   return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingLowerBoundFactor;
 }
 
-double timing_upper_bound(const double strict_value)
+double timing_upper_bound(double strict_value)
 {
   return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingUpperBoundFactor;
 }
 
-double execution_time_upper_bound(const double strict_value)
+double execution_time_upper_bound(double strict_value)
 {
   return kStrictTimingTests ? strict_value : strict_value * kRelaxedExecutionTimeUpperBoundFactor;
 }

--- a/hardware_interface_testing/CMakeLists.txt
+++ b/hardware_interface_testing/CMakeLists.txt
@@ -43,7 +43,7 @@ if(BUILD_TESTING)
 
   option(ROS2_CONTROL_STRICT_TIMING_TESTS
     "Use strict timing-sensitive assertions in ros2_control tests. Turn ON for RT-capable local validation."
-    OFF)
+    ON)
 
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
   target_link_libraries(test_resource_manager

--- a/hardware_interface_testing/CMakeLists.txt
+++ b/hardware_interface_testing/CMakeLists.txt
@@ -41,12 +41,19 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gmock REQUIRED)
 
+  option(ROS2_CONTROL_STRICT_TIMING_TESTS
+    "Use strict timing-sensitive assertions in ros2_control tests. Turn ON for RT-capable local validation."
+    OFF)
+
   ament_add_gmock(test_resource_manager test/test_resource_manager.cpp)
   target_link_libraries(test_resource_manager
                         hardware_interface::hardware_interface
                         rclcpp_lifecycle::rclcpp_lifecycle
                         ros2_control_test_assets::ros2_control_test_assets
                         ${lifecycle_msgs_TARGETS})
+  target_compile_definitions(
+    test_resource_manager
+    PRIVATE ROS2_CONTROL_STRICT_TIMING_TESTS=$<BOOL:${ROS2_CONTROL_STRICT_TIMING_TESTS}>)
 
   ament_add_gmock(test_resource_manager_prepare_perform_switch test/test_resource_manager_prepare_perform_switch.cpp)
   target_link_libraries(test_resource_manager_prepare_perform_switch

--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -52,6 +52,34 @@ using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_STATE_INTERFACES;
 using ros2_control_test_assets::TEST_SYSTEM_HARDWARE_TYPE;
 using testing::SizeIs;
 
+namespace
+{
+#if ROS2_CONTROL_STRICT_TIMING_TESTS
+constexpr bool kStrictTimingTests = true;
+#else
+constexpr bool kStrictTimingTests = false;
+#endif
+
+constexpr double kRelaxedTimingLowerBoundFactor = 0.8;
+constexpr double kRelaxedTimingUpperBoundFactor = 1.2;
+constexpr double kRelaxedExecutionTimeUpperBoundFactor = 1.2;
+
+double timing_lower_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingLowerBoundFactor;
+}
+
+double timing_upper_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedTimingUpperBoundFactor;
+}
+
+double execution_time_upper_bound(const double strict_value)
+{
+  return kStrictTimingTests ? strict_value : strict_value * kRelaxedExecutionTimeUpperBoundFactor;
+}
+}  // namespace
+
 auto configure_components =
   [](TestableResourceManager & rm, const std::vector<std::string> & components = {})
 {
@@ -2074,29 +2102,37 @@ public:
             const double expec_write_execution_time = (1.e6 / (6 * rate)) + 200.0;
             EXPECT_LT(
               status_map[component_name].read_statistics->execution_time.get_statistics().average,
-              expec_read_execution_time);
+              execution_time_upper_bound(expec_read_execution_time));
             EXPECT_LT(
               status_map[component_name].read_statistics->periodicity.get_statistics().average,
-              1.2 * rate);
+              timing_upper_bound(1.2 * rate));
             EXPECT_THAT(
               status_map[component_name].read_statistics->periodicity.get_statistics().min,
-              testing::AllOf(testing::Ge(0.5 * rate), testing::Lt((1.2 * rate))));
+              testing::AllOf(
+                testing::Ge(timing_lower_bound(0.5 * rate)),
+                testing::Lt(timing_upper_bound(1.2 * rate))));
             EXPECT_THAT(
               status_map[component_name].read_statistics->periodicity.get_statistics().max,
-              testing::AllOf(testing::Ge(0.75 * rate), testing::Lt((2.0 * rate))));
+              testing::AllOf(
+                testing::Ge(timing_lower_bound(0.75 * rate)),
+                testing::Lt(timing_upper_bound(2.0 * rate))));
 
             EXPECT_LT(
               status_map[component_name].write_statistics->execution_time.get_statistics().average,
-              expec_write_execution_time);
+              execution_time_upper_bound(expec_write_execution_time));
             EXPECT_LT(
               status_map[component_name].write_statistics->periodicity.get_statistics().average,
-              1.2 * rate);
+              timing_upper_bound(1.2 * rate));
             EXPECT_THAT(
               status_map[component_name].write_statistics->periodicity.get_statistics().min,
-              testing::AllOf(testing::Ge(0.5 * rate), testing::Lt((1.2 * rate))));
+              testing::AllOf(
+                testing::Ge(timing_lower_bound(0.5 * rate)),
+                testing::Lt(timing_upper_bound(1.2 * rate))));
             EXPECT_THAT(
               status_map[component_name].write_statistics->periodicity.get_statistics().max,
-              testing::AllOf(testing::Ge(0.75 * rate), testing::Lt((2.0 * rate))));
+              testing::AllOf(
+                testing::Ge(timing_lower_bound(0.75 * rate)),
+                testing::Lt(timing_upper_bound(2.0 * rate))));
           }
         };
 
@@ -2520,23 +2556,31 @@ public:
     {
       EXPECT_LT(
         status_map[component_name].read_statistics->periodicity.get_statistics().average,
-        1.2 * rate);
+        timing_upper_bound(1.2 * rate));
       EXPECT_THAT(
         status_map[component_name].read_statistics->periodicity.get_statistics().min,
-        testing::AllOf(testing::Ge(0.4 * rate), testing::Lt((1.2 * rate))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.4 * rate)),
+          testing::Lt(timing_upper_bound(1.2 * rate))));
       EXPECT_THAT(
         status_map[component_name].read_statistics->periodicity.get_statistics().max,
-        testing::AllOf(testing::Ge(0.75 * rate), testing::Lt((2.0 * rate))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.75 * rate)),
+          testing::Lt(timing_upper_bound(2.0 * rate))));
 
       EXPECT_LT(
         status_map[component_name].write_statistics->periodicity.get_statistics().average,
-        1.2 * rate);
+        timing_upper_bound(1.2 * rate));
       EXPECT_THAT(
         status_map[component_name].write_statistics->periodicity.get_statistics().min,
-        testing::AllOf(testing::Ge(0.4 * rate), testing::Lt((1.2 * rate))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.4 * rate)),
+          testing::Lt(timing_upper_bound(1.2 * rate))));
       EXPECT_THAT(
         status_map[component_name].write_statistics->periodicity.get_statistics().max,
-        testing::AllOf(testing::Ge(0.75 * rate), testing::Lt((2.0 * rate))));
+        testing::AllOf(
+          testing::Ge(timing_lower_bound(0.75 * rate)),
+          testing::Lt(timing_upper_bound(2.0 * rate))));
     };
 
     if (check_for_updated_values && is_write_active)
@@ -2550,22 +2594,22 @@ public:
         status_map[TEST_ACTUATOR_HARDWARE_NAME]
           .read_statistics->execution_time.get_statistics()
           .average,
-        expec_read_execution_time);
+        execution_time_upper_bound(expec_read_execution_time));
       EXPECT_LT(
         status_map[TEST_ACTUATOR_HARDWARE_NAME]
           .write_statistics->execution_time.get_statistics()
           .average,
-        expec_write_execution_time);
+        execution_time_upper_bound(expec_write_execution_time));
       EXPECT_LT(
         status_map[TEST_SYSTEM_HARDWARE_NAME]
           .read_statistics->execution_time.get_statistics()
           .average,
-        expec_read_execution_time);
+        execution_time_upper_bound(expec_read_execution_time));
       EXPECT_LT(
         status_map[TEST_SYSTEM_HARDWARE_NAME]
           .write_statistics->execution_time.get_statistics()
           .average,
-        expec_write_execution_time);
+        execution_time_upper_bound(expec_write_execution_time));
     }
   }
 


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
On github runners we see lots of flaky tests related to timing assertions.
This PR adds a CMake option to switch between relaxed and strict assertions (default). The latter can be used locally or with more powerful runners in future.

Fixes #2762, Fixes #2242, Fixes #1917

### Is this user-facing behavior change?
No

### Did you use Generative AI?
GPT 5.3 Codex

### Additional Information