### PR TITLE
Return hardware statistics by value to avoid diagnostics data race

### DIFF
--- a/controller_manager/src/controller_manager.cpp
+++ b/controller_manager/src/controller_manager.cpp
@@ -1127,15 +1127,16 @@ void ControllerManager::set_initial_hardware_components_state()
       component_name + ".stats/read_cycle/periodicity";
     register_controller_manager_statistics(
       read_cycle_exec_time_prefix,
-      &component_info.read_statistics->execution_time.get_statistics());
+      &component_info.read_statistics->execution_time.get_statistics_const_ptr());
     REGISTER_ENTITY(
       hardware_interface::CM_STATISTICS_KEY, read_cycle_exec_time_prefix + "/current_value",
-      &component_info.read_statistics->execution_time.get_current_data());
+      &component_info.read_statistics->execution_time.get_current_data_const_ptr());
     register_controller_manager_statistics(
-      read_cycle_periodicity_prefix, &component_info.read_statistics->periodicity.get_statistics());
+      read_cycle_periodicity_prefix,
+      &component_info.read_statistics->periodicity.get_statistics_const_ptr());
     REGISTER_ENTITY(
       hardware_interface::CM_STATISTICS_KEY, read_cycle_periodicity_prefix + "/current_value",
-      &component_info.read_statistics->periodicity.get_current_data());
+      &component_info.read_statistics->periodicity.get_current_data_const_ptr());
     if (component_info.write_statistics)
     {
       const std::string write_cycle_exec_time_prefix =
@@ -1144,16 +1145,16 @@ void ControllerManager::set_initial_hardware_components_state()
         component_name + ".stats/write_cycle/periodicity";
       register_controller_manager_statistics(
         write_cycle_exec_time_prefix,
-        &component_info.write_statistics->execution_time.get_statistics());
+        &component_info.write_statistics->execution_time.get_statistics_const_ptr());
       REGISTER_ENTITY(
         hardware_interface::CM_STATISTICS_KEY, write_cycle_exec_time_prefix + "/current_value",
-        &component_info.write_statistics->execution_time.get_current_data());
+        &component_info.write_statistics->execution_time.get_current_data_const_ptr());
       register_controller_manager_statistics(
         write_cycle_periodicity_prefix,
-        &component_info.write_statistics->periodicity.get_statistics());
+        &component_info.write_statistics->periodicity.get_statistics_const_ptr());
       REGISTER_ENTITY(
         hardware_interface::CM_STATISTICS_KEY, write_cycle_periodicity_prefix + "/current_value",
-        &component_info.write_statistics->periodicity.get_current_data());
+        &component_info.write_statistics->periodicity.get_current_data_const_ptr());
     }
   }
 }

--- a/hardware_interface/CMakeLists.txt
+++ b/hardware_interface/CMakeLists.txt
@@ -89,6 +89,9 @@ if(BUILD_TESTING)
   ament_add_gmock(test_lexical_casts test/test_lexical_casts.cpp)
   target_link_libraries(test_lexical_casts hardware_interface)
 
+  ament_add_gmock(test_statistics_types test/test_statistics_types.cpp)
+  target_link_libraries(test_statistics_types hardware_interface)
+
   ament_add_gmock(test_component_interfaces test/test_component_interfaces.cpp)
   target_link_libraries(test_component_interfaces hardware_interface ros2_control_test_assets::ros2_control_test_assets)
 

--- a/hardware_interface/include/hardware_interface/types/statistics_types.hpp
+++ b/hardware_interface/include/hardware_interface/types/statistics_types.hpp
@@ -259,6 +259,7 @@ public:
 
   void reset()
   {
+    std::unique_lock<DEFAULT_MUTEX> lock(mutex_);
     statistics_data_.average = std::numeric_limits<double>::quiet_NaN();
     statistics_data_.min = std::numeric_limits<double>::quiet_NaN();
     statistics_data_.max = std::numeric_limits<double>::quiet_NaN();
@@ -267,16 +268,42 @@ public:
   }
 
   /**
-   * @brief Get the statistics data.
-   * @return statistics data.
+   * @brief Get a reference to the statistics data, e.g. for registering it for introspection.
+   * @note The referenced data is updated concurrently by update_statistics().
+   * @return reference to the statistics data.
    */
-  const StatisticData & get_statistics() const
+  const StatisticData & get_statistics_const_ptr() const
   {
     std::unique_lock<DEFAULT_MUTEX> lock(mutex_);
     return statistics_data_;
   }
 
