### PR TITLE
Fix controller list handoff data races

### DIFF
--- a/controller_manager/include/controller_manager/controller_manager.hpp
+++ b/controller_manager/include/controller_manager/controller_manager.hpp
@@ -15,6 +15,7 @@
 #ifndef CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 #define CONTROLLER_MANAGER__CONTROLLER_MANAGER_HPP_
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -657,9 +658,9 @@ private:
 
     std::vector<ControllerSpec> controllers_lists_[2];
     /// The index of the controller list with the most updated information
-    int updated_controllers_index_ = 0;
+    std::atomic<int> updated_controllers_index_{0};
     /// The index of the controllers list being used in the real-time thread.
-    int used_by_realtime_controllers_index_ = -1;
+    std::atomic<int> used_by_realtime_controllers_index_{-1};
     /// The callback to be called when the list is switched
     std::function<void()> on_switch_callback_ = nullptr;
   };

--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -3708,8 +3708,20 @@ void ControllerManager::write(const rclcpp::Time & time, const rclcpp::Duration 
 std::vector<ControllerSpec> &
 ControllerManager::RTControllerListWrapper::update_and_get_used_by_rt_list()
 {
-  used_by_realtime_controllers_index_ = updated_controllers_index_;
-  return controllers_lists_[used_by_realtime_controllers_index_];
+  auto updated_controllers_index = updated_controllers_index_.load();
+  while (true)
+  {
+    // Announce the selected list, then confirm that the non-RT thread did not switch lists
+    // between the initial lookup and this announcement. The sequentially consistent operations
+    // are intentional: the announcement and recheck must be ordered with switch_updated_list().
+    used_by_realtime_controllers_index_.store(updated_controllers_index);
+    const auto latest_updated_controllers_index = updated_controllers_index_.load();
+    if (updated_controllers_index == latest_updated_controllers_index)
+    {
+      return controllers_lists_[updated_controllers_index];
+    }
+    updated_controllers_index = latest_updated_controllers_index;
+  }
 }
 
 std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::get_unused_list(
@@ -3721,7 +3733,7 @@ std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::get_un
   }
   controllers_lock_.unlock();
   // Get the index to the outdated controller list
-  int free_controllers_list = get_other_list(updated_controllers_index_);
+  int free_controllers_list = get_other_list(updated_controllers_index_.load());
 
   // Wait until the outdated controller list is not being used by the realtime thread
   wait_until_rt_not_using(free_controllers_list);
@@ -3736,7 +3748,7 @@ const std::vector<ControllerSpec> & ControllerManager::RTControllerListWrapper::
     throw std::runtime_error("controllers_lock_ not owned by thread");
   }
   controllers_lock_.unlock();
