### PR TITLE
Improve robustness of spawner tests

### DIFF
--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -15,6 +15,7 @@
 #ifndef CONTROLLER_MANAGER_TEST_COMMON_HPP_
 #define CONTROLLER_MANAGER_TEST_COMMON_HPP_
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -46,6 +47,70 @@ struct Strictness
 };
 Strictness strict{STRICT, controller_interface::return_type::ERROR, 0u};
 Strictness best_effort{BEST_EFFORT, controller_interface::return_type::OK, 1u};
+
+namespace controller_manager
+{
+namespace test
+{
+
+template <typename ControllerManagerT>
+bool wait_for_loaded_controller_count(
+  const std::shared_ptr<ControllerManagerT> & cm, size_t expected_count,
+  std::chrono::milliseconds timeout = std::chrono::seconds(2))
+{
+  const auto start = std::chrono::steady_clock::now();
+  while ((std::chrono::steady_clock::now() - start) < timeout)
+  {
+    if (cm->get_loaded_controllers().size() == expected_count)
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  return cm->get_loaded_controllers().size() == expected_count;
+}
+
+template <typename ControllerManagerT>
+bool wait_for_loaded_controller(
+  const std::shared_ptr<ControllerManagerT> & cm, const std::string & controller_name,
+  std::chrono::milliseconds timeout = std::chrono::seconds(2))
+{
+  const auto start = std::chrono::steady_clock::now();
+  while ((std::chrono::steady_clock::now() - start) < timeout)
+  {
+    const auto loaded_controllers = cm->get_loaded_controllers();
+    const auto it = std::find_if(
+      loaded_controllers.begin(), loaded_controllers.end(),
+      [&controller_name](const auto & controller)
+      { return controller.info.name == controller_name; });
+
+    if (it != loaded_controllers.end())
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  const auto loaded_controllers = cm->get_loaded_controllers();
+  return std::any_of(
+    loaded_controllers.begin(), loaded_controllers.end(),
+    [&controller_name](const auto & controller)
+    { return controller.info.name == controller_name; });
+}
+
+template <typename LoadedControllersT>
+auto find_loaded_controller_by_name(
+  const LoadedControllersT & loaded_controllers, const std::string & controller_name)
+{
+  return std::find_if(
+    loaded_controllers.begin(), loaded_controllers.end(),
+    [&controller_name](const auto & controller)
+    { return controller.info.name == controller_name; });
+}
+
+}  // namespace test
+}  // namespace controller_manager
 
 // Forward definition to avid compile error - defined at the end of the file
 template <typename CtrlMgr>

--- a/controller_manager/test/test_advanced_spawner.cpp
+++ b/controller_manager/test/test_advanced_spawner.cpp
@@ -897,6 +897,8 @@ TEST_F(TestLoadController, advanced_spawner_test_with_global_wildcard_entries)
 
 TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controllers)
 {
+  constexpr auto kControllerManagerTimeout = "5.0";
+
   const std::string test_file_path =
     std::string(PARAMETERS_FILE_PATH) + std::string("test_controller_spawner_with_interfaces.yaml");
 
@@ -906,8 +908,8 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
     call_advanced_spawner(
       "--controller ctrl_with_joint1_command_interface --param-file " + test_file_path +
       " --controller ctrl_with_joint2_command_interface -c  test_controller_manager "
-      "--controller-manager-timeout 1.0 --param-file " +
-      test_file_path),
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) + " --param-file " + test_file_path),
     0);
 
   ASSERT_TRUE(wait_for_loaded_controller_count(2ul));
@@ -953,7 +955,9 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "--param-file " +
       test_file_path),
     256)
@@ -997,7 +1001,9 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "--param-file " +
       test_file_path),
     256)
@@ -1009,7 +1015,9 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "--param-file " +
       test_file_path),
     0)

--- a/controller_manager/test/test_advanced_spawner.cpp
+++ b/controller_manager/test/test_advanced_spawner.cpp
@@ -65,49 +65,6 @@ public:
   void TearDown() override { update_executor_->cancel(); }
 
 protected:
-  bool wait_for_loaded_controller_count(
-    size_t expected_count, std::chrono::milliseconds timeout = std::chrono::seconds(2))
-  {
-    const auto start = std::chrono::steady_clock::now();
-    while ((std::chrono::steady_clock::now() - start) < timeout)
-    {
-      if (cm_->get_loaded_controllers().size() == expected_count)
-      {
-        return true;
-      }
-      std::this_thread::sleep_for(20ms);
-    }
-
-    return cm_->get_loaded_controllers().size() == expected_count;
-  }
-
-  bool wait_for_loaded_controller(
-    const std::string & controller_name,
-    std::chrono::milliseconds timeout = std::chrono::seconds(2))
-  {
-    const auto start = std::chrono::steady_clock::now();
-    while ((std::chrono::steady_clock::now() - start) < timeout)
-    {
-      const auto loaded_controllers = cm_->get_loaded_controllers();
-      const auto it = std::find_if(
-        loaded_controllers.begin(), loaded_controllers.end(),
-        [&controller_name](const auto & controller)
-        { return controller.info.name == controller_name; });
-
-      if (it != loaded_controllers.end())
-      {
-        return true;
-      }
-      std::this_thread::sleep_for(20ms);
-    }
-
-    const auto loaded_controllers = cm_->get_loaded_controllers();
-    return std::any_of(
-      loaded_controllers.begin(), loaded_controllers.end(),
-      [&controller_name](const auto & controller)
-      { return controller.info.name == controller_name; });
-  }
-
   rclcpp::TimerBase::SharedPtr update_timer_;
 
   // Using a MultiThreadedExecutor so we can call update on a separate thread from service callbacks
@@ -912,7 +869,7 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
       std::string(kControllerManagerTimeout) + " --param-file " + test_file_path),
     0);
 
-  ASSERT_TRUE(wait_for_loaded_controller_count(2ul));
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 2ul));
 
   const auto loaded_after_first_spawn = cm_->get_loaded_controllers();
 
@@ -964,9 +921,11 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
     << "Should fail as the ctrl_with_joint1_command_interface and "
        "ctrl_with_joint2_command_interface are active";
 
-  ASSERT_TRUE(wait_for_loaded_controller("ctrl_with_joint1_and_joint2_command_interfaces"))
+  ASSERT_TRUE(
+    controller_manager::test::wait_for_loaded_controller(
+      cm_, "ctrl_with_joint1_and_joint2_command_interfaces"))
     << "Expected the controller to be loaded, even if activation fails.";
-  ASSERT_TRUE(wait_for_loaded_controller_count(3ul));
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 3ul));
 
   const auto loaded_after_failed_activation = cm_->get_loaded_controllers();
   const auto it_ctrl_with_joint1_and_joint2_command_interfaces = std::find_if(
@@ -997,7 +956,7 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint1_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_TRUE(wait_for_loaded_controller_count(2ul));
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 2ul));
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
@@ -1011,7 +970,7 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint2_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_TRUE(wait_for_loaded_controller_count(1ul));
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 1ul));
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "

--- a/controller_manager/test/test_advanced_spawner.cpp
+++ b/controller_manager/test/test_advanced_spawner.cpp
@@ -15,6 +15,7 @@
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
@@ -64,6 +65,49 @@ public:
   void TearDown() override { update_executor_->cancel(); }
 
 protected:
+  bool wait_for_loaded_controller_count(
+    size_t expected_count, std::chrono::milliseconds timeout = std::chrono::seconds(2))
+  {
+    const auto start = std::chrono::steady_clock::now();
+    while ((std::chrono::steady_clock::now() - start) < timeout)
+    {
+      if (cm_->get_loaded_controllers().size() == expected_count)
+      {
+        return true;
+      }
+      std::this_thread::sleep_for(20ms);
+    }
+
+    return cm_->get_loaded_controllers().size() == expected_count;
+  }
+
+  bool wait_for_loaded_controller(
+    const std::string & controller_name,
+    std::chrono::milliseconds timeout = std::chrono::seconds(2))
+  {
+    const auto start = std::chrono::steady_clock::now();
+    while ((std::chrono::steady_clock::now() - start) < timeout)
+    {
+      const auto loaded_controllers = cm_->get_loaded_controllers();
+      const auto it = std::find_if(
+        loaded_controllers.begin(), loaded_controllers.end(),
+        [&controller_name](const auto & controller)
+        { return controller.info.name == controller_name; });
+
+      if (it != loaded_controllers.end())
+      {
+        return true;
+      }
+      std::this_thread::sleep_for(20ms);
+    }
+
+    const auto loaded_controllers = cm_->get_loaded_controllers();
+    return std::any_of(
+      loaded_controllers.begin(), loaded_controllers.end(),
+      [&controller_name](const auto & controller)
+      { return controller.info.name == controller_name; });
+  }
+
   rclcpp::TimerBase::SharedPtr update_timer_;
 
   // Using a MultiThreadedExecutor so we can call update on a separate thread from service callbacks
