### PR TITLE
Wait for control-loop activity before shutdown

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -15,6 +15,8 @@
 #ifndef CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 #define CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 
+#include <atomic>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -91,6 +93,9 @@ public:
 
   /// Shutdown all controllers in the controller manager.
   /**
+   * Waits for in-flight read, update, and write calls to finish and prevents new control-loop
+   * activity from starting. This operation is terminal for the controller manager's control loop.
+   *
    * \return true if all controllers are successfully shutdown, false otherwise.
    */
   bool shutdown_controllers();
@@ -345,6 +350,45 @@ protected:
   std::unique_ptr<hardware_interface::ResourceManager> resource_manager_ = nullptr;
 
 private:
+  // The high bit marks a terminal stop request; the remaining bits count in-flight read, update,
+  // and write calls. Normal control-loop activity uses only lock-free atomic operations. The
+  // non-real-time shutdown path waits until the count reaches zero.
+  bool begin_control_loop_activity();
+  void end_control_loop_activity();
+  void request_control_loop_stop();
+
+  class ControlLoopActivityGuard
+  {
+  public:
+    explicit ControlLoopActivityGuard(ControllerManager & manager)
+    : manager_(manager), active_(manager_.begin_control_loop_activity())
+    {
+    }
+
+    ControlLoopActivityGuard(const ControlLoopActivityGuard &) = delete;
+    ControlLoopActivityGuard & operator=(const ControlLoopActivityGuard &) = delete;
+    ControlLoopActivityGuard(ControlLoopActivityGuard &&) = delete;
+    ControlLoopActivityGuard & operator=(ControlLoopActivityGuard &&) = delete;
+
+    ~ControlLoopActivityGuard()
+    {
+      if (active_)
+      {
+        manager_.end_control_loop_activity();
+      }
+    }
+
+    explicit operator bool() const { return active_; }
+
+  private:
+    ControllerManager & manager_;
+    bool active_;
+  };
+
+  static constexpr std::uint32_t kControlLoopStopRequested = std::uint32_t{1} << 31;
+  static constexpr std::uint32_t kControlLoopActivityCount = ~kControlLoopStopRequested;
+  static_assert(std::atomic<std::uint32_t>::is_always_lock_free);
+
   std::vector<std::string> get_controller_names();
   std::pair<std::string, std::string> split_command_interface(
     const std::string & command_interface);
@@ -665,6 +709,10 @@ private:
   };
 
   bool use_sim_time_;
+  // Keep the shutdown coordination state in the existing padding before trigger_clock_. This
+  // preserves ControllerManager's public ABI while still giving the real-time loop a lock-free
+  // state transition.
+  std::atomic<std::uint32_t> control_loop_state_{0};
   rclcpp::Clock::SharedPtr trigger_clock_ = nullptr;
   std::unique_ptr<rclcpp::PreShutdownCallbackHandle> preshutdown_cb_handle_{nullptr};
   RTControllerListWrapper rt_controllers_wrapper_;

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -621,6 +621,7 @@ ControllerManager::~ControllerManager()
 
 bool ControllerManager::shutdown_controllers()
 {
+  request_control_loop_stop();
   RCLCPP_INFO(get_logger(), "Shutting down all controllers in the controller manager.");
   // Shutdown all controllers
   std::lock_guard<RTControllerListWrapper::controllers_lock_type> guard(
@@ -633,6 +634,7 @@ bool ControllerManager::shutdown_controllers()
     {
       RCLCPP_INFO(
         get_logger(), "Deactivating controller '%s'", controller.c->get_node()->get_name());
+      controller.c->prepare_for_deactivation();
       controller.c->get_node()->deactivate();
       controller.c->release_interfaces();
     }
@@ -648,6 +650,44 @@ bool ControllerManager::shutdown_controllers()
     executor_->remove_node(controller.c->get_node()->get_node_base_interface());
   }
   return ctrls_shutdown_status;
+}
+
+bool ControllerManager::begin_control_loop_activity()
+{
+  const auto previous_state = control_loop_state_.fetch_add(1, std::memory_order_acq_rel);
+  if ((previous_state & kControlLoopStopRequested) == 0)
+  {
+    return true;
+  }
+
+  const auto state_before_release = control_loop_state_.fetch_sub(1, std::memory_order_release);
+  if ((state_before_release & kControlLoopActivityCount) == 1)
+  {
+    control_loop_state_.notify_all();
+  }
+  return false;
+}
+
+void ControllerManager::end_control_loop_activity()
+{
+  const auto state_before_release = control_loop_state_.fetch_sub(1, std::memory_order_release);
+  if (
+    (state_before_release & kControlLoopStopRequested) != 0 &&
+    (state_before_release & kControlLoopActivityCount) == 1)
+  {
+    control_loop_state_.notify_all();
+  }
+}
+
+void ControllerManager::request_control_loop_stop()
+{
+  auto state = control_loop_state_.fetch_or(kControlLoopStopRequested, std::memory_order_acq_rel) |
+               kControlLoopStopRequested;
+  while ((state & kControlLoopActivityCount) != 0)
+  {
+    control_loop_state_.wait(state, std::memory_order_acquire);
+    state = control_loop_state_.load(std::memory_order_acquire);
+  }
 }
 
 void ControllerManager::init_controller_manager()