-  return controllers_lists_[updated_controllers_index_];
+  return controllers_lists_[updated_controllers_index_.load()];
 }
 
 void ControllerManager::RTControllerListWrapper::switch_updated_list(
@@ -3747,8 +3759,8 @@ void ControllerManager::RTControllerListWrapper::switch_updated_list(
     throw std::runtime_error("controllers_lock_ not owned by thread");
   }
   controllers_lock_.unlock();
-  int former_current_controllers_list_ = updated_controllers_index_;
-  updated_controllers_index_ = get_other_list(former_current_controllers_list_);
+  int former_current_controllers_list_ = updated_controllers_index_.load();
+  updated_controllers_index_.store(get_other_list(former_current_controllers_list_));
   wait_until_rt_not_using(former_current_controllers_list_);
   if (on_switch_callback_)
   {
@@ -3771,7 +3783,7 @@ int ControllerManager::RTControllerListWrapper::get_other_list(int index) const
 void ControllerManager::RTControllerListWrapper::wait_until_rt_not_using(
   int index, std::chrono::microseconds sleep_period) const
 {
-  while (used_by_realtime_controllers_index_ == index)
+  while (used_by_realtime_controllers_index_.load() == index)
   {
     if (!rclcpp::ok())
     {

--- a/controller_manager/test/controller_manager_test_common.hpp
+++ b/controller_manager/test/controller_manager_test_common.hpp
@@ -15,7 +15,9 @@
 #ifndef CONTROLLER_MANAGER_TEST_COMMON_HPP_
 #define CONTROLLER_MANAGER_TEST_COMMON_HPP_
 
+#include <atomic>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -149,16 +151,7 @@ class TestControllerManagerSrvs
 public:
   TestControllerManagerSrvs() {}
 
-  ~TestControllerManagerSrvs() override
-  {
-    RCLCPP_DEBUG(cm_->get_logger(), "Stopping controller manager updater thread");
-    stop_runner_ = true;
-    if (cm_rt_thread_.joinable())
-    {
-      cm_rt_thread_.join();
-    }
-    RCLCPP_DEBUG(cm_->get_logger(), "Controller manager updater thread stopped");
-  }
+  ~TestControllerManagerSrvs() override { stopCmRtThread(); }
 
   void SetUp() override
   {
@@ -210,23 +203,44 @@ public:
   template <typename T>
   std::shared_ptr<typename T::Response> call_service_and_wait(
     rclcpp::Client<T> & client, std::shared_ptr<typename T::Request> request,
-    rclcpp::Executor & service_executor, bool update_controller_while_spinning = false)
+    rclcpp::Executor & service_executor)
   {
     EXPECT_TRUE(client.wait_for_service(std::chrono::milliseconds(500)));
     auto result = client.async_send_request(request);
-    // Wait for the result.
-    if (update_controller_while_spinning)
+    EXPECT_EQ(
+      service_executor.spin_until_future_complete(result), rclcpp::FutureReturnCode::SUCCESS);
+    return result.get();
+  }
+
+  void stopCmRtThread()
+  {
+    if (!cm_rt_thread_.joinable())
     {
-      while (service_executor.spin_until_future_complete(result, std::chrono::milliseconds(50)) !=
-             rclcpp::FutureReturnCode::SUCCESS)
-      {
-        cm_->update(time_, rclcpp::Duration::from_seconds(0.01));
-      }
+      return;
     }
-    else
+    RCLCPP_DEBUG(cm_->get_logger(), "Stopping controller manager updater thread");
+    stop_runner_ = true;
+    cm_rt_thread_.join();
+    stop_runner_ = false;
+    RCLCPP_DEBUG(cm_->get_logger(), "Controller manager updater thread stopped");
+  }
+
+  controller_interface::return_type switch_controller_with_update(
+    const std::vector<std::string> & activate_controllers,
+    const std::vector<std::string> & deactivate_controllers, int strictness, bool activate_asap)
+  {
+    stopCmRtThread();
+    auto result = std::async(
+      std::launch::async,
+      [&]
+      {
+        return cm_->switch_controller(
+          activate_controllers, deactivate_controllers, strictness, activate_asap,
+          rclcpp::Duration(0, 0));
+      });
+    while (result.wait_for(std::chrono::milliseconds(10)) != std::future_status::ready)
     {
-      EXPECT_EQ(
-        service_executor.spin_until_future_complete(result), rclcpp::FutureReturnCode::SUCCESS);
+      cm_->update(time_, PERIOD);
     }
     return result.get();
   }

--- a/controller_manager/test/test_controller_manager_srvs.cpp
+++ b/controller_manager/test/test_controller_manager_srvs.cpp
@@ -382,7 +382,7 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv)
   test_controller.reset();  // destroy our copy of the controller
 
   request->force_kill = false;
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   // Cleanup is not called from UNCONFIGURED: https://design.ros2.org/articles/node_lifecycle.html
   ASSERT_EQ(cleanup_calls, 0u);
@@ -407,7 +407,7 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv)
   test_controller.reset();  // destroy our copy of the controller
 
   request->force_kill = false;
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   ASSERT_EQ(shutdown_calls, 1u);
   ASSERT_EQ(test_controller.use_count(), 0)
@@ -441,7 +441,7 @@ TEST_F(TestControllerManagerSrvs, reload_controller_libraries_srv)
 
   // Force stop active controller
   request->force_kill = true;
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
 
   ASSERT_EQ(test_controller_weak.use_count(), 0)
@@ -467,7 +467,7 @@ TEST_F(TestControllerManagerSrvs, load_controller_srv)
     std::string(test_controller::TEST_CONTROLLER_NAME) + ".type",
     test_controller::TEST_CONTROLLER_CLASS_NAME);
   cm_->set_parameter(controller_type_parameter);
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
@@ -502,7 +502,7 @@ TEST_F(TestControllerManagerSrvs, cleanup_controller_srv)
     test_controller::TEST_CONTROLLER_CLASS_NAME);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
 
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
@@ -522,7 +522,7 @@ TEST_F(TestControllerManagerSrvs, cleanup_controller_srv)
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
     cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Controller can not be cleaned in active state: " << request->name;
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
@@ -538,7 +538,7 @@ TEST_F(TestControllerManagerSrvs, cleanup_controller_srv)
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
     cm_->get_loaded_controllers()[0].c->get_lifecycle_state().id());
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok) << "Controller cleaned in inactive state: " << request->name;
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
@@ -566,7 +566,7 @@ TEST_F(TestControllerManagerSrvs, unload_controller_srv)
     test_controller::TEST_CONTROLLER_CLASS_NAME);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
 
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
@@ -602,7 +602,7 @@ TEST_F(TestControllerManagerSrvs, robot_description_on_load_and_unload_controlle
   // now unload and load the controller and see if the controller gets the new robot description
   auto unload_request = std::make_shared<controller_manager_msgs::srv::UnloadController::Request>();
   unload_request->name = test_controller::TEST_CONTROLLER_NAME;
-  auto result = call_service_and_wait(*unload_client, unload_request, srv_executor, true);
+  auto result = call_service_and_wait(*unload_client, unload_request, srv_executor);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
     test_controller->get_lifecycle_state().id());