@@ -866,9 +910,16 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
       test_file_path),
     0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
+  ASSERT_TRUE(wait_for_loaded_controller_count(2ul));
 
-  auto ctrl_with_joint2_command_interface = cm_->get_loaded_controllers()[0];
+  const auto loaded_after_first_spawn = cm_->get_loaded_controllers();
+
+  const auto it_ctrl_with_joint2_command_interface = std::find_if(
+    loaded_after_first_spawn.begin(), loaded_after_first_spawn.end(),
+    [](const auto & ctrl) { return ctrl.info.name == "ctrl_with_joint2_command_interface"; });
+  ASSERT_NE(it_ctrl_with_joint2_command_interface, loaded_after_first_spawn.end());
+  const auto ctrl_with_joint2_command_interface = *it_ctrl_with_joint2_command_interface;
+
   ASSERT_EQ(ctrl_with_joint2_command_interface.info.name, "ctrl_with_joint2_command_interface");
   ASSERT_EQ(
     ctrl_with_joint2_command_interface.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -881,7 +932,12 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
     ctrl_with_joint2_command_interface.c->command_interface_configuration().names,
     std::vector<std::string>({"joint2/velocity"}));
 
-  auto ctrl_with_joint1_command_interface = cm_->get_loaded_controllers()[1];
+  const auto it_ctrl_with_joint1_command_interface = std::find_if(
+    loaded_after_first_spawn.begin(), loaded_after_first_spawn.end(),
+    [](const auto & ctrl) { return ctrl.info.name == "ctrl_with_joint1_command_interface"; });
+  ASSERT_NE(it_ctrl_with_joint1_command_interface, loaded_after_first_spawn.end());
+  const auto ctrl_with_joint1_command_interface = *it_ctrl_with_joint1_command_interface;
+
   ASSERT_EQ(ctrl_with_joint1_command_interface.info.name, "ctrl_with_joint1_command_interface");
   ASSERT_EQ(
     ctrl_with_joint1_command_interface.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -904,9 +960,20 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
     << "Should fail as the ctrl_with_joint1_command_interface and "
        "ctrl_with_joint2_command_interface are active";
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 3ul);
+  ASSERT_TRUE(wait_for_loaded_controller("ctrl_with_joint1_and_joint2_command_interfaces"))
+    << "Expected the controller to be loaded, even if activation fails.";
+  ASSERT_TRUE(wait_for_loaded_controller_count(3ul));
 
-  auto ctrl_with_joint1_and_joint2_command_interfaces = cm_->get_loaded_controllers()[0];
+  const auto loaded_after_failed_activation = cm_->get_loaded_controllers();
+  const auto it_ctrl_with_joint1_and_joint2_command_interfaces = std::find_if(
+    loaded_after_failed_activation.begin(), loaded_after_failed_activation.end(),
+    [](const auto & ctrl)
+    { return ctrl.info.name == "ctrl_with_joint1_and_joint2_command_interfaces"; });
+  ASSERT_NE(
+    it_ctrl_with_joint1_and_joint2_command_interfaces, loaded_after_failed_activation.end());
+  const auto ctrl_with_joint1_and_joint2_command_interfaces =
+    *it_ctrl_with_joint1_and_joint2_command_interfaces;
+
   ASSERT_EQ(
     ctrl_with_joint1_and_joint2_command_interfaces.info.name,
     "ctrl_with_joint1_and_joint2_command_interfaces");
