### PR TITLE
Scale joint limit tolerances with the joint's range (#2981)

### DIFF
--- a/joint_limits/include/joint_limits/joint_limits_helpers.hpp
+++ b/joint_limits/include/joint_limits/joint_limits_helpers.hpp
@@ -27,9 +27,30 @@ namespace joint_limits
 {
 namespace internal
 {
-constexpr double POSITION_BOUNDS_TOLERANCE = 0.002;
-// 0.5 degrees (or) approx. 1 cm for the prismatic joint
-constexpr double OUT_OF_BOUNDS_EXCEPTION_TOLERANCE = 0.0087;
+/// Tolerances are expressed as a fraction of the joint's range (max_position - min_position),
+/// so that they scale with the joint instead of being fixed absolute values.
+constexpr double POSITION_BOUNDS_TOLERANCE_RATIO = 0.001;
+constexpr double OUT_OF_BOUNDS_EXCEPTION_TOLERANCE_RATIO = 0.005;
+
+/**
+ * @brief Compute the position bounds tolerance, scaled with the joint's range.
+ * @param limits The joint limits.
+ * @return The tolerance allowed beyond the position limits.
+ */
+inline double position_bounds_tolerance(const JointLimits & limits)
+{
+  return POSITION_BOUNDS_TOLERANCE_RATIO * (limits.max_position - limits.min_position);
+}
+
+/**
+ * @brief Compute the out-of-bounds exception tolerance, scaled with the joint's range.
+ * @param limits The joint limits.
+ * @return The tolerance beyond which an exception is thrown.
+ */
+inline double out_of_bounds_exception_tolerance(const JointLimits & limits)
+{
+  return OUT_OF_BOUNDS_EXCEPTION_TOLERANCE_RATIO * (limits.max_position - limits.min_position);
+}
 }  // namespace internal
 
 /**

--- a/joint_limits/src/joint_limits_helpers.cpp
+++ b/joint_limits/src/joint_limits_helpers.cpp
@@ -37,7 +37,6 @@ void check_and_swap_limits(double & lower_limit, double & upper_limit)
     std::swap(lower_limit, upper_limit);
   }
 }
-
 /**
  * @brief Verify if the actual position is within the limits and if not, log an error and throw an
  * exception.
@@ -53,9 +52,10 @@ void verify_actual_position_within_limits(
   if (actual_position.has_value() && limits.has_position_limits)
   {
     const double actual_pos = actual_position.value();
+    const double tolerance = out_of_bounds_exception_tolerance(limits);
     if (
-      actual_pos > (limits.max_position + internal::OUT_OF_BOUNDS_EXCEPTION_TOLERANCE) ||
-      actual_pos < (limits.min_position - internal::OUT_OF_BOUNDS_EXCEPTION_TOLERANCE))
+      actual_pos > (limits.max_position + tolerance) ||
+      actual_pos < (limits.min_position - tolerance))
     {
       const std::string error_message = fmt::format(
         FMT_COMPILE(
@@ -149,6 +149,7 @@ VelocityLimits compute_velocity_limits(
   if (limits.has_position_limits && act_pos.has_value())
   {
     const double actual_pos = act_pos.value();
+    const double position_tolerance = internal::position_bounds_tolerance(limits);
     const double max_vel_with_pos_limits = (limits.max_position - actual_pos) / dt;
     const double min_vel_with_pos_limits = (limits.min_position - actual_pos) / dt;
     vel_limits.lower_limit = std::max(min_vel_with_pos_limits, vel_limits.lower_limit);
@@ -157,9 +158,9 @@ VelocityLimits compute_velocity_limits(
     if (actual_pos > limits.max_position || actual_pos < limits.min_position)
     {
       if (
-        (actual_pos < (limits.max_position + internal::POSITION_BOUNDS_TOLERANCE) &&
+        (actual_pos < (limits.max_position + position_tolerance) &&
          (actual_pos > limits.min_position) && desired_vel >= 0.0) ||
-        (actual_pos > (limits.min_position - internal::POSITION_BOUNDS_TOLERANCE) &&
+        (actual_pos > (limits.min_position - position_tolerance) &&
          (actual_pos < limits.max_position) && desired_vel <= 0.0))
       {
         RCLCPP_WARN_EXPRESSION(
@@ -174,8 +175,8 @@ VelocityLimits compute_velocity_limits(
       // If the joint reports a position way out of bounds, then it would mean something is
       // extremely wrong, so no velocity command should be allowed as it might damage the robot
       else if (
-        (actual_pos > (limits.max_position + internal::POSITION_BOUNDS_TOLERANCE)) ||
-        (actual_pos < (limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)))
+        (actual_pos > (limits.max_position + position_tolerance)) ||
+        (actual_pos < (limits.min_position - position_tolerance)))
       {
         RCLCPP_ERROR_ONCE(
           rclcpp::get_logger("joint_limiter_interface"),

--- a/joint_limits/src/joint_soft_limiter.cpp
+++ b/joint_limits/src/joint_soft_limiter.cpp
@@ -147,10 +147,11 @@ bool JointSoftLimiter::on_enforce(
         -soft_joint_limits.k_position * (prev_command_position - soft_joint_limits.max_position),
         -hard_limits.max_velocity, hard_limits.max_velocity);
 
+      const double position_tolerance = internal::position_bounds_tolerance(hard_limits);
       if (
         std::isfinite(act_position) &&
-        ((act_position < (hard_limits.min_position - internal::POSITION_BOUNDS_TOLERANCE)) ||
-         (act_position > (hard_limits.max_position + internal::POSITION_BOUNDS_TOLERANCE))))
+        ((act_position < (hard_limits.min_position - position_tolerance)) ||
+         (act_position > (hard_limits.max_position + position_tolerance))))
       {
         soft_min_vel = 0.0;
         soft_max_vel = 0.0;

--- a/joint_limits/test/test_joint_range_limiter.cpp
+++ b/joint_limits/test/test_joint_range_limiter.cpp
@@ -235,7 +235,8 @@ TEST_F(JointSaturationLimiterTest, check_desired_velocity_only_cases)
   test_limit_enforcing(std::nullopt, 0.12, 0.12, false);
   test_limit_enforcing(std::nullopt, 0.0, 0.0, false);
 
-  const double outside_limits_pos = 5.0 + (2.0 * joint_limits::internal::POSITION_BOUNDS_TOLERANCE);
+  const double position_tolerance = joint_limits::internal::position_bounds_tolerance(limits);
+  const double outside_limits_pos = 5.0 + (2.0 * position_tolerance);
   // The cases where the actual position value exist
   test_limit_enforcing(4.5, 5.0, 0.5, true);
   test_limit_enforcing(4.8, 5.0, 0.2, true);
@@ -260,23 +261,15 @@ TEST_F(JointSaturationLimiterTest, check_desired_velocity_only_cases)
   test_limit_enforcing(-1.0 * outside_limits_pos, 1.0, 0.0, true);
   // If the reported actual position is within the limits and the tolerance, then the velocity is
   // allowed to move into the range, but not away from the range
-  test_limit_enforcing(
-    -5.0 - joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, -3.0, 0.0, true);
-  test_limit_enforcing(
-    -5.0 - joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, 1.0, 1.0, false);
-  test_limit_enforcing(
-    -5.0 - joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, 0.2, 0.2, false);
-  test_limit_enforcing(
-    -5.0 - joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, 2.0, 1.0, true);
+  test_limit_enforcing(-5.0 - position_tolerance / 2.0, -3.0, 0.0, true);
+  test_limit_enforcing(-5.0 - position_tolerance / 2.0, 1.0, 1.0, false);
+  test_limit_enforcing(-5.0 - position_tolerance / 2.0, 0.2, 0.2, false);
+  test_limit_enforcing(-5.0 - position_tolerance / 2.0, 2.0, 1.0, true);
 
-  test_limit_enforcing(
-    5.0 + joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, 3.0, 0.0, true);
-  test_limit_enforcing(
-    5.0 + joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, -1.0, -1.0, false);
-  test_limit_enforcing(
-    5.0 + joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, -0.2, -0.2, false);
-  test_limit_enforcing(
-    5.0 + joint_limits::internal::POSITION_BOUNDS_TOLERANCE / 2.0, -2.0, -1.0, true);
+  test_limit_enforcing(5.0 + position_tolerance / 2.0, 3.0, 0.0, true);
+  test_limit_enforcing(5.0 + position_tolerance / 2.0, -1.0, -1.0, false);
+  test_limit_enforcing(5.0 + position_tolerance / 2.0, -0.2, -0.2, false);
+  test_limit_enforcing(5.0 + position_tolerance / 2.0, -2.0, -1.0, true);
 
   // Now remove the position limits and only test with acceleration limits
   limits.has_position_limits = false;

--- a/joint_limits/test/test_joint_soft_limiter.cpp
+++ b/joint_limits/test/test_joint_soft_limiter.cpp
@@ -427,7 +427,8 @@ TEST_F(JointSoftLimiterTest, check_desired_velocity_only_cases)
     EXPECT_FALSE(desired_state_.has_jerk());
   };
 
-  const double outside_limits_pos = 5.0 + (2.0 * joint_limits::internal::POSITION_BOUNDS_TOLERANCE);
+  const double position_tolerance = joint_limits::internal::position_bounds_tolerance(limits);
+  const double outside_limits_pos = 5.0 + (2.0 * position_tolerance);
   auto test_generic_cases = [&](const joint_limits::SoftJointLimits & soft_joint_limits)
   {
     ASSERT_TRUE(Init(limits, soft_joint_limits));


### PR DESCRIPTION
## Description

The position tolerances used when checking joint limits were fixed absolute values (`POSITION_BOUNDS_TOLERANCE = 0.002`, `OUT_OF_BOUNDS_EXCEPTION_TOLERANCE = 0.0087`) applied identically to every joint regardless of its scale. As noted in the issue, this isn't a good fit for every application — the values are too tight for joints with a large range, e.g. a prismatic joint with a 2.5 m range.

This replaces the constants with ratios of the joint's range (`max_position - min_position`):

- `POSITION_BOUNDS_TOLERANCE_RATIO = 0.001` (0.1% of range)
- `OUT_OF_BOUNDS_EXCEPTION_TOLERANCE_RATIO = 0.005` (0.5% of range)

For a 2.5 m prismatic joint this gives 2.5 mm / 12.5 mm instead of 2 mm / 8.7 mm; for a ±π revolute joint, 0.0063 rad / 0.031 rad. The ~5x ratio between the two tolerances is preserved.

The helpers are defined `inline` in the header rather than in the `.cpp` because they replace header constants that were previously available to targets which don't link `joint_limits_helpers` (both test targets).

All call sites are already guarded by `has_position_limits`, so joints without position limits are unaffected.

Fixes #2981

### Is this user-facing behavior change?

Yes — the tolerance applied before a joint is considered out of bounds now depends on the joint's range instead of being a fixed value. Joints with a large range get a more permissive tolerance; joints with a very small range get a tighter one. Happy to add a lower bound on the tolerance for small-range joints if that's preferred.

### Did you use Generative AI?

Yes — I used Claude to help navigate the codebase and draft this description. The approach follows the direction agreed in the issue, and I made and tested the changes myself.

### Additional Information

Built and tested locally on ROS 2 Humble: `colcon test --packages-select joint_limits` passes (61 tests, 0 failures). The existing tests were updated to compute the tolerance from the fixture's limits rather than referencing the removed constants.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [ ] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.