@@ -3270,6 +3310,12 @@ std::vector<std::string> ControllerManager::get_controller_names()
 
 void ControllerManager::read(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
+  ControlLoopActivityGuard activity_guard(*this);
+  if (!activity_guard)
+  {
+    return;
+  }
+
   periodicity_stats_.add_measurement(1.0 / period.seconds());
   const auto start_time = std::chrono::steady_clock::now();
   auto [result, failed_hardware_names] = resource_manager_->read(time, period);
@@ -3368,6 +3414,12 @@ void ControllerManager::manage_switch()
 controller_interface::return_type ControllerManager::update(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
+  ControlLoopActivityGuard activity_guard(*this);
+  if (!activity_guard)
+  {
+    return controller_interface::return_type::OK;
+  }
+
   const auto start_time = std::chrono::steady_clock::now();
   execution_time_.switch_time = 0.0;
   execution_time_.switch_chained_mode_time = 0.0;
@@ -3593,6 +3645,12 @@ controller_interface::return_type ControllerManager::update(
 
 void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration & period)
 {
+  ControlLoopActivityGuard activity_guard(*this);
+  if (!activity_guard)
+  {
+    return;
+  }
+
   const auto start_time = std::chrono::steady_clock::now();
   auto [result, failed_hardware_names] = resource_manager_->write(time, period);
 

--- a/controller_manager/test/test_controller_manager.cpp
+++ b/controller_manager/test/test_controller_manager.cpp
@@ -11,8 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "controller_manager/controller_manager.hpp"
@@ -53,7 +59,152 @@ double execution_time_upper_bound(double strict_value)
 {
   return kStrictTimingTests ? strict_value : strict_value * kRelaxedExecutionTimeUpperBoundFactor;
 }
+
+class BlockingUpdateController : public test_controller::TestController
+{
+public:
+  controller_interface::return_type update(const rclcpp::Time &, const rclcpp::Duration &) override
+  {
+    if (!block_updates_.load())
+    {
+      return controller_interface::return_type::OK;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(update_mutex_);
+      update_running_.store(true);
+    }
+    update_condition_.notify_all();
+
+    std::unique_lock<std::mutex> lock(update_mutex_);
+    update_condition_.wait(lock, [this]() { return release_update_; });
+    update_running_.store(false);
+    return controller_interface::return_type::OK;
+  }
+
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State &) override
+  {
+    deactivated_during_update_.store(update_running_.load());
+    return CallbackReturn::SUCCESS;
+  }
+
+  bool wait_until_update_is_running()
+  {
+    std::unique_lock<std::mutex> lock(update_mutex_);
+    return update_condition_.wait_for(
+      lock, std::chrono::seconds(5), [this]() { return update_running_.load(); });
+  }
+
+  void release_update()
+  {
+    {
+      std::lock_guard<std::mutex> lock(update_mutex_);
+      release_update_ = true;
+    }
+    update_condition_.notify_all();
+  }
+
+  void block_updates() { block_updates_.store(true); }
+
+  bool deactivated_during_update() const { return deactivated_during_update_.load(); }
+
+private:
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  std::mutex update_mutex_;
+  std::condition_variable update_condition_;
+  std::atomic<bool> block_updates_{false};
+  std::atomic<bool> update_running_{false};
+  std::atomic<bool> deactivated_during_update_{false};
+  bool release_update_{false};
+};
 }  // namespace
+
+class TestControllerManagerShutdown
+: public ControllerManagerFixture<controller_manager::ControllerManager>
+{
+protected:
+  std::shared_ptr<BlockingUpdateController> add_and_activate_blocking_controller(bool is_async)
+  {
+    auto controller = std::make_shared<BlockingUpdateController>();
+    controller_manager::ControllerSpec controller_spec;
+    controller_spec.c = controller;
+    controller_spec.info.name = test_controller::TEST_CONTROLLER_NAME;
+    controller_spec.info.type = test_controller::TEST_CONTROLLER_CLASS_NAME;
+    controller_spec.last_update_cycle_time =
+      std::make_shared<rclcpp::Time>(0, 0, cm_->get_trigger_clock()->get_clock_type());
+    cm_->add_controller(controller_spec);
+
+    controller->get_node()->set_parameter({"is_async", is_async});
+    EXPECT_EQ(lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, controller->configure().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller->get_node()->activate().id());
+    EXPECT_EQ(
+      lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, controller->get_lifecycle_state().id());
+    return controller;
+  }
+};
+
+TEST_F(TestControllerManagerShutdown, shutdown_waits_for_running_control_update)
+{
+  auto controller = add_and_activate_blocking_controller(false);
+  ASSERT_FALSE(controller->is_async());
+
+  controller->block_updates();
+  time_ = cm_->get_trigger_clock()->now();
+  std::thread update_thread([this]() { cm_->update(time_, rclcpp::Duration::from_seconds(0.01)); });
+  if (!controller->wait_until_update_is_running())
+  {
+    controller->release_update();
+    update_thread.join();
+    ADD_FAILURE() << "controller update did not start within five seconds";
+    return;
+  }
+
+  auto shutdown_future = std::async(
+    std::launch::async, &controller_manager::ControllerManager::shutdown_controllers, cm_);
+  const auto shutdown_status = shutdown_future.wait_for(std::chrono::milliseconds(100));
+
+  controller->release_update();
+  update_thread.join();
+  const bool shutdown_succeeded = shutdown_future.get();
+
+  EXPECT_EQ(std::future_status::timeout, shutdown_status)
+    << "shutdown must wait until the in-flight controller update returns";
+  EXPECT_FALSE(controller->deactivated_during_update());
+  EXPECT_TRUE(shutdown_succeeded);
+
+  cm_.reset();
+  executor_.reset();
+}
+
+TEST_F(TestControllerManagerShutdown, shutdown_waits_for_running_async_controller_update)
+{
+  auto controller = add_and_activate_blocking_controller(true);
+  ASSERT_TRUE(controller->is_async());
+
+  controller->block_updates();
+  time_ = cm_->get_trigger_clock()->now();
+  ASSERT_EQ(
+    controller_interface::return_type::OK,
+    cm_->update(time_, rclcpp::Duration::from_seconds(0.01)));
+  ASSERT_TRUE(controller->wait_until_update_is_running());
+
+  auto shutdown_future = std::async(
+    std::launch::async, &controller_manager::ControllerManager::shutdown_controllers, cm_);
+  const auto shutdown_status = shutdown_future.wait_for(std::chrono::milliseconds(100));
+
+  EXPECT_EQ(std::future_status::timeout, shutdown_status)
+    << "shutdown must wait until the asynchronous controller update returns";
+  EXPECT_FALSE(controller->deactivated_during_update());
+
+  controller->release_update();
+  EXPECT_TRUE(shutdown_future.get());
+  EXPECT_FALSE(controller->deactivated_during_update());
+
+  cm_.reset();
+  executor_.reset();
+}
 
 class TestControllerManagerWithStrictness
 : public ControllerManagerFixture<controller_manager::ControllerManager>,


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description

The controller manager's pre-shutdown callback could deactivate controllers and release their
interfaces while the dedicated control thread was still inside `read`, `update`, or `write`. This
is the teardown race behind the reported JTC crash, and it can also affect asynchronous controller
callbacks whose work outlives `ControllerManager::update`.

This change:

- marks the control loop terminal before shutdown, prevents new phases from entering, and waits for
  in-flight `read`, `update`, and `write` calls;
- waits for an active asynchronous controller callback before deactivation and interface release;
- keeps the real-time path lock-free and allocation-free; and
- preserves the existing `ControllerManager` class size and public ABI.

Fixes https://github.com/ros-controls/ros2_controllers/issues/2561

This is complementary to #3492: that PR makes the force-torque semantic component robust to empty
interfaces, while this change prevents controller-manager shutdown teardown from overlapping
control-loop activity across controller types.

### Is this user-facing behavior change?

Yes. Controller-manager shutdown now waits for active control-loop work instead of tearing down
controllers and hardware concurrently. Calling `shutdown_controllers()` makes subsequent
`read`/`update`/`write` calls no-ops, which matches the method's terminal lifecycle operation.

### Did you use Generative AI?

OpenAI Codex (GPT-5; accessed 2026-08-17)

## Validation

- Added synchronous and asynchronous shutdown-race regressions.
- The identical two-test source fails both tests on the unpatched base: synchronous deactivation
  overlaps the blocked update, and asynchronous deactivation overlaps the active callback.
- Both tests pass on this change under normal execution and GCC ThreadSanitizer with no race report.
- Full serial `controller_manager` CTest suite: 21/21 passed.
- ABI Compliance Checker: 100% binary compatibility and 100% source compatibility, with zero
  problems or warnings.
- `ament_cppcheck`, `ament_cpplint`, `ament_copyright`, clang-format, codespell, and the repository
  pre-commit checks passed for the changed files.