-  const double & get_current_data() const
+  /**
+   * @brief Get a copy of the statistics data.
+   * @return statistics data.
+   */
+  StatisticData get_statistics() const
+  {
+    std::unique_lock<DEFAULT_MUTEX> lock(mutex_);
+    return statistics_data_;
+  }
+
+  /**
+   * @brief Get a reference to the current data value, e.g. for registering it for introspection.
+   * @note The referenced data is updated concurrently by update_statistics().
+   * @return reference to the current data value.
+   */
+  const double & get_current_data_const_ptr() const
+  {
+    std::unique_lock<DEFAULT_MUTEX> lock(mutex_);
+    return current_data_;
+  }
+
+  /**
+   * @brief Get a copy of the current data value.
+   * @return current data value.
+   */
+  double get_current_data() const
   {
     std::unique_lock<DEFAULT_MUTEX> lock(mutex_);
     return current_data_;

--- a/hardware_interface/test/test_statistics_types.cpp
+++ b/hardware_interface/test/test_statistics_types.cpp
@@ -1,0 +1,91 @@
+// Copyright 2026 ros2_control Development Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <cmath>
+#include <memory>
+#include <thread>
+
+#include "gmock/gmock.h"
+#include "hardware_interface/types/statistics_types.hpp"
+
+using ros2_control::MovingAverageStatistics;
+using ros2_control::MovingAverageStatisticsData;
+
+TEST(TestMovingAverageStatisticsData, get_statistics_returns_snapshot)
+{
+  auto collector = std::make_shared<MovingAverageStatistics>();
+  collector->reset();
+  MovingAverageStatisticsData data;
+
+  collector->add_measurement(1.0);
+  data.update_statistics(collector);
+  const auto & snapshot = data.get_statistics();
+  const auto & current = data.get_current_data();
+  EXPECT_EQ(snapshot.sample_count, 1u);
+  EXPECT_DOUBLE_EQ(snapshot.average, 1.0);
+  EXPECT_DOUBLE_EQ(current, 1.0);
+
+  collector->add_measurement(3.0);
+  data.update_statistics(collector);
+
+  // The previously returned values must not change when the statistics are updated.
+  EXPECT_EQ(snapshot.sample_count, 1u);
+  EXPECT_DOUBLE_EQ(snapshot.average, 1.0);
+  EXPECT_DOUBLE_EQ(current, 1.0);
+
+  EXPECT_EQ(data.get_statistics().sample_count, 2u);
+  EXPECT_DOUBLE_EQ(data.get_statistics().average, 2.0);
+  EXPECT_DOUBLE_EQ(data.get_current_data(), 3.0);
+}
+
+TEST(TestMovingAverageStatisticsData, concurrent_update_and_read)
+{
+  auto collector = std::make_shared<MovingAverageStatistics>();
+  collector->reset();
+  MovingAverageStatisticsData data;
+  std::atomic<bool> done{false};
+  constexpr uint64_t kSamples = 20000;
+
+  std::thread writer(
+    [&]()
+    {
+      for (uint64_t i = 1; i <= kSamples; ++i)
+      {
+        collector->add_measurement(static_cast<double>(i));
+        data.update_statistics(collector);
+      }
+      done = true;
+    });
+
+  uint64_t reads = 0;
+  while (!done)
+  {
+    const auto stats = data.get_statistics();
+    const double current = data.get_current_data();
+    if (stats.sample_count > 0)
+    {
+      // Every snapshot must be internally consistent: measurements are 1..n
+      EXPECT_DOUBLE_EQ(stats.min, 1.0);
+      EXPECT_DOUBLE_EQ(stats.max, static_cast<double>(stats.sample_count));
+      EXPECT_FALSE(std::isnan(current));
+    }
+    ++reads;
+  }
+  writer.join();
+
+  EXPECT_GT(reads, 0u);
+  EXPECT_EQ(data.get_statistics().sample_count, kSamples);
+  EXPECT_DOUBLE_EQ(data.get_current_data(), static_cast<double>(kSamples));
+}


### PR DESCRIPTION
## Description

### Problem

ThreadSanitizer reports a data race between `ros2_control::MovingAverageStatisticsData::update_statistics()` (called from `hardware_interface::ResourceManager::read()`/`write()` in the control loop) and `ControllerManager::hardware_components_diagnostic_callback()` (called from the diagnostics thread), see https://github.com/ros-controls/ros2_control/issues/3603.

### Root cause

`hardware_interface/include/hardware_interface/types/statistics_types.hpp:273-283` — `MovingAverageStatisticsData::get_statistics()` and `get_current_data()` take the mutex but return a `const &` to the guarded member. The lock is released on return, so the caller reads the member without synchronization. The diagnostics callback (`controller_manager/src/controller_manager.cpp:4656-4657`, `const auto periodicity_stats = statistics->periodicity.get_statistics();`) copies the struct field by field while the control loop writes it under the lock in `update_statistics()` (`statistics_types.hpp:236-242`), which is exactly the write/read pair in the TSan report.

`MovingAverageStatisticsData::reset()` (`statistics_types.hpp:260`) also modified the guarded members without taking the mutex.

### Fix

Mirror the pattern that `MovingAverageStatistics` already uses in the same header (`get_statistics()` by value, `get_statistics_const_ptr()` by reference):

- `MovingAverageStatisticsData::get_statistics()` now returns `StatisticData` by value and `get_current_data()` returns `double` by value, so the copy happens while the mutex is held.
- New `get_statistics_const_ptr()` / `get_current_data_const_ptr()` keep returning references for the pal_statistics introspection registrations, which need a stable address. `ControllerManager::set_initial_hardware_components_state()` is switched to these for the eight `register_controller_manager_statistics(...)` / `REGISTER_ENTITY(...)` calls; behavior there is unchanged.
- `MovingAverageStatisticsData::reset()` takes the mutex.

All other in-tree callers (`hardware_components_diagnostic_callback`, `hardware_interface_testing/test/test_resource_manager.cpp`) already copy the result, so they compile unchanged. Code that took the address of `get_statistics()`/`get_current_data()` would need to move to the `_const_ptr()` variants; a GitHub code search over the ros-controls organization found no such users outside this repository.

### How tested

New test `hardware_interface/test/test_statistics_types.cpp` (registered in `hardware_interface/CMakeLists.txt`):

- `get_statistics_returns_snapshot`: values returned by `get_statistics()`/`get_current_data()` must not change when `update_statistics()` is called afterwards.
- `concurrent_update_and_read`: one thread updates, the main thread reads and checks each snapshot is internally consistent.

Built on Ubuntu 26.04 / ROS 2 Rolling (GCC 15.2) with TSan (`-fsanitize=thread -g -O1 -fno-omit-frame-pointer` for CXX flags and linker flags, `--packages-up-to controller_manager hardware_interface_testing`).

Before the fix, `test_statistics_types` fails deterministically and TSan reports the same race as the issue:

```text
[ RUN      ] TestMovingAverageStatisticsData.get_statistics_returns_snapshot
hardware_interface/test/test_statistics_types.cpp:44: Failure
Expected equality of these values:
  snapshot.sample_count
    Which is: 2
  1u
    Which is: 1
hardware_interface/test/test_statistics_types.cpp:45: Failure
Expected equality of these values:
  snapshot.average
    Which is: 2
  1.0
    Which is: 1
hardware_interface/test/test_statistics_types.cpp:46: Failure
Expected equality of these values:
  current
    Which is: 3
  1.0
    Which is: 1
[  FAILED  ] TestMovingAverageStatisticsData.get_statistics_returns_snapshot (0 ms)
[ RUN      ] TestMovingAverageStatisticsData.concurrent_update_and_read
WARNING: ThreadSanitizer: data race (pid=35)
  Write of size 8 at 0x7fffffffe1d8 by thread T1 (mutexes: write M0):
    #0 ros2_control::MovingAverageStatisticsData::update_statistics(...) hardware_interface/include/hardware_interface/types/statistics_types.hpp:236
  Previous read of size 8 at 0x7fffffffe1d8 by main thread:
    #0 TestMovingAverageStatisticsData_concurrent_update_and_read_Test::TestBody() hardware_interface/test/test_statistics_types.cpp:75
SUMMARY: ThreadSanitizer: data race .../statistics_types.hpp:236 in ros2_control::MovingAverageStatisticsData::update_statistics(...)
(repeated for statistics_types.hpp:237 and :242, read frames at test_statistics_types.cpp:75 and :76)
```

After the fix, same TSan build:

```text
[ RUN      ] TestMovingAverageStatisticsData.get_statistics_returns_snapshot
[       OK ] TestMovingAverageStatisticsData.get_statistics_returns_snapshot (0 ms)
[ RUN      ] TestMovingAverageStatisticsData.concurrent_update_and_read
[       OK ] TestMovingAverageStatisticsData.concurrent_update_and_read (127 ms)
[  PASSED  ] 2 tests.
```

with no ThreadSanitizer output. `controller_manager` and `hardware_interface_testing` build with the change, `test_resource_manager` tests that read the hardware statistics pass, and `pre-commit run` (clang-format, ament_cpplint, ament_copyright, ament_lint_cmake) is clean on the touched files.

### Links

- https://github.com/ros-controls/ros2_control/issues/3603

Fixes #3603

### Is this user-facing behavior change?

No. Diagnostics and introspection output is unchanged. For downstream C++ code: `MovingAverageStatisticsData::get_statistics()` and `get_current_data()` now return by value; anything that stored the address of the returned reference should use `get_statistics_const_ptr()` / `get_current_data_const_ptr()` instead.

### Did you use Generative AI?

Yes. Claude Code (Claude Fable 5.1), operated by KR-Ravindra, who reviewed and tested the change.

### Additional Information

The introspection registrations intentionally keep pointing at the live members via the `_const_ptr()` accessors, as `MovingAverageStatistics` already does for controller statistics; pal_statistics reads those addresses asynchronously by design, and changing that is out of scope for this PR.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