@@ -926,7 +993,7 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint1_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
+  ASSERT_TRUE(wait_for_loaded_controller_count(2ul));
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
@@ -938,7 +1005,7 @@ TEST_F(TestLoadController, advanced_spawner_test_failed_activation_of_controller
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint2_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
+  ASSERT_TRUE(wait_for_loaded_controller_count(1ul));
   EXPECT_EQ(
     call_advanced_spawner(
       "--controller ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -470,6 +470,8 @@ TEST_F(TestLoadController, spawner_test_with_global_wildcard_entries)
 
 TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
 {
+  constexpr auto kControllerManagerTimeout = "5.0";
+
   const std::string test_file_path =
     std::string(PARAMETERS_FILE_PATH) + std::string("test_controller_spawner_with_interfaces.yaml");
 
@@ -479,14 +481,22 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
     call_spawner(
       "ctrl_with_joint1_command_interface ctrl_with_joint2_command_interface -c "
       "test_controller_manager "
-      "--controller-manager-timeout 5.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "-p " +
       test_file_path),
     0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 2ul));
 
-  auto ctrl_with_joint2_command_interface = cm_->get_loaded_controllers()[0];
+  const auto loaded_after_first_spawn = cm_->get_loaded_controllers();
+  const auto it_ctrl_with_joint2_command_interface =
+    controller_manager::test::find_loaded_controller_by_name(
+      loaded_after_first_spawn, "ctrl_with_joint2_command_interface");
+  ASSERT_NE(it_ctrl_with_joint2_command_interface, loaded_after_first_spawn.end());
+  const auto ctrl_with_joint2_command_interface = *it_ctrl_with_joint2_command_interface;
+
   ASSERT_EQ(ctrl_with_joint2_command_interface.info.name, "ctrl_with_joint2_command_interface");
   ASSERT_EQ(
     ctrl_with_joint2_command_interface.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -499,7 +509,12 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
     ctrl_with_joint2_command_interface.c->command_interface_configuration().names,
     std::vector<std::string>({"joint2/velocity"}));
 
-  auto ctrl_with_joint1_command_interface = cm_->get_loaded_controllers()[1];
+  const auto it_ctrl_with_joint1_command_interface =
+    controller_manager::test::find_loaded_controller_by_name(
+      loaded_after_first_spawn, "ctrl_with_joint1_command_interface");
+  ASSERT_NE(it_ctrl_with_joint1_command_interface, loaded_after_first_spawn.end());
+  const auto ctrl_with_joint1_command_interface = *it_ctrl_with_joint1_command_interface;
+
   ASSERT_EQ(ctrl_with_joint1_command_interface.info.name, "ctrl_with_joint1_command_interface");
   ASSERT_EQ(
     ctrl_with_joint1_command_interface.info.type, test_controller::TEST_CONTROLLER_CLASS_NAME);
@@ -515,16 +530,30 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 5.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "-p " +
       test_file_path),
     256)
     << "Should fail as the ctrl_with_joint1_command_interface and "
        "ctrl_with_joint2_command_interface are active";
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 3ul);
+  ASSERT_TRUE(
+    controller_manager::test::wait_for_loaded_controller(
+      cm_, "ctrl_with_joint1_and_joint2_command_interfaces"))
+    << "Expected the controller to be loaded, even if activation fails.";
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 3ul));
 
-  auto ctrl_with_joint1_and_joint2_command_interfaces = cm_->get_loaded_controllers()[0];
+  const auto loaded_after_failed_activation = cm_->get_loaded_controllers();
+  const auto it_ctrl_with_joint1_and_joint2_command_interfaces =
+    controller_manager::test::find_loaded_controller_by_name(
+      loaded_after_failed_activation, "ctrl_with_joint1_and_joint2_command_interfaces");
+  ASSERT_NE(
+    it_ctrl_with_joint1_and_joint2_command_interfaces, loaded_after_failed_activation.end());
+  const auto ctrl_with_joint1_and_joint2_command_interfaces =
+    *it_ctrl_with_joint1_and_joint2_command_interfaces;
+
   ASSERT_EQ(
     ctrl_with_joint1_and_joint2_command_interfaces.info.name,
     "ctrl_with_joint1_and_joint2_command_interfaces");
@@ -544,11 +573,13 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint1_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 2ul);
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 2ul));
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 5.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "-p " +
       test_file_path),
     256)
@@ -556,11 +587,13 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
 
   EXPECT_EQ(call_unspawner("ctrl_with_joint2_command_interface -c test_controller_manager"), 0);
 
-  ASSERT_EQ(cm_->get_loaded_controllers().size(), 1ul);
+  ASSERT_TRUE(controller_manager::test::wait_for_loaded_controller_count(cm_, 1ul));
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 5.0 "
+      "--controller-manager-timeout " +
+      std::string(kControllerManagerTimeout) +
+      " "
       "-p " +
       test_file_path),
     0)

