### PR TITLE
Accumulate the changed flag over the whole parameter batch in check_for_limits_update

### DIFF
--- a/joint_limits/include/joint_limits/joint_limits_rosparam.hpp
+++ b/joint_limits/include/joint_limits/joint_limits_rosparam.hpp
@@ -452,37 +452,37 @@ inline bool check_for_limits_update(
     {
       if (param_name == param_base_name + ".min_position")
       {
-        changed = updated_limits.min_position != parameter.get_value<double>();
+        changed |= updated_limits.min_position != parameter.get_value<double>();
         updated_limits.min_position = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_position")
       {
-        changed = updated_limits.max_position != parameter.get_value<double>();
+        changed |= updated_limits.max_position != parameter.get_value<double>();
         updated_limits.max_position = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_velocity")
       {
-        changed = updated_limits.max_velocity != parameter.get_value<double>();
+        changed |= updated_limits.max_velocity != parameter.get_value<double>();
         updated_limits.max_velocity = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_acceleration")
       {
-        changed = updated_limits.max_acceleration != parameter.get_value<double>();
+        changed |= updated_limits.max_acceleration != parameter.get_value<double>();
         updated_limits.max_acceleration = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_deceleration")
       {
-        changed = updated_limits.max_deceleration != parameter.get_value<double>();
+        changed |= updated_limits.max_deceleration != parameter.get_value<double>();
         updated_limits.max_deceleration = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_jerk")
       {
-        changed = updated_limits.max_jerk != parameter.get_value<double>();
+        changed |= updated_limits.max_jerk != parameter.get_value<double>();
         updated_limits.max_jerk = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".max_effort")
       {
-        changed = updated_limits.max_effort != parameter.get_value<double>();
+        changed |= updated_limits.max_effort != parameter.get_value<double>();
         updated_limits.max_effort = parameter.get_value<double>();
       }
     }
@@ -818,22 +818,22 @@ inline bool check_for_limits_update(
     {
       if (param_name == param_base_name + ".k_position")
       {
-        changed = updated_limits.k_position != parameter.get_value<double>();
+        changed |= updated_limits.k_position != parameter.get_value<double>();
         updated_limits.k_position = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".k_velocity")
       {
-        changed = updated_limits.k_velocity != parameter.get_value<double>();
+        changed |= updated_limits.k_velocity != parameter.get_value<double>();
         updated_limits.k_velocity = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".soft_lower_limit")
       {
-        changed = updated_limits.min_position != parameter.get_value<double>();
+        changed |= updated_limits.min_position != parameter.get_value<double>();
         updated_limits.min_position = parameter.get_value<double>();
       }
       else if (param_name == param_base_name + ".soft_upper_limit")
       {
-        changed = updated_limits.max_position != parameter.get_value<double>();
+        changed |= updated_limits.max_position != parameter.get_value<double>();
         updated_limits.max_position = parameter.get_value<double>();
       }
     }

--- a/joint_limits/test/joint_limits_rosparam_test.cpp
+++ b/joint_limits/test/joint_limits_rosparam_test.cpp
@@ -458,6 +458,54 @@ TEST_F(
   }
 }
 
+TEST_F(JointLimitsRosParamTest, check_for_limits_update_accumulates_over_the_whole_batch)
+{
+  // A parameter event delivers the whole set at once. A change to any one of them has to
+  // be reported, no matter what follows it in the batch.
+  {
+    joint_limits::JointLimits limits;
+    limits.min_position = -1.0;
+    limits.max_position = 1.0;
+    limits.max_velocity = 2.0;
+
+    const std::vector<rclcpp::Parameter> parameters{
+      rclcpp::Parameter("joint_limits.foo_joint.min_position", -5.0),  // changed
+      rclcpp::Parameter("joint_limits.foo_joint.max_velocity", 2.0)};  // unchanged
+
+    joint_limits::JointLimits updated_limits = limits;
+    EXPECT_TRUE(
+      joint_limits::check_for_limits_update(
+        "foo_joint", parameters, node_->get_node_logging_interface(), updated_limits));
+    EXPECT_EQ(-5.0, updated_limits.min_position);
+
+    // ... and a batch that changes nothing still has to report no change
+    const std::vector<rclcpp::Parameter> unchanged_parameters{
+      rclcpp::Parameter("joint_limits.foo_joint.min_position", -5.0),
+      rclcpp::Parameter("joint_limits.foo_joint.max_velocity", 2.0)};
+    EXPECT_FALSE(
+      joint_limits::check_for_limits_update(
+        "foo_joint", unchanged_parameters, node_->get_node_logging_interface(), updated_limits));
+  }
+
+  {
+    joint_limits::SoftJointLimits soft_limits;
+    soft_limits.k_position = 10.0;
+    soft_limits.k_velocity = 20.0;
+    soft_limits.min_position = 0.1;
+    soft_limits.max_position = 0.9;
+
+    const std::vector<rclcpp::Parameter> parameters{
+      rclcpp::Parameter("joint_limits.foo_joint.k_position", 30.0),   // changed
+      rclcpp::Parameter("joint_limits.foo_joint.k_velocity", 20.0)};  // unchanged
+
+    joint_limits::SoftJointLimits updated_limits = soft_limits;
+    EXPECT_TRUE(
+      joint_limits::check_for_limits_update(
+        "foo_joint", parameters, node_->get_node_logging_interface(), updated_limits));
+    EXPECT_EQ(30.0, updated_limits.k_position);
+  }
+}
+
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);


### PR DESCRIPTION
## Description

`check_for_limits_update()` walks every parameter in the event and reports whether any joint limit actually changed. Both overloads *assign* to `changed` inside that loop instead of accumulating into it (`joint_limits/include/joint_limits/joint_limits_rosparam.hpp:455-485` and `:821-836`), so the return value only reflects the last numeric parameter in the batch that matched a branch:

```
batch: min_position -1.0 -> -5.0 (changed), then max_velocity 2.0 -> 2.0 (unchanged)
  before: returns false, min_position is -5.0 in updated_limits
  after:  returns true
```

`joint_limiter_interface.hpp:108` already accumulates with `|=` across joints and only calls `updated_limits_.writeFromNonRT()` `if (changed)`, and `updated_joint_limits` is rebuilt from `joint_limits_` on the next event, so a change reported as `false` is dropped for good. The second loop in the same function only ever sets the flag `true`, which is the accumulate semantics this first loop was meant to have.

Single-parameter `ros2 param set` calls are unaffected; it needs two or more matching parameters in one event, which is what a parameter file load delivers.

Fixes # (no issue)

### Is this user-facing behavior change?

Yes, in the sense that a dynamic joint-limit update that is currently silently dropped will now be applied. Nothing else changes: `|=` can only make `changed` true in cases where a limit really did change.

### Did you use Generative AI?

Yes. Claude was used to find this, write the one-token change and write the test.

### Additional Information

New test `check_for_limits_update_accumulates_over_the_whole_batch` covers both overloads. It asserts both directions: a batch with one real change followed by an unchanged parameter must return true, *and* a batch that changes nothing must still return false — the second assertion is there because "just set `changed = true` whenever a matching parameter is present" also passes the first one and is wrong. `grep` for `check_for_limits_update` finds only the two definitions and the one caller; there was no existing test.

What I could not run: I have no ROS 2 install, so `colcon test` did not run here and the new test is unrun by me. `pre-commit run` passes for both files (clang-format v23.1.0, codespell, whitespace); `ament_cppcheck`, `ament_cpplint` and `ament_copyright` are not installed locally. The before/after above comes from a transcription of that loop compiled standalone with a stand-in for `rclcpp::Parameter`.