@@ -644,7 +644,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     test_controller::TEST_CONTROLLER_CLASS_NAME);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
 
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
@@ -655,7 +655,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     test_controller->get_lifecycle_state().id());
 
   // configure_controller must reject any state other than UNCONFIGURED
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Controller configured from inactive state: " << request->name;
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
@@ -691,7 +691,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   ASSERT_NE(nullptr, abstract_test_chainable_controller);
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
 
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
@@ -705,7 +705,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     test_chainable_controller->get_lifecycle_state().id());
 
   // configure_controller must reject any state other than UNCONFIGURED
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Controller configured from inactive state: " << request->name;
   EXPECT_EQ(2u, cm_->get_loaded_controllers().size());
   EXPECT_EQ(
@@ -722,14 +722,14 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   auto cleanup_request =
     std::make_shared<controller_manager_msgs::srv::CleanupController::Request>();
   cleanup_request->name = test_chainable_controller::TEST_CONTROLLER_NAME;
-  ASSERT_TRUE(call_service_and_wait(*cleanup_client, cleanup_request, srv_executor, true)->ok);
+  ASSERT_TRUE(call_service_and_wait(*cleanup_client, cleanup_request, srv_executor)->ok);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED,
     test_chainable_controller->get_lifecycle_state().id());
 
   // Now try to configure the chainable controller with duplicated command interfaces
   test_chainable_controller->set_command_interface_configuration(duplicated_chained_cmd_cfg);
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Controller not configured: " << request->name;
   EXPECT_EQ(
     test_chainable_controller::TEST_CONTROLLER_NAME,
@@ -747,7 +747,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
     {"joint1/position", "joint1/position", "joint1/velocity"}};
   test_chainable_controller->set_command_interface_configuration(chained_cmd_cfg);
   test_chainable_controller->set_state_interface_configuration(duplicated_chained_state_cfg);
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_FALSE(result->ok) << "Controller not configured: " << request->name;
   EXPECT_EQ(
     test_chainable_controller::TEST_CONTROLLER_NAME,
@@ -762,7 +762,7 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   // Now try to configure the chainable controller again with unique state and command interfaces
   test_chainable_controller->set_command_interface_configuration(chained_cmd_cfg);
   test_chainable_controller->set_state_interface_configuration(chained_state_cfg);
-  result = call_service_and_wait(*client, request, srv_executor, true);
+  result = call_service_and_wait(*client, request, srv_executor);
   ASSERT_TRUE(result->ok);
   EXPECT_EQ(
     test_chainable_controller::TEST_CONTROLLER_NAME,
@@ -777,14 +777,14 @@ TEST_F(TestControllerManagerSrvs, configure_controller_srv)
   // now unload the controller and check the state
   auto unload_request = std::make_shared<controller_manager_msgs::srv::UnloadController::Request>();
   unload_request->name = test_controller::TEST_CONTROLLER_NAME;
-  ASSERT_TRUE(call_service_and_wait(*unload_client, unload_request, srv_executor, true)->ok);
+  ASSERT_TRUE(call_service_and_wait(*unload_client, unload_request, srv_executor)->ok);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
     test_controller->get_lifecycle_state().id());
   EXPECT_EQ(1u, cm_->get_loaded_controllers().size());
 
   unload_request->name = test_chainable_controller::TEST_CONTROLLER_NAME;
-  ASSERT_TRUE(call_service_and_wait(*unload_client, unload_request, srv_executor, true)->ok);
+  ASSERT_TRUE(call_service_and_wait(*unload_client, unload_request, srv_executor)->ok);
   EXPECT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED,
     test_chainable_controller->get_lifecycle_state().id());
