### PR TITLE
Add GPIO interface validation tests

### DIFF
--- a/hardware_interface_testing/test/test_resource_manager.cpp
+++ b/hardware_interface_testing/test/test_resource_manager.cpp
@@ -223,6 +223,18 @@ TEST_F(ResourceManagerTest, expect_validation_failure_if_not_all_interfaces_are_
     ros2_control_test_assets::minimal_robot_missing_command_keys_urdf);
 }
 
+TEST_F(ResourceManagerTest, expect_validation_failure_if_gpio_state_interface_is_not_exported)
+{
+  test_load_and_initialized_components_failure(
+    ros2_control_test_assets::minimal_robot_missing_gpio_state_keys_urdf);
+}
+
+TEST_F(ResourceManagerTest, expect_validation_failure_if_gpio_command_interface_is_not_exported)
+{
+  test_load_and_initialized_components_failure(
+    ros2_control_test_assets::minimal_robot_missing_gpio_command_keys_urdf);
+}
+
 TEST_F(ResourceManagerTest, initialization_with_urdf_unclaimed)
 {
   // we validate the results manually

--- a/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
+++ b/ros2_control_test_assets/include/ros2_control_test_assets/descriptions.hpp
@@ -1467,6 +1467,46 @@ const auto hardware_resources_missing_command_keys =
   </ros2_control>
 )";
 
+const auto hardware_resources_missing_gpio_state_keys =
+  R"(
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <command_interface name="max_acceleration"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <gpio name="configuration">
+      <command_interface name="max_tcp_jerk"/>
+      <state_interface name="max_tcp_jerk"/>
+      <state_interface name="does_not_exist"/>
+    </gpio>
+  </ros2_control>
+)";
+
+const auto hardware_resources_missing_gpio_command_keys =
+  R"(
+  <ros2_control name="TestSystemHardware" type="system">
+    <hardware>
+      <plugin>test_system</plugin>
+    </hardware>
+    <joint name="joint2">
+      <command_interface name="velocity"/>
+      <command_interface name="max_acceleration"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <gpio name="configuration">
+      <command_interface name="max_tcp_jerk"/>
+      <command_interface name="does_not_exist"/>
+      <state_interface name="max_tcp_jerk"/>
+    </gpio>
+  </ros2_control>
+)";
+
 const auto hardware_resources_with_exclusive_interface =
   R"(
   <ros2_control name="TestActuatorHardware1" type="actuator">
@@ -2381,6 +2421,14 @@ const auto minimal_robot_missing_state_keys_urdf =
 
 const auto minimal_robot_missing_command_keys_urdf =
   std::string(urdf_head) + std::string(hardware_resources_missing_command_keys) +
+  std::string(urdf_tail);
+
+const auto minimal_robot_missing_gpio_state_keys_urdf =
+  std::string(urdf_head) + std::string(hardware_resources_missing_gpio_state_keys) +
+  std::string(urdf_tail);
+
+const auto minimal_robot_missing_gpio_command_keys_urdf =
+  std::string(urdf_head) + std::string(hardware_resources_missing_gpio_command_keys) +
   std::string(urdf_tail);
 
 [[maybe_unused]] const std::string TEST_ACTUATOR_HARDWARE_NAME = "TestActuatorHardware";


### PR DESCRIPTION
## Description

Add focused ResourceManager regression coverage for GPIO interfaces declared in the robot description but not exported by the hardware plugin.

- add one fixture with an unexported GPIO state interface
- add one fixture with an unexported GPIO command interface
- keep all joint interfaces valid so each failure is isolated to GPIO validation
- verify ResourceManager initialization rejects both mismatches

This is a test-only change; production behavior and dependencies are unchanged.

Fixes #976

### Is this user-facing behavior change?

No. This PR adds regression coverage for existing validation behavior.

### Did you use Generative AI?

Yes. OpenAI Codex was used to research the issue and prior maintainer feedback, author the two test fixtures and assertions, and run local validation. The final diff and test evidence were reviewed locally before submission.

### Additional Information

Local validation:

- targeted GPIO ResourceManager tests: 2 passed
- `colcon test --packages-select ros2_control_test_assets hardware_interface hardware_interface_testing`: 255 tests passed, 0 errors, 0 failures, 0 skipped
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

The local source-pinned environment reports ROS 2 Humble; the upstream CI matrix will provide native Rolling and multi-distro coverage.

## TODOs

- [x] Fork the repository.
- [x] Modify the source with a focused change.
- [x] Ensure local tests and pre-commit pass.
- [x] Commit to the fork using a clear commit message.
- [x] Send this pull request and answer the default questions.
- [x] Monitor automated CI and participate in review.