--- a/controller_manager/test/test_spawner_unspawner.cpp
+++ b/controller_manager/test/test_spawner_unspawner.cpp
@@ -479,7 +479,7 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
     call_spawner(
       "ctrl_with_joint1_command_interface ctrl_with_joint2_command_interface -c "
       "test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout 5.0 "
       "-p " +
       test_file_path),
     0);
@@ -515,7 +515,7 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout 5.0 "
       "-p " +
       test_file_path),
     256)
@@ -548,7 +548,7 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout 5.0 "
       "-p " +
       test_file_path),
     256)
@@ -560,7 +560,7 @@ TEST_F(TestLoadController, spawner_test_failed_activation_of_controllers)
   EXPECT_EQ(
     call_spawner(
       "ctrl_with_joint1_and_joint2_command_interfaces -c test_controller_manager "
-      "--controller-manager-timeout 1.0 "
+      "--controller-manager-timeout 5.0 "
       "-p " +
       test_file_path),
     0)


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
We have flaky tests like

```
2026-02-27T04:02:31.6714917Z     [  FAILED  ] TestLoadController.advanced_spawner_test_failed_activation_of_controllers
2026-02-27T04:02:31.6716011Z     
2026-02-27T04:02:31.6716397Z      1 FAILED TEST
2026-02-27T04:02:31.6716872Z     -- run_test.py: return code 1
2026-02-27T04:02:31.6719103Z     -- run_test.py: inject classname prefix into gtest result file '/home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/build/controller_manager/test_results/controller_manager/test_advanced_spawner.gtest.xml'
2026-02-27T04:02:31.6721417Z     -- run_test.py: verify result file '/home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/build/controller_manager/test_results/controller_manager/test_advanced_spawner.gtest.xml'
2026-02-27T04:02:31.6723009Z   >>>
2026-02-27T04:02:31.6723830Z build/controller_manager/test_results/controller_manager/test_advanced_spawner.gtest.xml: 21 tests, 0 errors, 1 failure, 0 skipped
2026-02-27T04:02:31.6725051Z - controller_manager.TestLoadController advanced_spawner_test_failed_activation_of_controllers
2026-02-27T04:02:31.6725757Z   <<< failure message
2026-02-27T04:02:31.6726698Z     /home/runner/work/ros2_control_ci/ros2_control_ci/.work/target_ws/src/ros-controls/ros2_control/controller_manager/test/test_advanced_spawner.cpp:864
2026-02-27T04:02:31.6728070Z     Expected equality of these values:
2026-02-27T04:02:31.6728512Z       cm_->get_loaded_controllers().size()
2026-02-27T04:02:31.6728918Z         Which is: 2
2026-02-27T04:02:31.6729270Z       3ul
2026-02-27T04:02:31.6729524Z         Which is: 3
2026-02-27T04:02:31.6729789Z   >>>
```
or
```
[INFO] [1786969813.799672369] [spawner_ctrl_with_joint1_command_interface]: waiting for service /test_controller_manager/list_controllers to become available...
[FATAL] [1786969814.803405366] [spawner_ctrl_with_joint1_command_interface]: Could not contact service /test_controller_manager/list_controllers
/tmp/ws/src/ros2_control/controller_manager/test/test_advanced_spawner.cpp:862: Failure
Expected equality of these values:
  call_advanced_spawner( "--controller ctrl_with_joint1_command_interface --param-file " + test_file_path + " --controller ctrl_with_joint2_command_interface -c  test_controller_manager " "--controller-manager-timeout 1.0 --param-file " + test_file_path)
    Which is: 256
  0

/tmp/ws/src/ros2_control/controller_manager/test/test_advanced_spawner.cpp:870: Failure
Expected equality of these values:
  cm_->get_loaded_controllers().size()
    Which is: 0
  2ul
    Which is: 2

[INFO] [1786969815.130742960] [test_controller_manager.pal_statistics]: Async messages lost 0
[INFO] [1786969815.130819162] [test_controller_manager.pal_statistics]: publish_async_failures_ 1
[INFO] [1786969815.132921565] [test_controller_manager.pal_statistics]: Async messages lost 0
[INFO] [1786969815.132992617] [test_controller_manager.pal_statistics]: publish_async_failures_ 0
[  FAILED  ] TestLoadController.advanced_spawner_test_failed_activation_of_controllers (2780 ms)
```

which should be improved by some wait-until-something patterns and increased service timeouts.

Fixes #3054

### Is this user-facing behavior change?
No

### Did you use Generative AI?
GPT 5.3 Codex