@@ -2511,6 +2511,11 @@ TEST_F(TestControllerManagerSrvs, switch_controller_controllers_taking_long_time
   ASSERT_EQ(result->controller[1].name, test_ctrl_2_name);
   ASSERT_EQ(result->controller[0].name, test_ctrl_3_name);
 
+  // From this point on the test reads exact controller counters. Keep the control loop under
+  // explicit test control when reading counters, and only drive update() while switch_controller
+  // is waiting for RT progress.
+  stopCmRtThread();
+
   ASSERT_EQ(0u, test_controller_1->internal_counter);
   ASSERT_EQ(0u, test_controller_2->internal_counter);
   ASSERT_EQ(0u, test_controller_3->internal_counter);
@@ -2525,10 +2530,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_controllers_taking_long_time
 
   // activate non time taking controllers
   {
-    auto res = cm_->switch_controller(
+    auto res = switch_controller_with_update(
       {test_ctrl_1_name, test_ctrl_2_name}, {},
-      controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-      rclcpp::Duration(0, 0));
+      controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
     ASSERT_EQ(res, controller_interface::return_type::OK);
   }
   unsigned int old_counter_1 = test_controller_1->internal_counter;
@@ -2556,9 +2560,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_controllers_taking_long_time
   old_counter_1 = test_controller_1->internal_counter;
   old_counter_2 = test_controller_2->internal_counter;
   {
-    auto res = cm_->switch_controller(
-      {test_ctrl_3_name}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-      rclcpp::Duration(0, 0));
+    auto res = switch_controller_with_update(
+      {test_ctrl_3_name}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT,
+      true);
     ASSERT_EQ(res, controller_interface::return_type::OK);
   }
 
@@ -2584,9 +2588,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_controllers_taking_long_time
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   // Now, let's deactivate and activate again but with activate_asap as false
   {
-    auto res = cm_->switch_controller(
-      {}, {test_ctrl_3_name}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-      rclcpp::Duration(0, 0));
+    auto res = switch_controller_with_update(
+      {}, {test_ctrl_3_name}, controller_manager_msgs::srv::SwitchController::Request::STRICT,
+      true);
     ASSERT_EQ(res, controller_interface::return_type::OK);
   }
 
@@ -2603,9 +2607,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_controllers_taking_long_time
   old_counter_1 = test_controller_1->internal_counter;
   old_counter_2 = test_controller_2->internal_counter;
   {
-    auto res = cm_->switch_controller(
+    auto res = switch_controller_with_update(
       {test_ctrl_3_name}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT,
-      false, rclcpp::Duration(0, 0));
+      false);
     ASSERT_EQ(res, controller_interface::return_type::OK);
   }
   const auto ideal_cycles =
@@ -2824,9 +2828,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
   ASSERT_EQ(result->controller[1].name, TEST_CONTROLLER_1);
 
   // Check individual activation and they should work fine
-  auto res = cm_->switch_controller(
-    {TEST_CONTROLLER_1}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  auto res = switch_controller_with_update(
+    {TEST_CONTROLLER_1}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
 
   ASSERT_EQ(
@@ -2838,9 +2841,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
 
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
-  res = cm_->switch_controller(
-    {}, {TEST_CONTROLLER_1}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  res = switch_controller_with_update(
+    {}, {TEST_CONTROLLER_1}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
 
   ASSERT_EQ(
@@ -2852,9 +2854,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
   // Now test activating controller_2
-  res = cm_->switch_controller(
-    {TEST_CONTROLLER_2}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  res = switch_controller_with_update(
+    {TEST_CONTROLLER_2}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
 
   ASSERT_EQ(
@@ -2865,9 +2866,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
     test_controller_2->get_lifecycle_state().id());
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
-  res = cm_->switch_controller(
-    {}, {TEST_CONTROLLER_2}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  res = switch_controller_with_update(
+    {}, {TEST_CONTROLLER_2}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
 
   ASSERT_EQ(
@@ -2880,9 +2880,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
 
   // Now try activating both the controllers at once, it should fail as they are using same
   // interface
-  res = cm_->switch_controller(
+  res = switch_controller_with_update(
     {TEST_CONTROLLER_1, TEST_CONTROLLER_2}, {},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, false, rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, false);
   ASSERT_EQ(res, controller_interface::return_type::ERROR);
 
   ASSERT_EQ(
@@ -2894,9 +2894,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
   // Now activate controller 2 and then try to activate controller 1 while deactivating controller 2
-  res = cm_->switch_controller(
-    {TEST_CONTROLLER_2}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  res = switch_controller_with_update(
+    {TEST_CONTROLLER_2}, {}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,
@@ -2906,9 +2905,9 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
     test_controller_2->get_lifecycle_state().id());
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
-  res = cm_->switch_controller(
+  res = switch_controller_with_update(
     {TEST_CONTROLLER_1}, {TEST_CONTROLLER_2},
-    controller_manager_msgs::srv::SwitchController::Request::STRICT, false, rclcpp::Duration(0, 0));
+    controller_manager_msgs::srv::SwitchController::Request::STRICT, false);
   ASSERT_EQ(res, controller_interface::return_type::OK);
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE,
@@ -2919,9 +2918,8 @@ TEST_F(TestControllerManagerSrvs, switch_controller_test_two_controllers_using_a
   cm_->update(cm_->now(), rclcpp::Duration::from_seconds(0.01));
 
   // deactivate controller 2
-  res = cm_->switch_controller(
-    {}, {TEST_CONTROLLER_1}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true,
-    rclcpp::Duration(0, 0));
+  res = switch_controller_with_update(
+    {}, {TEST_CONTROLLER_1}, controller_manager_msgs::srv::SwitchController::Request::STRICT, true);
   ASSERT_EQ(res, controller_interface::return_type::OK);
   ASSERT_EQ(
     lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE,


### PR DESCRIPTION
## Description

Fix the controller-list handoff data race between the real-time update loop and
non-real-time controller management, and remove the test-only second update-loop
owner that produces the separate write/write reports in #3083.

- make both double-buffer list indices atomic;
- announce the selected list from the RT path and recheck the published index
  before dereferencing it, closing the stale-list retirement window;
- remove the service test helper's obsolete fallback `update()` call now that
  the fixture owns a dedicated update thread;
- give the two direct-switch tests one explicit update owner while preserving
  their original assertions.

The RT path remains mutex-free, and this does not make
`ControllerManager::update()` generally reentrant.

Fixes #3083

### Is this user-facing behavior change?

No public API or controller behavior changes. The change synchronizes the
existing controller-list handoff and corrects test update-loop ownership.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) was used to investigate the ThreadSanitizer reports,
trace the test-fixture history, implement the synchronization protocol and test
cleanup, and prepare the validation evidence. The final diff, root-cause
analysis, and test results were reviewed locally before submission.

### Additional Information

Local validation against the current `master` source with pinned source
dependencies over a ROS 2 Humble underlay:

- fresh normal build through `controller_manager`: 10 packages completed;
- fresh ThreadSanitizer build through `controller_manager`: 10 packages completed;
- focused normal service tests: 3 passed;
- focused TSAN `load_controller_srv`: 20/20 repeated passes, zero TSAN reports;
- pre-commit on all four changed files: passed;
- `git diff --check`: passed.

The TSAN build used `-fsanitize=thread -fno-omit-frame-pointer -g` for compile
and link steps. Native Rolling and the full upstream CI matrix remain the
upstream validation boundary.

A broader local TSAN diagnostic also exposed a separate race in switch timing
statistics between `manage_switch()` and `update()`. It is not one of #3083's
controller-list or duplicate-update root causes and is intentionally not mixed
into this focused patch.

## TODOs

- [x] Fork the repository.
- [x] Modify the source with a focused change.
- [x] Ensure focused local tests and pre-commit pass.
- [x] Commit to the fork using a clear commit message.
- [x] Send this pull request and answer the default questions.
- [ ] Monitor automated CI and participate in review.
